### PR TITLE
fix: do not allow reporting slashing after a withdrawal

### DIFF
--- a/src/CSModule.sol
+++ b/src/CSModule.sol
@@ -164,6 +164,7 @@ contract CSModule is
     error SigningKeysInvalidOffset();
 
     error AlreadySubmitted();
+    error AlreadyWithdrawn();
 
     error AlreadySet();
     error InvalidAmount();
@@ -1093,6 +1094,7 @@ contract CSModule is
 
         if (_isValidatorSlashed[pointer]) {
             amount += INITIAL_SLASHING_PENALTY;
+            // TODO: Add an explainer.
             accounting.resetBondCurve(nodeOperatorId);
         }
 
@@ -1125,6 +1127,10 @@ contract CSModule is
         }
 
         uint256 pointer = _keyPointer(nodeOperatorId, keyIndex);
+
+        if (_isValidatorWithdrawn[pointer]) {
+            revert AlreadyWithdrawn();
+        }
 
         if (_isValidatorSlashed[pointer]) {
             revert AlreadySubmitted();

--- a/test/CSModule.t.sol
+++ b/test/CSModule.t.sol
@@ -4819,6 +4819,15 @@ contract CsmSubmitInitialSlashing is CSMCommon {
         vm.expectRevert(CSModule.AlreadySubmitted.selector);
         csm.submitInitialSlashing(noId, 0);
     }
+
+    function test_submitInitialSlashing_RevertWhenAlreadyWithdrawn() public {
+        uint256 noId = createNodeOperator();
+        csm.obtainDepositData(1, "");
+        csm.submitWithdrawal(noId, 0, 32 ether);
+
+        vm.expectRevert(CSModule.AlreadyWithdrawn.selector);
+        csm.submitInitialSlashing(noId, 0);
+    }
 }
 
 contract CsmGetStakingModuleSummary is CSMCommon {


### PR DESCRIPTION
Eliminates "over-penalization" case if an initial slashing wasn't reported before a withdrawal.