### PR TITLE
feat: add fork helper scripts

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -3,4 +3,5 @@ RPC_URL=
 DEPLOYER_PRIVATE_KEY=
 # Testing purposes
 DEPLOY_CONFIG=/configs/holesky-devnet0/deploy-holesky-devnet.json
+# Specify the chain to deploy or test on. Note that tests required a Staking Router 1.5 to be deployed.
 CHAIN=mainnet | holesky | devnet

--- a/.env.sample
+++ b/.env.sample
@@ -1,7 +1,6 @@
 RPC_URL=
 # For deployment
 DEPLOYER_PRIVATE_KEY=
-KEEP_ANVIL_AFTER_LOCAL_DEPLOY=false
 # Testing purposes
 DEPLOY_CONFIG=/configs/holesky-devnet0/deploy-holesky-devnet.json
 CHAIN=mainnet | holesky | devnet

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -115,7 +115,8 @@ jobs:
       - name: Run local integration tests
         run: just test-local
         env:
-          RPC_URL: ${{ secrets.RPC_URL }}
+          CHAIN: devnet
+          RPC_URL: ${{ secrets.RPC_URL_HOLESKY }}
 
       # TODO: Enable later
       # - name: Check gas report

--- a/Justfile
+++ b/Justfile
@@ -109,7 +109,7 @@ deploy-local:
     just make-fork &
     @while ! echo exit | nc {{anvil_host}} {{anvil_port}} > /dev/null; do sleep 1; done
     just deploy
-    @if ${KEEP_ANVIL_AFTER_LOCAL_DEPLOY}; then just _warn "anvil is kept running in the background: http://{{anvil_host}}:{{anvil_port}}"; else just kill-fork; fi
+    just _warn "anvil is kept running in the background: http://{{anvil_host}}:{{anvil_port}}"
 
 test-local *args:
     just make-fork --silent &
@@ -120,6 +120,12 @@ test-local *args:
     RPC_URL=http://{{anvil_host}}:{{anvil_port}} \
         just test-integration {{args}}
     just kill-fork
+
+simulate-vote:
+    cast rpc anvil_autoImpersonateAccount true
+    forge script script/fork-helpers/SimulateVote.sol --rpc-url=http://{{anvil_host}}:{{anvil_port}} -vvv \
+        --broadcast --slow --unlocked --sender=`cat localhost.json | jq -r ".available_accounts[0]"`
+    cast rpc anvil_autoImpersonateAccount false
 
 _warn message:
     @tput setaf 3 && printf "[WARNING]" && tput sgr0 && echo " {{message}}"

--- a/Justfile
+++ b/Justfile
@@ -13,6 +13,7 @@ deploy_script_path := if chain == "mainnet" {
 
 anvil_host := env_var_or_default("ANVIL_IP_ADDR", "127.0.0.1")
 anvil_port := "8545"
+anvil_rpc_url := "http://" + anvil_host + ":" + anvil_port
 
 default: clean deps build test-all
 
@@ -100,7 +101,7 @@ kill-fork:
     @-pkill anvil && just _warn "anvil process is killed"
 
 deploy *args:
-    forge script {{deploy_script_path}} --rpc-url http://{{anvil_host}}:{{anvil_port}} --broadcast --slow {{args}}
+    forge script {{deploy_script_path}} --rpc-url {{anvil_rpc_url}} --broadcast --slow {{args}}
 
 deploy-prod:
     forge script {{deploy_script_path}} --force --rpc-url ${RPC_URL} --broadcast --slow
@@ -109,7 +110,7 @@ deploy-local:
     just make-fork &
     @while ! echo exit | nc {{anvil_host}} {{anvil_port}} > /dev/null; do sleep 1; done
     just deploy
-    just _warn "anvil is kept running in the background: http://{{anvil_host}}:{{anvil_port}}"
+    just _warn "anvil is kept running in the background: {{anvil_rpc_url}}"
 
 test-local *args:
     just make-fork --silent &
@@ -117,15 +118,15 @@ test-local *args:
     DEPLOYER_PRIVATE_KEY=`cat localhost.json | jq -r ".private_keys[0]"` \
         just deploy --silent
     DEPLOY_CONFIG=./out/latest.json \
-    RPC_URL=http://{{anvil_host}}:{{anvil_port}} \
+    RPC_URL={{anvil_rpc_url}} \
         just test-integration {{args}}
     just kill-fork
 
 simulate-vote:
-    cast rpc anvil_autoImpersonateAccount true
-    forge script script/fork-helpers/SimulateVote.sol --rpc-url=http://{{anvil_host}}:{{anvil_port}} -vvv \
+    cast rpc --rpc-url={{anvil_rpc_url}} anvil_autoImpersonateAccount true
+    forge script script/fork-helpers/SimulateVote.sol --rpc-url={{anvil_rpc_url}} -vvv \
         --broadcast --slow --unlocked --sender=`cat localhost.json | jq -r ".available_accounts[0]"`
-    cast rpc anvil_autoImpersonateAccount false
+    cast rpc --rpc-url={{anvil_rpc_url}} anvil_autoImpersonateAccount false
 
 _warn message:
     @tput setaf 3 && printf "[WARNING]" && tput sgr0 && echo " {{message}}"

--- a/README.md
+++ b/README.md
@@ -47,6 +47,17 @@ just test-local
 DEPLOYMENT_CONFIG=./config/holesky-devnet-0/deploy-holesky-devnet.json just test-integration
 ```
 
+**Note:** the CSM requires to be added to the Staking Router 1.5,
+so it's impossible to run integration tests over the network with the old contracts.
+Technically it's possible to add the CSM to the previous Staking Router version,
+but it's supposed to be added to the new one.
+
+Please Make sure that `test-local` or `test-integration` are running against the correct protocol setup:
+
+```bash
+export CHAIN=devnet
+```
+
 ## Make a gas report
 
 ```bash
@@ -68,12 +79,6 @@ Whenever you install new libraries using yarn, make sure to update your
 
 ```bash
 just deploy-local
-```
-
-It's possible to specify a chain
-
-```bash
-CHAIN=holesky just deploy-local
 ```
 
 The result of deployment is `./out/latest.json` deployment config, which is required for integration testing

--- a/README.md
+++ b/README.md
@@ -87,9 +87,9 @@ Integration tests should pass either before a vote, or after
 
 ```bash
 just deploy-local
+export RPC_URL=http://127.0.0.1:8545
+export DEPLOY_CONFIG=./out/latest.json
 
-RPC_URL=http://127.0.0.1:8545 \
-DEPLOY_CONFIG=./out/latest.json \
 just test-integration
 ```
 
@@ -97,10 +97,10 @@ There also fork helper scripts to prepare a fork state for e.g. UI testing purpo
 
 ```bash
 just deploy-local
-just simulate-vote
+export RPC_URL=http://127.0.0.1:8545
+export DEPLOY_CONFIG=./out/latest.json
 
-RPC_URL=http://127.0.0.1:8545 \
-DEPLOY_CONFIG=./out/latest.json \
+just simulate-vote
 just test-integration
 ```
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ just
 
 ### Features
 
-- Run tests
+## Run tests
 
 ```bash
 just test-all # run all tests that possible to run without additional configurations
@@ -47,13 +47,13 @@ just test-local
 DEPLOYMENT_CONFIG=./config/holesky-devnet-0/deploy-holesky-devnet.json just test-integration
 ```
 
-- Make a gas report
+## Make a gas report
 
 ```bash
 just gas-report
 ```
 
-- Install dependencies
+## Add new dependencies
 
 Dependencies are managed using yarn. To install new dependencies, run:
 
@@ -61,19 +61,46 @@ Dependencies are managed using yarn. To install new dependencies, run:
 yarn add <package-name>
 ```
 
-- Deploy to local fork
+Whenever you install new libraries using yarn, make sure to update your
+`remappings.txt`.
+
+## Deploy and test using local fork
 
 ```bash
 just deploy-local
 ```
 
-- Deploy to local fork of non-mainnet chain
+It's possible to specify a chain
 
 ```bash
 CHAIN=holesky just deploy-local
 ```
 
-### Notes
+The result of deployment is `./out/latest.json` deployment config, which is required for integration testing
 
-Whenever you install new libraries using yarn, make sure to update your
-`remappings.txt`.
+Integration tests should pass either before a vote, or after
+
+```bash
+just deploy-local
+
+RPC_URL=http://127.0.0.1:8545 \
+DEPLOY_CONFIG=./out/latest.json \
+just test-integration
+```
+
+There also fork helper scripts to prepare a fork state for e.g. UI testing purposes
+
+```bash
+just deploy-local
+just simulate-vote
+
+RPC_URL=http://127.0.0.1:8545 \
+DEPLOY_CONFIG=./out/latest.json \
+just test-integration
+```
+
+Kill fork after testing
+
+```bash
+just kill-fork
+```

--- a/script/fork-helpers/SimulateVote.sol
+++ b/script/fork-helpers/SimulateVote.sol
@@ -1,0 +1,96 @@
+// SPDX-FileCopyrightText: 2023 Lido <info@lido.fi>
+// SPDX-License-Identifier: GPL-3.0
+
+pragma solidity 0.8.24;
+
+import "forge-std/Script.sol";
+import "forge-std/console.sol";
+import { DeploymentFixtures } from "test/helpers/Fixtures.sol";
+import { IStakingRouter } from "../../src/interfaces/IStakingRouter.sol";
+import { IBurner } from "../../src/interfaces/IBurner.sol";
+
+contract SimulateVote is Script, DeploymentFixtures {
+    function run() external {
+        Env memory env = envVars();
+        initializeFromDeployment(env.DEPLOY_CONFIG);
+
+        IStakingRouter stakingRouter = IStakingRouter(locator.stakingRouter());
+        IBurner burner = IBurner(locator.burner());
+
+        address agent = stakingRouter.getRoleMember(
+            stakingRouter.STAKING_MODULE_MANAGE_ROLE(),
+            0
+        );
+        vm.label(agent, "agent");
+        console.logUint(agent.balance);
+
+        address csmAdmin = payable(
+            csm.getRoleMember(csm.DEFAULT_ADMIN_ROLE(), 0)
+        );
+        vm.label(csmAdmin, "csmAdmin");
+
+        address burnerAdmin = payable(
+            burner.getRoleMember(burner.DEFAULT_ADMIN_ROLE(), 0)
+        );
+        vm.label(burnerAdmin, "burnerAdmin");
+
+        vm.rpc(
+            "anvil_setBalance",
+            string.concat(
+                '["',
+                vm.toString(csmAdmin),
+                '", ',
+                "1000000000000000000",
+                "]"
+            )
+        );
+        vm.rpc(
+            "anvil_setBalance",
+            string.concat(
+                '["',
+                vm.toString(burnerAdmin),
+                '", ',
+                "1000000000000000000",
+                "]"
+            )
+        );
+
+        vm.startBroadcast(csmAdmin);
+        csm.grantRole(csm.DEFAULT_ADMIN_ROLE(), agent);
+        hashConsensus.grantRole(hashConsensus.DEFAULT_ADMIN_ROLE(), agent);
+        vm.stopBroadcast();
+
+        vm.startBroadcast(burnerAdmin);
+        burner.grantRole(burner.DEFAULT_ADMIN_ROLE(), agent);
+        vm.stopBroadcast();
+
+        vm.startBroadcast(agent);
+        // 1. Grant manager role
+        csm.grantRole(csm.MODULE_MANAGER_ROLE(), agent);
+
+        // 2. Add CommunityStaking module
+        stakingRouter.addStakingModule({
+            _name: "community-staking-v1",
+            _stakingModuleAddress: address(csm),
+            _stakeShareLimit: 2000, // 20%
+            _priorityExitShareThreshold: 2500, // 25%
+            _stakingModuleFee: 800, // 8%
+            _treasuryFee: 200, // 2%
+            _maxDepositsPerBlock: 30,
+            _minDepositBlockDistance: 25
+        });
+        // 3. burner role
+        burner.grantRole(
+            burner.REQUEST_BURN_SHARES_ROLE(),
+            address(accounting)
+        );
+        // 4. Grant resume to agent
+        csm.grantRole(csm.RESUME_ROLE(), agent);
+        // 5. Resume CSM
+        csm.resume();
+        // 6. Revoke resume
+        csm.revokeRole(csm.RESUME_ROLE(), agent);
+        // 7. Update initial epoch
+        hashConsensus.updateInitialEpoch(47480);
+    }
+}

--- a/script/fork-helpers/SimulateVote.sol
+++ b/script/fork-helpers/SimulateVote.sol
@@ -4,7 +4,6 @@
 pragma solidity 0.8.24;
 
 import "forge-std/Script.sol";
-import "forge-std/console.sol";
 import { DeploymentFixtures } from "test/helpers/Fixtures.sol";
 import { IStakingRouter } from "../../src/interfaces/IStakingRouter.sol";
 import { IBurner } from "../../src/interfaces/IBurner.sol";
@@ -22,7 +21,6 @@ contract SimulateVote is Script, DeploymentFixtures {
             0
         );
         vm.label(agent, "agent");
-        console.logUint(agent.balance);
 
         address csmAdmin = payable(
             csm.getRoleMember(csm.DEFAULT_ADMIN_ROLE(), 0)
@@ -34,26 +32,8 @@ contract SimulateVote is Script, DeploymentFixtures {
         );
         vm.label(burnerAdmin, "burnerAdmin");
 
-        vm.rpc(
-            "anvil_setBalance",
-            string.concat(
-                '["',
-                vm.toString(csmAdmin),
-                '", ',
-                "1000000000000000000",
-                "]"
-            )
-        );
-        vm.rpc(
-            "anvil_setBalance",
-            string.concat(
-                '["',
-                vm.toString(burnerAdmin),
-                '", ',
-                "1000000000000000000",
-                "]"
-            )
-        );
+        _setBalance(csmAdmin, "1000000000000000000");
+        _setBalance(burnerAdmin, "1000000000000000000");
 
         vm.startBroadcast(csmAdmin);
         csm.grantRole(csm.DEFAULT_ADMIN_ROLE(), agent);
@@ -92,5 +72,12 @@ contract SimulateVote is Script, DeploymentFixtures {
         csm.revokeRole(csm.RESUME_ROLE(), agent);
         // 7. Update initial epoch
         hashConsensus.updateInitialEpoch(47480);
+    }
+
+    function _setBalance(address account, string memory balance) internal {
+        vm.rpc(
+            "anvil_setBalance",
+            string.concat('["', vm.toString(account), '", ', balance, "]")
+        );
     }
 }

--- a/src/interfaces/IBurner.sol
+++ b/src/interfaces/IBurner.sol
@@ -15,6 +15,11 @@ interface IBurner {
 
     function grantRole(bytes32 role, address account) external;
 
+    function hasRole(
+        bytes32 role,
+        address account
+    ) external view returns (bool);
+
     function requestBurnShares(
         address _from,
         uint256 _sharesAmountToBurn

--- a/test/helpers/Fixtures.sol
+++ b/test/helpers/Fixtures.sol
@@ -77,7 +77,6 @@ contract DeploymentFixtures is StdCheats, Test {
     struct Env {
         string RPC_URL;
         string DEPLOY_CONFIG;
-        uint256 MODULE_ID;
     }
 
     struct DeploymentConfig {
@@ -94,8 +93,7 @@ contract DeploymentFixtures is StdCheats, Test {
     function envVars() public returns (Env memory) {
         Env memory env = Env(
             vm.envOr("RPC_URL", string("")),
-            vm.envOr("DEPLOY_CONFIG", string("")),
-            vm.envOr("MODULE_ID", uint256(0))
+            vm.envOr("DEPLOY_CONFIG", string(""))
         );
         vm.skip(_isEmpty(env.RPC_URL));
         vm.skip(_isEmpty(env.DEPLOY_CONFIG));

--- a/test/integration/ClaimInTokens.t.sol
+++ b/test/integration/ClaimInTokens.t.sol
@@ -36,7 +36,7 @@ contract ClaimIntegrationTest is
         vm.startPrank(csm.getRoleMember(csm.DEFAULT_ADMIN_ROLE(), 0));
         csm.grantRole(csm.RESUME_ROLE(), address(this));
         vm.stopPrank();
-        csm.resume();
+        if (csm.isPaused()) csm.resume();
 
         vm.startPrank(
             feeDistributor.getRoleMember(feeDistributor.DEFAULT_ADMIN_ROLE(), 0)
@@ -67,7 +67,7 @@ contract ClaimIntegrationTest is
         defaultNoId = csm.getNodeOperatorsCount() - 1;
     }
 
-    function test_claimExessBondStETH() public {
+    function test_claimExcessBondStETH() public {
         uint256 amount = 1 ether;
         vm.startPrank(user);
         vm.deal(user, amount);
@@ -97,7 +97,7 @@ contract ClaimIntegrationTest is
         assertEq(sharesAfter, sharesBefore + excessBond);
     }
 
-    function test_claimExessBondWstETH() public {
+    function test_claimExcessBondWstETH() public {
         uint256 amount = 1 ether;
         vm.startPrank(user);
         vm.deal(user, amount);
@@ -131,7 +131,7 @@ contract ClaimIntegrationTest is
         assertEq(balanceAfter, balanceBefore + excessBondWstETH);
     }
 
-    function test_requestExessBondETH() public {
+    function test_requestExcessBondETH() public {
         IWithdrawalQueue wq = IWithdrawalQueue(locator.withdrawalQueue());
         uint256[] memory requestsIdsBefore = wq.getWithdrawalRequests(
             nodeOperator

--- a/test/integration/ClaimInTokens.t.sol
+++ b/test/integration/ClaimInTokens.t.sol
@@ -33,10 +33,12 @@ contract ClaimIntegrationTest is
         vm.createSelectFork(env.RPC_URL);
         initializeFromDeployment(env.DEPLOY_CONFIG);
 
-        vm.startPrank(csm.getRoleMember(csm.DEFAULT_ADMIN_ROLE(), 0));
-        csm.grantRole(csm.RESUME_ROLE(), address(this));
-        vm.stopPrank();
-        if (csm.isPaused()) csm.resume();
+        if (csm.isPaused()) {
+            vm.startPrank(csm.getRoleMember(csm.DEFAULT_ADMIN_ROLE(), 0));
+            csm.grantRole(csm.RESUME_ROLE(), address(this));
+            vm.stopPrank();
+            csm.resume();
+        }
 
         vm.startPrank(
             feeDistributor.getRoleMember(feeDistributor.DEFAULT_ADMIN_ROLE(), 0)

--- a/test/integration/Deploy.t.sol
+++ b/test/integration/Deploy.t.sol
@@ -25,7 +25,7 @@ contract TestDeployment is Test, DeploymentFixtures {
         vm.startPrank(csm.getRoleMember(csm.DEFAULT_ADMIN_ROLE(), 0));
         csm.grantRole(csm.RESUME_ROLE(), address(this));
         vm.stopPrank();
-        csm.resume();
+        if (csm.isPaused()) csm.resume();
     }
 
     function test_init() public {

--- a/test/integration/Deploy.t.sol
+++ b/test/integration/Deploy.t.sol
@@ -22,10 +22,12 @@ contract TestDeployment is Test, DeploymentFixtures {
         vm.createSelectFork(env.RPC_URL);
         initializeFromDeployment(env.DEPLOY_CONFIG);
 
-        vm.startPrank(csm.getRoleMember(csm.DEFAULT_ADMIN_ROLE(), 0));
-        csm.grantRole(csm.RESUME_ROLE(), address(this));
-        vm.stopPrank();
-        if (csm.isPaused()) csm.resume();
+        if (csm.isPaused()) {
+            vm.startPrank(csm.getRoleMember(csm.DEFAULT_ADMIN_ROLE(), 0));
+            csm.grantRole(csm.RESUME_ROLE(), address(this));
+            vm.stopPrank();
+            csm.resume();
+        }
     }
 
     function test_init() public {

--- a/test/integration/DepositInTokens.t.sol
+++ b/test/integration/DepositInTokens.t.sol
@@ -35,7 +35,7 @@ contract DepositIntegrationTest is
         csm.grantRole(csm.RESUME_ROLE(), address(this));
         csm.grantRole(csm.STAKING_ROUTER_ROLE(), address(stakingRouter));
         vm.stopPrank();
-        csm.resume();
+        if (csm.isPaused()) csm.resume();
 
         userPrivateKey = 0xa11ce;
         user = vm.addr(userPrivateKey);

--- a/test/integration/DepositInTokens.t.sol
+++ b/test/integration/DepositInTokens.t.sol
@@ -23,6 +23,7 @@ contract DepositIntegrationTest is
 {
     address internal user;
     address internal stranger;
+    uint256 internal defaultNoId;
     uint256 internal userPrivateKey;
     uint256 internal strangerPrivateKey;
 
@@ -55,6 +56,7 @@ contract DepositIntegrationTest is
             new bytes32[](0),
             address(0)
         );
+        defaultNoId = csm.getNodeOperatorsCount() - 1;
     }
 
     function test_depositStETH() public {
@@ -64,11 +66,12 @@ contract DepositIntegrationTest is
             _referal: address(0)
         });
 
-        uint256 preShares = accounting.getBondShares(0);
+        uint256 preShares = accounting.getBondShares(defaultNoId);
+        uint256 preTotalShares = accounting.totalBondShares();
 
         lido.approve(address(accounting), type(uint256).max);
         csm.depositStETH(
-            0,
+            defaultNoId,
             32 ether,
             ICSAccounting.PermitInput({
                 value: 0,
@@ -80,22 +83,23 @@ contract DepositIntegrationTest is
         );
 
         assertEq(ILido(locator.lido()).balanceOf(user), 0);
-        assertEq(accounting.getBondShares(0), shares + preShares);
-        assertEq(accounting.totalBondShares(), shares + preShares);
+        assertEq(accounting.getBondShares(defaultNoId), shares + preShares);
+        assertEq(accounting.totalBondShares(), shares + preTotalShares);
     }
 
     function test_depositETH() public {
         vm.startPrank(user);
         vm.deal(user, 32 ether);
 
-        uint256 preShares = accounting.getBondShares(0);
+        uint256 preShares = accounting.getBondShares(defaultNoId);
+        uint256 preTotalShares = accounting.totalBondShares();
 
         uint256 shares = lido.getSharesByPooledEth(32 ether);
-        csm.depositETH{ value: 32 ether }(0);
+        csm.depositETH{ value: 32 ether }(defaultNoId);
 
         assertEq(user.balance, 0);
-        assertEq(accounting.getBondShares(0), shares + preShares);
-        assertEq(accounting.totalBondShares(), shares + preShares);
+        assertEq(accounting.getBondShares(defaultNoId), shares + preShares);
+        assertEq(accounting.totalBondShares(), shares + preTotalShares);
     }
 
     function test_depositWstETH() public {
@@ -109,11 +113,12 @@ contract DepositIntegrationTest is
             wstETH.getStETHByWstETH(wstETHAmount)
         );
 
-        uint256 preShares = accounting.getBondShares(0);
+        uint256 preShares = accounting.getBondShares(defaultNoId);
+        uint256 preTotalShares = accounting.totalBondShares();
 
         wstETH.approve(address(accounting), type(uint256).max);
         csm.depositWstETH(
-            0,
+            defaultNoId,
             wstETHAmount,
             ICSAccounting.PermitInput({
                 value: 0,
@@ -125,8 +130,8 @@ contract DepositIntegrationTest is
         );
 
         assertEq(wstETH.balanceOf(user), 0);
-        assertEq(accounting.getBondShares(0), shares + preShares);
-        assertEq(accounting.totalBondShares(), shares + preShares);
+        assertEq(accounting.getBondShares(defaultNoId), shares + preShares);
+        assertEq(accounting.totalBondShares(), shares + preTotalShares);
     }
 
     function test_depositStETHWithPermit() public {
@@ -146,10 +151,11 @@ contract DepositIntegrationTest is
             _referal: address(0)
         });
 
-        uint256 preShares = accounting.getBondShares(0);
+        uint256 preShares = accounting.getBondShares(defaultNoId);
+        uint256 preTotalShares = accounting.totalBondShares();
 
         csm.depositStETH(
-            0,
+            defaultNoId,
             32 ether,
             ICSAccounting.PermitInput({
                 value: 32 ether,
@@ -161,8 +167,8 @@ contract DepositIntegrationTest is
         );
 
         assertEq(lido.balanceOf(user), 0);
-        assertEq(accounting.getBondShares(0), shares + preShares);
-        assertEq(accounting.totalBondShares(), shares + preShares);
+        assertEq(accounting.getBondShares(defaultNoId), shares + preShares);
+        assertEq(accounting.totalBondShares(), shares + preTotalShares);
     }
 
     function test_depositWstETHWithPermit() public {
@@ -186,10 +192,11 @@ contract DepositIntegrationTest is
             wstETH.getStETHByWstETH(wstETHAmount)
         );
 
-        uint256 preShares = accounting.getBondShares(0);
+        uint256 preShares = accounting.getBondShares(defaultNoId);
+        uint256 preTotalShares = accounting.totalBondShares();
 
         csm.depositWstETH(
-            0,
+            defaultNoId,
             wstETHAmount,
             ICSAccounting.PermitInput({
                 value: 32 ether,
@@ -201,7 +208,7 @@ contract DepositIntegrationTest is
         );
 
         assertEq(wstETH.balanceOf(user), 0);
-        assertEq(accounting.getBondShares(0), shares + preShares);
-        assertEq(accounting.totalBondShares(), shares + preShares);
+        assertEq(accounting.getBondShares(defaultNoId), shares + preShares);
+        assertEq(accounting.totalBondShares(), shares + preTotalShares);
     }
 }

--- a/test/integration/Penalty.t.sol
+++ b/test/integration/Penalty.t.sol
@@ -44,7 +44,7 @@ contract PenaltyIntegrationTest is
             address(this)
         );
         vm.stopPrank();
-        csm.resume();
+        if (csm.isPaused()) csm.resume();
 
         user = nextAddress("User");
         stranger = nextAddress("stranger");
@@ -69,8 +69,13 @@ contract PenaltyIntegrationTest is
         defaultNoId = csm.getNodeOperatorsCount() - 1;
 
         // grant role if testing against non-connected CSM
-        if (env.MODULE_ID == 0) {
-            IBurner burner = IBurner(locator.burner());
+        IBurner burner = IBurner(locator.burner());
+        if (
+            !burner.hasRole(
+                burner.REQUEST_BURN_SHARES_ROLE(),
+                address(accounting)
+            )
+        ) {
             vm.startPrank(burner.getRoleMember(burner.DEFAULT_ADMIN_ROLE(), 0));
             burner.grantRole(
                 burner.REQUEST_BURN_SHARES_ROLE(),

--- a/test/integration/RecoverTokens.t.sol
+++ b/test/integration/RecoverTokens.t.sol
@@ -38,7 +38,7 @@ contract RecoverIntegrationTest is
         csm.grantRole(csm.RESUME_ROLE(), address(this));
         csm.grantRole(csm.RECOVERER_ROLE(), recoverer);
         vm.stopPrank();
-        csm.resume();
+        if (csm.isPaused()) csm.resume();
 
         vm.startPrank(
             accounting.getRoleMember(accounting.DEFAULT_ADMIN_ROLE(), 0)

--- a/test/integration/StakingRouter.t.sol
+++ b/test/integration/StakingRouter.t.sol
@@ -77,7 +77,7 @@ contract StakingRouterIntegrationTest is Test, Utilities, DeploymentFixtures {
             _maxDepositsPerBlock: 30,
             _minDepositBlockDistance: 25
         });
-        return ids[ids.length - 1] + 1;
+        return ids.length + 1;
     }
 
     function addNodeOperator(
@@ -126,15 +126,14 @@ contract StakingRouterIntegrationTest is Test, Utilities, DeploymentFixtures {
 
     function test_RouterDeposit() public {
         address nodeOperatorManager = nextAddress();
-        uint256 noId = addNodeOperator(nodeOperatorManager, 2);
-
+        uint256 noId = addNodeOperator(nodeOperatorManager, 1);
+        (, , uint256 totalDepositableKeys) = csm.getStakingModuleSummary();
         hugeDeposit();
 
         vm.prank(locator.depositSecurityModule());
-        lido.deposit(1, moduleId, "");
-        (, , , , , , uint256 totalDepositedValidators, ) = csm
-            .getNodeOperatorSummary(noId);
-        assertEq(totalDepositedValidators, 1);
+        lido.deposit(totalDepositableKeys, moduleId, "");
+        NodeOperator memory no = csm.getNodeOperator(noId);
+        assertEq(no.totalDepositedKeys, 1);
     }
 
     function test_routerReportRewardsMinted() public {
@@ -189,9 +188,8 @@ contract StakingRouterIntegrationTest is Test, Utilities, DeploymentFixtures {
         vm.prank(agent);
         stakingRouter.updateRefundedValidatorsCount(moduleId, noId, 1);
 
-        (, , , uint256 refundedValidatorsCount, , , , ) = csm
-            .getNodeOperatorSummary(noId);
-        assertEq(refundedValidatorsCount, 1);
+        NodeOperator memory no = csm.getNodeOperator(noId);
+        assertEq(no.refundedValidatorsCount, 1);
     }
 
     function test_reportStakingModuleExitedValidatorsCountByNodeOperator()
@@ -202,8 +200,9 @@ contract StakingRouterIntegrationTest is Test, Utilities, DeploymentFixtures {
 
         hugeDeposit();
 
+        (, , uint256 totalDepositableKeys) = csm.getStakingModuleSummary();
         vm.prank(locator.depositSecurityModule());
-        lido.deposit(3, moduleId, "");
+        lido.deposit(totalDepositableKeys - 2, moduleId, "");
 
         uint256 exited = 1;
         vm.prank(agent);
@@ -213,9 +212,8 @@ contract StakingRouterIntegrationTest is Test, Utilities, DeploymentFixtures {
             bytes.concat(bytes16(uint128(exited)))
         );
 
-        (, , , , , uint256 totalExitedValidators, , ) = csm
-            .getNodeOperatorSummary(noId);
-        assertEq(totalExitedValidators, exited);
+        NodeOperator memory no = csm.getNodeOperator(noId);
+        assertEq(no.totalExitedKeys, exited);
     }
 
     function test_reportStakingModuleStuckValidatorsCountByNodeOperator()
@@ -226,8 +224,9 @@ contract StakingRouterIntegrationTest is Test, Utilities, DeploymentFixtures {
 
         hugeDeposit();
 
+        (, , uint256 totalDepositableKeys) = csm.getStakingModuleSummary();
         vm.prank(locator.depositSecurityModule());
-        lido.deposit(3, moduleId, "");
+        lido.deposit(totalDepositableKeys - 2, moduleId, "");
 
         uint256 stuck = 1;
         vm.prank(agent);
@@ -237,9 +236,8 @@ contract StakingRouterIntegrationTest is Test, Utilities, DeploymentFixtures {
             bytes.concat(bytes16(uint128(stuck)))
         );
 
-        (, , uint256 stuckValidatorsCount, , , , , ) = csm
-            .getNodeOperatorSummary(noId);
-        assertEq(stuckValidatorsCount, stuck);
+        NodeOperator memory no = csm.getNodeOperator(noId);
+        assertEq(no.stuckValidatorsCount, stuck);
     }
 
     function test_getStakingModuleSummary() public {
@@ -252,7 +250,8 @@ contract StakingRouterIntegrationTest is Test, Utilities, DeploymentFixtures {
 
         hugeDeposit();
 
-        uint256 keysToDeposit = 3;
+        (, , uint256 totalDepositableKeys) = csm.getStakingModuleSummary();
+        uint256 keysToDeposit = totalDepositableKeys - 2;
         vm.prank(locator.depositSecurityModule());
         lido.deposit(keysToDeposit, moduleId, "");
 
@@ -287,7 +286,8 @@ contract StakingRouterIntegrationTest is Test, Utilities, DeploymentFixtures {
 
         hugeDeposit();
 
-        uint256 keysToDeposit = 3;
+        (, , uint256 totalDepositableKeys) = csm.getStakingModuleSummary();
+        uint256 keysToDeposit = totalDepositableKeys - 2;
         vm.prank(locator.depositSecurityModule());
         lido.deposit(keysToDeposit, moduleId, "");
 
@@ -309,14 +309,13 @@ contract StakingRouterIntegrationTest is Test, Utilities, DeploymentFixtures {
 
         IStakingRouter.NodeOperatorSummary memory summary = stakingRouter
             .getNodeOperatorSummary(moduleId, noId);
-        // TODO: Uncomment. Commented due to interface mismatch
-        // assertEq(summary.isTargetLimitActive, 0);
-        // assertEq(summary.targetValidatorsCount, 0);
+        assertEq(summary.targetLimitMode, 0);
+        assertEq(summary.targetValidatorsCount, 0);
         assertEq(summary.stuckValidatorsCount, stuck);
         assertEq(summary.refundedValidatorsCount, 0);
         assertEq(summary.stuckPenaltyEndTimestamp, 0);
         assertEq(summary.totalExitedValidators, exited);
-        assertEq(summary.totalDepositedValidators, keysToDeposit);
+        assertEq(summary.totalDepositedValidators, keysCount - 2);
         assertEq(summary.depositableValidatorsCount, 0); // due to stuck != 0
     }
 
@@ -326,8 +325,9 @@ contract StakingRouterIntegrationTest is Test, Utilities, DeploymentFixtures {
 
         hugeDeposit();
 
+        (, , uint256 totalDepositableKeys) = csm.getStakingModuleSummary();
         vm.prank(locator.depositSecurityModule());
-        lido.deposit(6, moduleId, "");
+        lido.deposit(totalDepositableKeys - 4, moduleId, "");
 
         uint256 exited = 2;
         vm.prank(agent);
@@ -371,17 +371,8 @@ contract StakingRouterIntegrationTest is Test, Utilities, DeploymentFixtures {
             correction
         );
 
-        (
-            ,
-            ,
-            uint256 stuckValidatorsCount,
-            ,
-            ,
-            uint256 totalExitedValidators,
-            ,
-
-        ) = csm.getNodeOperatorSummary(noId);
-        assertEq(stuckValidatorsCount, unsafeStuck);
-        assertEq(totalExitedValidators, unsafeExited);
+        NodeOperator memory no = csm.getNodeOperator(noId);
+        assertEq(no.stuckValidatorsCount, unsafeStuck);
+        assertEq(no.totalExitedKeys, unsafeExited);
     }
 }


### PR DESCRIPTION
first one is simulating vote

- removed MODULE_ID because it's difficult to get module id from the script and pass it to the tests, for loop search seems ok for me
- staking router interface updated to the new version
- removed KEEP_ANVIL_AFTER_LOCAL_DEPLOY env var because it seems redundant