### PR TITLE
Remove wsteth deposits

### DIFF
--- a/src/CSAccounting.sol
+++ b/src/CSAccounting.sol
@@ -307,39 +307,6 @@ contract CSAccounting is
         return requiredForNextKeys - excess;
     }
 
-    function getBondAmountByKeysCountWstETH(
-        uint256 keysCount
-    ) public view returns (uint256) {
-        return
-            WSTETH.getWstETHByStETH(
-                CSBondCurve.getBondAmountByKeysCount(keysCount)
-            );
-    }
-
-    function getBondAmountByKeysCountWstETH(
-        uint256 keysCount,
-        BondCurve memory curve
-    ) public view returns (uint256) {
-        return
-            WSTETH.getWstETHByStETH(
-                CSBondCurve.getBondAmountByKeysCount(keysCount, curve)
-            );
-    }
-
-    /// @notice Returns the required bond in wstETH (inc. missed and excess) for the given node operator to upload new keys.
-    /// @param nodeOperatorId id of the node operator to get required bond for.
-    /// @param additionalKeys number of new keys to add.
-    /// @return required bond in wstETH.
-    function getRequiredBondForNextKeysWstETH(
-        uint256 nodeOperatorId,
-        uint256 additionalKeys
-    ) public view returns (uint256) {
-        return
-            WSTETH.getWstETHByStETH(
-                getRequiredBondForNextKeys(nodeOperatorId, additionalKeys)
-            );
-    }
-
     /// @notice Stake user's ETH to Lido and make deposit in stETH to the bond
     /// @dev if `from` is not the same as `msg.sender`, then `msg.sender` should be CSM
     /// @param from address to stake ETH and deposit stETH from
@@ -414,63 +381,6 @@ contract CSAccounting is
             );
         }
         return CSBondCore._depositStETH(from, nodeOperatorId, stETHAmount);
-    }
-
-    /// @notice Unwrap user's wstETH and make deposit in stETH to the bond for the given Node Operator
-    /// @dev if `from` is not the same as `msg.sender`, then `msg.sender` should be CSM
-    /// @param from address to unwrap wstETH from
-    /// @param nodeOperatorId id of the node operator to deposit stETH for
-    /// @param wstETHAmount amount of wstETH to deposit
-    /// @return stETH shares amount
-    function depositWstETH(
-        address from,
-        uint256 nodeOperatorId,
-        uint256 wstETHAmount
-    )
-        external
-        whenResumed
-        onlyExistingNodeOperator(nodeOperatorId)
-        returns (uint256)
-    {
-        // TODO: can it be two functions rather than one with `from` param and condition?
-        from = _validateDepositSender(from);
-        return CSBondCore._depositWstETH(from, nodeOperatorId, wstETHAmount);
-    }
-
-    /// @notice Unwrap user's wstETH and make deposit in stETH to the bond for the given Node Operator using the proper permit for the contract
-    /// @dev if `from` is not the same as `msg.sender`, then `msg.sender` should be CSM
-    /// @param from address to unwrap wstETH from
-    /// @param nodeOperatorId id of the node operator to deposit stETH for
-    /// @param wstETHAmount amount of wstETH to deposit
-    /// @param permit wstETH permit for the contract
-    /// @return stETH shares amount
-    function depositWstETHWithPermit(
-        address from,
-        uint256 nodeOperatorId,
-        uint256 wstETHAmount,
-        PermitInput calldata permit
-    )
-        external
-        whenResumed
-        onlyExistingNodeOperator(nodeOperatorId)
-        returns (uint256)
-    {
-        // TODO: can it be two functions rather than one with `from` param and condition?
-        from = _validateDepositSender(from);
-        // preventing revert for already used permit
-        if (WSTETH.allowance(from, address(this)) < permit.value) {
-            // solhint-disable-next-line func-named-parameters
-            WSTETH.permit(
-                from,
-                address(this),
-                permit.value,
-                permit.deadline,
-                permit.v,
-                permit.r,
-                permit.s
-            );
-        }
-        return CSBondCore._depositWstETH(from, nodeOperatorId, wstETHAmount);
     }
 
     /// @dev only CSM can pass `from` != `msg.sender`

--- a/src/CSBondCore.sol
+++ b/src/CSBondCore.sol
@@ -21,11 +21,6 @@ abstract contract CSBondCoreBase {
         address to,
         uint256 amount
     );
-    event BondDepositedWstETH(
-        uint256 indexed nodeOperatorId,
-        address from,
-        uint256 amount
-    );
     event BondClaimedWstETH(
         uint256 indexed nodeOperatorId,
         address to,
@@ -53,7 +48,7 @@ abstract contract CSBondCoreBase {
 /// It contains:
 ///  - store bond shares
 ///  - get bond shares and bond amount
-///  - deposit ETH/stETH/wstETH
+///  - deposit ETH/stETH
 ///  - claim ETH/stETH/wstETH
 ///  - burn
 ///
@@ -124,20 +119,6 @@ abstract contract CSBondCore is CSBondCoreBase {
         LIDO.transferSharesFrom(from, address(this), shares);
         _increaseBond(nodeOperatorId, shares);
         emit BondDeposited(nodeOperatorId, from, amount);
-    }
-
-    /// @dev Transfers user's wstETH to the contract, unwrap and stores stETH shares as Node Operator's bond shares.
-    function _depositWstETH(
-        address from,
-        uint256 nodeOperatorId,
-        uint256 amount
-    ) internal returns (uint256) {
-        WSTETH.transferFrom(from, address(this), amount);
-        uint256 stETHAmount = WSTETH.unwrap(amount);
-        uint256 shares = _sharesByEth(stETHAmount);
-        _increaseBond(nodeOperatorId, shares);
-        emit BondDepositedWstETH(nodeOperatorId, from, amount);
-        return shares;
     }
 
     function _increaseBond(uint256 nodeOperatorId, uint256 shares) private {

--- a/src/CSModule.sol
+++ b/src/CSModule.sol
@@ -385,63 +385,6 @@ contract CSModule is ICSModule, CSModuleBase, AccessControl, PausableUntil {
         _addSigningKeys(id, keysCount, publicKeys, signatures);
     }
 
-    /// @notice Adds a new node operator with wstETH bond
-    /// @param keysCount Count of signing keys
-    /// @param publicKeys Public keys to submit
-    /// @param signatures Signatures of public keys
-    function addNodeOperatorWstETH(
-        uint256 keysCount,
-        bytes calldata publicKeys,
-        bytes calldata signatures,
-        bytes32[] calldata eaProof
-    ) external whenResumed {
-        // TODO: sanity checks
-
-        uint256 id = _createNodeOperator();
-        _processEarlyAdoption(id, eaProof);
-
-        accounting.depositWstETH(
-            msg.sender,
-            id,
-            accounting.getBondAmountByKeysCountWstETH(
-                keysCount,
-                accounting.getBondCurve(id)
-            )
-        );
-
-        _addSigningKeys(id, keysCount, publicKeys, signatures);
-    }
-
-    /// @notice Adds a new node operator with permit to use wstETH as bond
-    /// @param keysCount Count of signing keys
-    /// @param publicKeys Public keys to submit
-    /// @param signatures Signatures of public keys
-    /// @param permit Permit to use wstETH as bond
-    function addNodeOperatorWstETHWithPermit(
-        uint256 keysCount,
-        bytes calldata publicKeys,
-        bytes calldata signatures,
-        bytes32[] calldata eaProof,
-        ICSAccounting.PermitInput calldata permit
-    ) external whenResumed {
-        // TODO: sanity checks
-
-        uint256 id = _createNodeOperator();
-        _processEarlyAdoption(id, eaProof);
-
-        accounting.depositWstETHWithPermit(
-            msg.sender,
-            id,
-            accounting.getBondAmountByKeysCountWstETH(
-                keysCount,
-                accounting.getBondCurve(id)
-            ),
-            permit
-        );
-
-        _addSigningKeys(id, keysCount, publicKeys, signatures);
-    }
-
     /// @notice Adds a new keys to the node operator with ETH bond
     /// @param nodeOperatorId ID of the node operator
     /// @param keysCount Count of signing keys
@@ -508,59 +451,6 @@ contract CSModule is ICSModule, CSModuleBase, AccessControl, PausableUntil {
             msg.sender,
             nodeOperatorId,
             accounting.getRequiredBondForNextKeys(nodeOperatorId, keysCount),
-            permit
-        );
-
-        _addSigningKeys(nodeOperatorId, keysCount, publicKeys, signatures);
-    }
-
-    /// @notice Adds a new keys to the node operator with wstETH bond
-    /// @param nodeOperatorId ID of the node operator
-    /// @param keysCount Count of signing keys
-    /// @param publicKeys Public keys to submit
-    /// @param signatures Signatures of public keys
-    function addValidatorKeysWstETH(
-        uint256 nodeOperatorId,
-        uint256 keysCount,
-        bytes calldata publicKeys,
-        bytes calldata signatures
-    ) external whenResumed {
-        // TODO: sanity checks
-
-        accounting.depositWstETH(
-            msg.sender,
-            nodeOperatorId,
-            accounting.getRequiredBondForNextKeysWstETH(
-                nodeOperatorId,
-                keysCount
-            )
-        );
-
-        _addSigningKeys(nodeOperatorId, keysCount, publicKeys, signatures);
-    }
-
-    /// @notice Adds a new keys to the node operator with permit to use wstETH as bond
-    /// @param nodeOperatorId ID of the node operator
-    /// @param keysCount Count of signing keys
-    /// @param publicKeys Public keys to submit
-    /// @param signatures Signatures of public keys
-    /// @param permit Permit to use wstETH as bond
-    function addValidatorKeysWstETHWithPermit(
-        uint256 nodeOperatorId,
-        uint256 keysCount,
-        bytes calldata publicKeys,
-        bytes calldata signatures,
-        ICSAccounting.PermitInput calldata permit
-    ) external whenResumed {
-        // TODO: sanity checks
-
-        accounting.depositWstETHWithPermit(
-            msg.sender,
-            nodeOperatorId,
-            accounting.getRequiredBondForNextKeysWstETH(
-                nodeOperatorId,
-                keysCount
-            ),
             permit
         );
 

--- a/src/interfaces/ICSAccounting.sol
+++ b/src/interfaces/ICSAccounting.sol
@@ -21,36 +21,9 @@ interface ICSAccounting is ICSBondCore, ICSBondCurve, ICSBondLock {
         uint256 additionalKeys
     ) external view returns (uint256);
 
-    function getBondAmountByKeysCountWstETH(
-        uint256 keysCount
-    ) external view returns (uint256);
-
-    function getBondAmountByKeysCountWstETH(
-        uint256 keysCount,
-        BondCurve memory curve
-    ) external view returns (uint256);
-
-    function getRequiredBondForNextKeysWstETH(
-        uint256 nodeOperatorId,
-        uint256 additionalKeys
-    ) external view returns (uint256);
-
     function getUnbondedKeysCount(
         uint256 nodeOperatorId
     ) external view returns (uint256);
-
-    function depositWstETHWithPermit(
-        address from,
-        uint256 nodeOperatorId,
-        uint256 wstETHAmount,
-        PermitInput calldata permit
-    ) external returns (uint256);
-
-    function depositWstETH(
-        address from,
-        uint256 nodeOperatorId,
-        uint256 wstETHAmount
-    ) external returns (uint256);
 
     function depositStETHWithPermit(
         address from,

--- a/test/CSAccounting.t.sol
+++ b/test/CSAccounting.t.sol
@@ -235,27 +235,6 @@ contract CSAccountingPauseAffectingTest is CSAccountingBaseTest {
         );
     }
 
-    function test_depositWstETH_RevertWhen_Paused() public {
-        vm.expectRevert(PausableUntil.ResumedExpected.selector);
-        accounting.depositWstETH(address(user), 0, 1 ether);
-    }
-
-    function test_depositWstETHWithPermit_RevertWhen_Paused() public {
-        vm.expectRevert(PausableUntil.ResumedExpected.selector);
-        accounting.depositWstETHWithPermit(
-            address(user),
-            0,
-            1 ether,
-            CSAccounting.PermitInput({
-                value: 1 ether,
-                deadline: type(uint256).max,
-                v: 0,
-                r: 0,
-                s: 0
-            })
-        );
-    }
-
     function test_claimExcessBondStETH_RevertWhen_Paused() public {
         vm.expectRevert(PausableUntil.ResumedExpected.selector);
         accounting.claimExcessBondStETH(0, 1 ether);
@@ -897,144 +876,6 @@ contract CSAccountingGetRequiredETHBondTest is
     }
 }
 
-contract CSAccountingGetRequiredWstETHBondTest is
-    CSAccountingGetRequiredBondBaseTest
-{
-    function test_default() public override {
-        _operator({ ongoing: 16, withdrawn: 0 });
-        assertEq(
-            accounting.getRequiredBondForNextKeysWstETH(0, 0),
-            stETH.getSharesByPooledEth(32 ether)
-        );
-    }
-
-    function test_WithCurve() public override {
-        _operator({ ongoing: 16, withdrawn: 0 });
-        _curve(defaultCurve);
-        assertEq(
-            accounting.getRequiredBondForNextKeysWstETH(0, 0),
-            stETH.getSharesByPooledEth(17 ether)
-        );
-    }
-
-    function test_WithLocked() public override {
-        _operator({ ongoing: 16, withdrawn: 0 });
-        _lock({ id: 0, amount: 1 ether });
-        assertEq(
-            accounting.getRequiredBondForNextKeysWstETH(0, 0),
-            stETH.getSharesByPooledEth(33 ether)
-        );
-    }
-
-    function test_WithCurveAndLocked() public override {
-        _operator({ ongoing: 16, withdrawn: 0 });
-        _curve(defaultCurve);
-        _lock({ id: 0, amount: 1 ether });
-        assertEq(
-            accounting.getRequiredBondForNextKeysWstETH(0, 0),
-            stETH.getSharesByPooledEth(18 ether)
-        );
-    }
-
-    function test_WithOneWithdrawnValidator() public override {
-        _operator({ ongoing: 16, withdrawn: 1 });
-        assertEq(
-            accounting.getRequiredBondForNextKeysWstETH(0, 0),
-            stETH.getSharesByPooledEth(30 ether)
-        );
-    }
-
-    function test_OneWithdrawnOneAddedValidator() public override {
-        _operator({ ongoing: 16, withdrawn: 1 });
-        assertEq(
-            accounting.getRequiredBondForNextKeysWstETH(0, 1),
-            stETH.getSharesByPooledEth(32 ether)
-        );
-    }
-
-    function test_WithBond() public override {
-        _operator({ ongoing: 16, withdrawn: 0 });
-        _deposit({ bond: 32 ether });
-        assertApproxEqAbs(
-            accounting.getRequiredBondForNextKeysWstETH(0, 0),
-            0,
-            1 wei
-        );
-    }
-
-    function test_WithBondAndOneWithdrawnValidator() public override {
-        _operator({ ongoing: 16, withdrawn: 1 });
-        _deposit({ bond: 32 ether });
-        assertEq(accounting.getRequiredBondForNextKeysWstETH(0, 0), 0);
-    }
-
-    function test_WithBondAndOneWithdrawnAndOneAddedValidator()
-        public
-        override
-    {
-        _operator({ ongoing: 16, withdrawn: 1 });
-        _deposit({ bond: 32 ether });
-        assertApproxEqAbs(
-            accounting.getRequiredBondForNextKeysWstETH(0, 1),
-            0,
-            1
-        );
-    }
-
-    function test_WithExcessBond() public override {
-        _operator({ ongoing: 16, withdrawn: 0 });
-        _deposit({ bond: 33 ether });
-        assertEq(accounting.getRequiredBondForNextKeysWstETH(0, 0), 0);
-    }
-
-    function test_WithExcessBondAndOneWithdrawnValidator() public override {
-        _operator({ ongoing: 16, withdrawn: 1 });
-        _deposit({ bond: 33 ether });
-        assertEq(accounting.getRequiredBondForNextKeysWstETH(0, 0), 0);
-    }
-
-    function test_WithExcessBondAndOneWithdrawnAndOneAddedValidator()
-        public
-        override
-    {
-        _operator({ ongoing: 16, withdrawn: 1 });
-        _deposit({ bond: 33 ether });
-        assertEq(accounting.getRequiredBondForNextKeysWstETH(0, 1), 0);
-    }
-
-    function test_WithMissingBond() public override {
-        _operator({ ongoing: 16, withdrawn: 0 });
-        _deposit({ bond: 16 ether });
-        assertApproxEqAbs(
-            accounting.getRequiredBondForNextKeysWstETH(0, 0),
-            stETH.getSharesByPooledEth(16 ether),
-            1 wei
-        );
-    }
-
-    function test_WithMissingBondAndOneWithdrawnValidator() public override {
-        _operator({ ongoing: 16, withdrawn: 1 });
-        _deposit({ bond: 16 ether });
-        assertEq(
-            accounting.getRequiredBondForNextKeysWstETH(0, 0),
-            stETH.getSharesByPooledEth(14 ether)
-        );
-    }
-
-    function test_WithMissingBondAndOneWithdrawnAndOneAddedValidator()
-        public
-        override
-    {
-        _operator({ ongoing: 16, withdrawn: 1 });
-        _deposit({ bond: 16 ether });
-        assertApproxEqAbs(
-            accounting.getRequiredBondForNextKeysWstETH(0, 1),
-            stETH.getSharesByPooledEth(16 ether),
-            1 wei
-        );
-    }
-}
-
 abstract contract CSAccountingGetRequiredBondForKeysBaseTest is
     CSAccountingBaseTest
 {
@@ -1047,47 +888,6 @@ abstract contract CSAccountingGetRequiredBondForKeysBaseTest is
     function test_default() public virtual;
 
     function test_WithCurve() public virtual;
-}
-
-contract CSAccountingGetBondAmountByKeysCountWstETHTest is
-    CSAccountingGetRequiredBondForKeysBaseTest
-{
-    function test_default() public override {
-        assertEq(accounting.getBondAmountByKeysCountWstETH(0), 0);
-        assertEq(
-            accounting.getBondAmountByKeysCountWstETH(1),
-            wstETH.getWstETHByStETH(2 ether)
-        );
-        assertEq(
-            accounting.getBondAmountByKeysCountWstETH(2),
-            wstETH.getWstETHByStETH(4 ether)
-        );
-        assertEq(
-            accounting.getBondAmountByKeysCountWstETH(8),
-            wstETH.getWstETHByStETH(16 ether)
-        );
-    }
-
-    function test_WithCurve() public override {
-        CSBondCurve.BondCurve memory curve = CSBondCurve.BondCurve({
-            id: 0,
-            points: defaultCurve,
-            trend: 1 ether
-        });
-        assertEq(accounting.getBondAmountByKeysCountWstETH(0, curve), 0);
-        assertEq(
-            accounting.getBondAmountByKeysCountWstETH(1, curve),
-            wstETH.getWstETHByStETH(2 ether)
-        );
-        assertEq(
-            accounting.getBondAmountByKeysCountWstETH(2, curve),
-            wstETH.getWstETHByStETH(3 ether)
-        );
-        assertEq(
-            accounting.getBondAmountByKeysCountWstETH(15, curve),
-            wstETH.getWstETHByStETH(16 ether)
-        );
-    }
 }
 
 abstract contract CSAccountingRewardsBaseTest is CSAccountingBondStateBaseTest {
@@ -3810,37 +3610,6 @@ contract CSAccountingDepositsTest is CSAccountingBaseTest {
         assertEq(accounting.totalBondShares(), sharesToDeposit);
     }
 
-    function test_depositWstETH() public {
-        vm.deal(user, 32 ether);
-        vm.startPrank(user);
-        stETH.submit{ value: 32 ether }({ _referal: address(0) });
-        uint256 wstETHAmount = wstETH.wrap(32 ether);
-        uint256 sharesToDeposit = stETH.getSharesByPooledEth(
-            wstETH.getStETHByWstETH(wstETHAmount)
-        );
-        vm.stopPrank();
-
-        vm.prank(user);
-        accounting.depositWstETH(user, 0, wstETHAmount);
-
-        assertEq(
-            wstETH.balanceOf(user),
-            0,
-            "user balance should be 0 after deposit"
-        );
-        assertEq(
-            accounting.getBondShares(0),
-            sharesToDeposit,
-            "bond shares should be equal to deposited shares"
-        );
-        assertEq(
-            stETH.sharesOf(address(accounting)),
-            sharesToDeposit,
-            "bond manager shares should be equal to deposited shares"
-        );
-        assertEq(accounting.totalBondShares(), sharesToDeposit);
-    }
-
     function test_depositStETHWithPermit() public {
         vm.deal(user, 32 ether);
         vm.prank(user);
@@ -4004,181 +3773,6 @@ contract CSAccountingDepositsTest is CSAccountingBaseTest {
         );
     }
 
-    function test_depositWstETHWithPermit() public {
-        vm.deal(user, 32 ether);
-        vm.startPrank(user);
-        stETH.submit{ value: 32 ether }({ _referal: address(0) });
-        uint256 wstETHAmount = wstETH.wrap(32 ether);
-        uint256 sharesToDeposit = stETH.getSharesByPooledEth(
-            wstETH.getStETHByWstETH(wstETHAmount)
-        );
-        vm.stopPrank();
-
-        vm.expectEmit(true, true, true, true, address(wstETH));
-        emit Approval(user, address(accounting), 32 ether);
-
-        vm.prank(user);
-        accounting.depositWstETHWithPermit(
-            user,
-            0,
-            wstETHAmount,
-            CSAccounting.PermitInput({
-                value: 32 ether,
-                deadline: type(uint256).max,
-                // mock permit signature
-                v: 0,
-                r: 0,
-                s: 0
-            })
-        );
-
-        assertEq(
-            wstETH.balanceOf(user),
-            0,
-            "user balance should be 0 after deposit"
-        );
-        assertEq(
-            accounting.getBondShares(0),
-            sharesToDeposit,
-            "bond shares should be equal to deposited shares"
-        );
-        assertEq(
-            accounting.totalBondShares(),
-            sharesToDeposit,
-            "bond manager shares should be equal to deposited shares"
-        );
-        assertEq(accounting.totalBondShares(), sharesToDeposit);
-    }
-
-    function test_depositWstETHWithPermit_AlreadyPermittedWithLess() public {
-        vm.deal(user, 32 ether);
-        vm.startPrank(user);
-        stETH.submit{ value: 32 ether }({ _referal: address(0) });
-        uint256 wstETHAmount = wstETH.wrap(32 ether);
-        uint256 sharesToDeposit = stETH.getSharesByPooledEth(
-            wstETH.getStETHByWstETH(wstETHAmount)
-        );
-        vm.stopPrank();
-
-        vm.mockCall(
-            address(wstETH),
-            abi.encodeWithSelector(
-                wstETH.allowance.selector,
-                user,
-                address(accounting)
-            ),
-            abi.encode(1 ether)
-        );
-
-        vm.expectEmit(true, true, true, true, address(wstETH));
-        emit Approval(user, address(accounting), 32 ether);
-
-        vm.recordLogs();
-
-        vm.prank(user);
-        accounting.depositWstETHWithPermit(
-            user,
-            0,
-            wstETHAmount,
-            CSAccounting.PermitInput({
-                value: 32 ether,
-                deadline: type(uint256).max,
-                // mock permit signature
-                v: 0,
-                r: 0,
-                s: 0
-            })
-        );
-
-        assertEq(
-            vm.getRecordedLogs().length,
-            2,
-            "should emit only one event about approve and deposit"
-        );
-    }
-
-    function test_depositWstETHWithPermit_AlreadyPermittedWithInf() public {
-        vm.deal(user, 32 ether);
-        vm.startPrank(user);
-        stETH.submit{ value: 32 ether }({ _referal: address(0) });
-        uint256 wstETHAmount = wstETH.wrap(32 ether);
-        vm.stopPrank();
-
-        vm.mockCall(
-            address(wstETH),
-            abi.encodeWithSelector(
-                wstETH.allowance.selector,
-                user,
-                address(accounting)
-            ),
-            abi.encode(UINT256_MAX)
-        );
-
-        vm.recordLogs();
-
-        vm.prank(user);
-        accounting.depositWstETHWithPermit(
-            user,
-            0,
-            wstETHAmount,
-            CSAccounting.PermitInput({
-                value: 32 ether,
-                deadline: type(uint256).max,
-                // mock permit signature
-                v: 0,
-                r: 0,
-                s: 0
-            })
-        );
-
-        assertEq(
-            vm.getRecordedLogs().length,
-            1,
-            "should emit only one event about deposit"
-        );
-    }
-
-    function test_depositWstETHWithPermit_AlreadyPermittedWithTheSame() public {
-        vm.deal(user, 32 ether);
-        vm.startPrank(user);
-        stETH.submit{ value: 32 ether }({ _referal: address(0) });
-        uint256 wstETHAmount = wstETH.wrap(32 ether);
-        vm.stopPrank();
-
-        vm.mockCall(
-            address(wstETH),
-            abi.encodeWithSelector(
-                wstETH.allowance.selector,
-                user,
-                address(accounting)
-            ),
-            abi.encode(32 ether)
-        );
-
-        vm.recordLogs();
-
-        vm.prank(user);
-        accounting.depositWstETHWithPermit(
-            user,
-            0,
-            wstETHAmount,
-            CSAccounting.PermitInput({
-                value: 32 ether,
-                deadline: type(uint256).max,
-                // mock permit signature
-                v: 0,
-                r: 0,
-                s: 0
-            })
-        );
-
-        assertEq(
-            vm.getRecordedLogs().length,
-            1,
-            "should emit only one event about deposit"
-        );
-    }
-
     function test_depositETH_RevertIfNotExistedOperator() public {
         vm.expectRevert(NodeOperatorDoesNotExist.selector);
         vm.prank(user);
@@ -4189,12 +3783,6 @@ contract CSAccountingDepositsTest is CSAccountingBaseTest {
         vm.expectRevert(NodeOperatorDoesNotExist.selector);
         vm.prank(user);
         accounting.depositStETH(user, 1, 0 ether);
-    }
-
-    function test_depositWstETH_RevertIfNotExistedOperator() public {
-        vm.expectRevert(NodeOperatorDoesNotExist.selector);
-        vm.prank(user);
-        accounting.depositWstETH(user, 1, 0 ether);
     }
 
     function test_depositETH_RevertIfInvalidSender() public {
@@ -4213,30 +3801,6 @@ contract CSAccountingDepositsTest is CSAccountingBaseTest {
         vm.expectRevert(InvalidSender.selector);
         vm.prank(stranger);
         accounting.depositStETHWithPermit(
-            user,
-            0,
-            32 ether,
-            CSAccounting.PermitInput({
-                value: 32 ether,
-                deadline: type(uint256).max,
-                // mock permit signature
-                v: 0,
-                r: 0,
-                s: 0
-            })
-        );
-    }
-
-    function test_depositWstETH_RevertIfInvalidSender() public {
-        vm.expectRevert(InvalidSender.selector);
-        vm.prank(stranger);
-        accounting.depositWstETH(user, 0, 32 ether);
-    }
-
-    function test_depositWstETHWithPermit_RevertIfInvalidSender() public {
-        vm.expectRevert(InvalidSender.selector);
-        vm.prank(stranger);
-        accounting.depositWstETHWithPermit(
             user,
             0,
             32 ether,

--- a/test/CSBondCore.t.sol
+++ b/test/CSBondCore.t.sol
@@ -37,14 +37,6 @@ contract CSBondCoreTestable is CSBondCore {
         _depositStETH(from, nodeOperatorId, amount);
     }
 
-    function depositWstETH(
-        address from,
-        uint256 nodeOperatorId,
-        uint256 amount
-    ) external {
-        _depositWstETH(from, nodeOperatorId, amount);
-    }
-
     function requestETH(
         uint256 nodeOperatorId,
         uint256 claimableShares,
@@ -385,27 +377,6 @@ contract CSBondCoreStETHTest is CSBondCoreTestBase {
 }
 
 contract CSBondCoreWstETHTest is CSBondCoreTestBase {
-    function test_depositWstETH() public {
-        vm.deal(user, 1 ether);
-        vm.startPrank(user);
-        stETH.submit{ value: 1 ether }(address(0));
-        uint256 wstETHAmount = wstETH.wrap(1 ether);
-        vm.stopPrank();
-
-        vm.expectEmit(true, true, true, true, address(bondCore));
-        emit BondDepositedWstETH(0, user, wstETHAmount);
-
-        bondCore.depositWstETH(user, 0, wstETHAmount);
-
-        assertApproxEqAbs(bondCore.getBondShares(0), wstETHAmount, 1 wei);
-        assertApproxEqAbs(bondCore.totalBondShares(), wstETHAmount, 1 wei);
-        assertApproxEqAbs(
-            stETH.sharesOf(address(bondCore)),
-            wstETHAmount,
-            1 wei
-        );
-    }
-
     function test_claimWstETH() public {
         _deposit(1 ether);
 

--- a/test/CSBondLock.t.sol
+++ b/test/CSBondLock.t.sol
@@ -9,7 +9,6 @@ import { CSBondLockBase, CSBondLock } from "../src/CSBondLock.sol";
 import { PermitTokenBase } from "./helpers/Permit.sol";
 import { Stub } from "./helpers/mocks/Stub.sol";
 import { LidoMock } from "./helpers/mocks/LidoMock.sol";
-import { WstETHMock } from "./helpers/mocks/WstETHMock.sol";
 import { LidoLocatorMock } from "./helpers/mocks/LidoLocatorMock.sol";
 
 import { Utilities } from "./helpers/Utilities.sol";

--- a/test/helpers/Permit.sol
+++ b/test/helpers/Permit.sol
@@ -40,9 +40,6 @@ contract PermitHelper {
     string internal STETH_NAME = "Liquid staked Ether 2.0";
     string internal STETH_VERSION = "2";
 
-    string internal WSTETH_NAME = "Wrapped liquid staked Ether 2.0";
-    string internal WSTETH_VERSION = "1";
-
     function stETHPermitDigest(
         address owner,
         address spender,
@@ -61,27 +58,6 @@ contract PermitHelper {
                 token,
                 STETH_NAME,
                 STETH_VERSION
-            );
-    }
-
-    function wstETHPermitDigest(
-        address owner,
-        address spender,
-        uint256 value,
-        uint256 nonce,
-        uint256 deadline,
-        address token
-    ) public view returns (bytes32) {
-        return
-            _preparePermitDigest(
-                owner,
-                spender,
-                value,
-                nonce,
-                deadline,
-                token,
-                WSTETH_NAME,
-                WSTETH_VERSION
             );
     }
 

--- a/test/integration/DepositInTokens.t.sol
+++ b/test/integration/DepositInTokens.t.sol
@@ -100,24 +100,6 @@ contract DepositIntegrationTest is
         assertEq(accounting.totalBondShares(), shares);
     }
 
-    function test_depositWstETH() public {
-        vm.startPrank(user);
-        vm.deal(user, 32 ether);
-        ILido(locator.lido()).submit{ value: 32 ether }({
-            _referal: address(0)
-        });
-        ILido(locator.lido()).approve(address(wstETH), type(uint256).max);
-        uint256 wstETHAmount = wstETH.wrap(32 ether);
-
-        vm.startPrank(user);
-        wstETH.approve(address(accounting), type(uint256).max);
-        uint256 shares = accounting.depositWstETH(user, 0, wstETHAmount);
-
-        assertEq(wstETH.balanceOf(user), 0);
-        assertEq(accounting.getBondShares(0), shares);
-        assertEq(accounting.totalBondShares(), shares);
-    }
-
     function test_depositStETHWithPermit() public {
         bytes32 digest = stETHPermitDigest(
             user,
@@ -151,45 +133,6 @@ contract DepositIntegrationTest is
         );
 
         assertEq(ILido(locator.lido()).balanceOf(user), 0);
-        assertEq(accounting.getBondShares(0), shares);
-        assertEq(accounting.totalBondShares(), shares);
-    }
-
-    function test_depositWstETHWithPermit() public {
-        bytes32 digest = wstETHPermitDigest(
-            user,
-            address(accounting),
-            32 ether,
-            vm.getNonce(user),
-            type(uint256).max,
-            address(wstETH)
-        );
-        (uint8 v, bytes32 r, bytes32 s) = vm.sign(userPrivateKey, digest);
-
-        vm.deal(user, 32 ether);
-        vm.startPrank(user);
-        ILido(locator.lido()).submit{ value: 32 ether }({
-            _referal: address(0)
-        });
-        ILido(locator.lido()).approve(address(wstETH), type(uint256).max);
-        uint256 wstETHAmount = wstETH.wrap(32 ether);
-        vm.stopPrank();
-
-        vm.prank(user);
-        uint256 shares = accounting.depositWstETHWithPermit(
-            user,
-            0,
-            wstETHAmount,
-            CSAccounting.PermitInput({
-                value: 32 ether,
-                deadline: type(uint256).max,
-                v: v,
-                r: r,
-                s: s
-            })
-        );
-
-        assertEq(wstETH.balanceOf(user), 0);
         assertEq(accounting.getBondShares(0), shares);
         assertEq(accounting.totalBondShares(), shares);
     }


### PR DESCRIPTION
due to the possibility of unwrapping wsteth right in the UI, it is decided to remove wsteth at all from the onchain code in order to reduce contract sizes and complexities

```
| CSAccounting               | 20.292    | 4.284       |
| CSModule                   | 23.496    | 1.08        |
--->>>
| CSAccounting               | 18.617    | 5.959       |
| CSModule                   | 22.97     | 1.606       |
```