### PR TITLE
audit-fix: settle locked penalty might cause a revert if the bond is …

### DIFF
--- a/src/CSAccounting.sol
+++ b/src/CSAccounting.sol
@@ -372,12 +372,10 @@ contract CSAccounting is
     /// @notice Settle locked bond ETH for the given Node Operator
     /// @dev Called by CSM exclusively
     /// @param nodeOperatorId ID of the Node Operator
-    function settleLockedBondETH(
-        uint256 nodeOperatorId
-    ) external onlyCSM returns (uint256 settledAmount) {
+    function settleLockedBondETH(uint256 nodeOperatorId) external onlyCSM {
         uint256 lockedAmount = CSBondLock.getActualLockedBond(nodeOperatorId);
         if (lockedAmount > 0) {
-            settledAmount = CSBondCore._burn(nodeOperatorId, lockedAmount);
+            CSBondCore._burn(nodeOperatorId, lockedAmount);
         }
         // reduce all locked bond even if bond isn't covered lock fully
         CSBondLock._remove(nodeOperatorId);

--- a/src/CSModule.sol
+++ b/src/CSModule.sol
@@ -1053,7 +1053,7 @@ contract CSModule is
         });
     }
 
-    /// @notice Settle blocked bond for the given Node Operators
+    /// @notice Settle locked bond for the given Node Operators
     /// @dev SETTLE_EL_REWARDS_STEALING_PENALTY_ROLE role is expected to be assigned to Easy Track
     /// @param nodeOperatorIds IDs of the Node Operators
     function settleELRewardsStealingPenalty(

--- a/src/CSModule.sol
+++ b/src/CSModule.sol
@@ -1062,8 +1062,15 @@ contract CSModule is
         for (uint256 i; i < nodeOperatorIds.length; ++i) {
             uint256 nodeOperatorId = nodeOperatorIds[i];
             _onlyExistingNodeOperator(nodeOperatorId);
-            uint256 settled = accounting.settleLockedBondETH(nodeOperatorId);
-            if (settled > 0) {
+            uint256 lockedBondBefore = accounting.getActualLockedBond(
+                nodeOperatorId
+            );
+
+            accounting.settleLockedBondETH(nodeOperatorId);
+
+            // settled amount might be zero either if the lock expired, or the bond is zero
+            // so we need to check actual locked bond before to determine if the penalty was settled
+            if (lockedBondBefore > 0) {
                 // Bond curve should be reset to default in case of confirmed MEV stealing. See https://hackmd.io/@lido/SygBLW5ja
                 accounting.resetBondCurve(nodeOperatorId);
                 // Nonce should be updated if depositableValidators change

--- a/src/abstract/CSBondCore.sol
+++ b/src/abstract/CSBondCore.sol
@@ -247,8 +247,11 @@ abstract contract CSBondCore is ICSBondCore {
             address(this),
             burnedShares
         );
-        uint256 burned = _ethByShares(burnedShares);
-        emit BondBurned(nodeOperatorId, _ethByShares(toBurnShares), burned);
+        emit BondBurned(
+            nodeOperatorId,
+            _ethByShares(toBurnShares),
+            _ethByShares(burnedShares)
+        );
     }
 
     /// @dev Transfer Node Operator's bond shares (stETH) to charge recipient to pay some fee

--- a/src/abstract/CSBondCore.sol
+++ b/src/abstract/CSBondCore.sol
@@ -237,17 +237,17 @@ abstract contract CSBondCore is ICSBondCore {
     /// @dev Burn Node Operator's bond shares (stETH). Shares will be burned on the next stETH rebase
     /// @dev The method sender should be granted as `Burner.REQUEST_BURN_SHARES_ROLE` and make stETH allowance for `Burner`
     /// @param amount Bond amount to burn in ETH (stETH)
-    function _burn(
-        uint256 nodeOperatorId,
-        uint256 amount
-    ) internal returns (uint256 burned) {
+    function _burn(uint256 nodeOperatorId, uint256 amount) internal {
         uint256 toBurnShares = _sharesByEth(amount);
         uint256 burnedShares = _reduceBond(nodeOperatorId, toBurnShares);
+        // If no bond already
+        if (burnedShares == 0) return;
+
         IBurner(LIDO_LOCATOR.burner()).requestBurnShares(
             address(this),
             burnedShares
         );
-        burned = _ethByShares(burnedShares);
+        uint256 burned = _ethByShares(burnedShares);
         emit BondBurned(nodeOperatorId, _ethByShares(toBurnShares), burned);
     }
 

--- a/src/abstract/CSBondCurve.sol
+++ b/src/abstract/CSBondCurve.sol
@@ -222,9 +222,11 @@ abstract contract CSBondCurve is ICSBondCurve, Initializable {
     /// @dev Reset bond curve for the given Node Operator to default.
     ///      (for example, because of breaking the rules by Node Operator)
     function _resetBondCurve(uint256 nodeOperatorId) internal {
-        _getCSBondCurveStorage().operatorBondCurveId[
-            nodeOperatorId
-        ] = DEFAULT_BOND_CURVE_ID;
+        CSBondCurveStorage storage $ = _getCSBondCurveStorage();
+        uint256 curveId = $.operatorBondCurveId[nodeOperatorId];
+        if (curveId == DEFAULT_BOND_CURVE_ID) return;
+
+        $.operatorBondCurveId[nodeOperatorId] = DEFAULT_BOND_CURVE_ID;
         emit BondCurveSet(nodeOperatorId, DEFAULT_BOND_CURVE_ID);
     }
 

--- a/src/abstract/CSBondCurve.sol
+++ b/src/abstract/CSBondCurve.sol
@@ -223,8 +223,8 @@ abstract contract CSBondCurve is ICSBondCurve, Initializable {
     ///      (for example, because of breaking the rules by Node Operator)
     function _resetBondCurve(uint256 nodeOperatorId) internal {
         CSBondCurveStorage storage $ = _getCSBondCurveStorage();
-        uint256 curveId = $.operatorBondCurveId[nodeOperatorId];
-        if (curveId == DEFAULT_BOND_CURVE_ID) return;
+        if ($.operatorBondCurveId[nodeOperatorId] == DEFAULT_BOND_CURVE_ID)
+            return;
 
         $.operatorBondCurveId[nodeOperatorId] = DEFAULT_BOND_CURVE_ID;
         emit BondCurveSet(nodeOperatorId, DEFAULT_BOND_CURVE_ID);

--- a/src/interfaces/ICSAccounting.sol
+++ b/src/interfaces/ICSAccounting.sol
@@ -102,9 +102,7 @@ interface ICSAccounting is
         uint256 amount
     ) external;
 
-    function settleLockedBondETH(
-        uint256 nodeOperatorId
-    ) external returns (uint256);
+    function settleLockedBondETH(uint256 nodeOperatorId) external;
 
     function compensateLockedBondETH(uint256 nodeOperatorId) external payable;
 

--- a/test/CSAccounting.t.sol
+++ b/test/CSAccounting.t.sol
@@ -3725,6 +3725,25 @@ contract CSAccountingLockBondETHTest is CSAccountingBaseTest {
         assertEq(accounting.getActualLockedBond(noId), 0);
         assertEq(accounting.getBondShares(noId), bond);
     }
+
+    function test_settleLockedBondETH_noBond() public assertInvariants {
+        mock_getNodeOperatorsCount(1);
+        uint256 noId = 0;
+        uint256 amount = 1 ether;
+
+        vm.startPrank(address(stakingModule));
+        accounting.lockBondETH(noId, amount);
+
+        expectNoCall(
+            address(burner),
+            abi.encodeWithSelector(IBurner.requestBurnShares.selector)
+        );
+        accounting.settleLockedBondETH(noId);
+        vm.stopPrank();
+
+        assertEq(accounting.getActualLockedBond(noId), 0);
+        assertEq(accounting.getBondShares(noId), 0);
+    }
 }
 
 contract CSAccountingBondCurveTest is CSAccountingBaseTest {

--- a/test/CSAccounting.t.sol
+++ b/test/CSAccounting.t.sol
@@ -3708,17 +3708,22 @@ contract CSAccountingLockBondETHTest is CSAccountingBaseTest {
         assertEq(accounting.getActualLockedBond(noId), amount);
 
         vm.prank(address(stakingModule));
-        uint256 settled = accounting.settleLockedBondETH(noId);
-        assertEq(settled, ethToSharesToEth(amount));
+        accounting.settleLockedBondETH(noId);
         assertEq(accounting.getActualLockedBond(noId), 0);
     }
 
     function test_settleLockedBondETH_noLocked() public assertInvariants {
         mock_getNodeOperatorsCount(1);
+        uint256 noId = 0;
+        vm.deal(address(stakingModule), 32 ether);
         vm.prank(address(stakingModule));
-        uint256 settled = accounting.settleLockedBondETH(0);
-        assertEq(settled, 0 ether);
-        assertEq(accounting.getActualLockedBond(0), 0);
+        accounting.depositETH{ value: 32 ether }(user, noId);
+        uint256 bond = accounting.getBondShares(noId);
+
+        vm.prank(address(stakingModule));
+        accounting.settleLockedBondETH(noId);
+        assertEq(accounting.getActualLockedBond(noId), 0);
+        assertEq(accounting.getBondShares(noId), bond);
     }
 }
 

--- a/test/CSBondCurve.t.sol
+++ b/test/CSBondCurve.t.sol
@@ -207,6 +207,17 @@ contract CSBondCurveTest is Test {
         assertEq(bondCurve.getBondCurveId(noId), 0);
     }
 
+    function test_resetBondCurve_nothingToChange() public {
+        uint256 noId = 0;
+        assertEq(bondCurve.getBondCurveId(noId), 0);
+        Vm.Log[] memory entries = vm.getRecordedLogs();
+
+        bondCurve.resetBondCurve(noId);
+
+        assertEq(entries.length, 0);
+        assertEq(bondCurve.getBondCurveId(noId), 0);
+    }
+
     function test_getKeysCountByBondAmount_default() public {
         assertEq(bondCurve.getKeysCountByBondAmount(0, 0), 0);
         assertEq(bondCurve.getKeysCountByBondAmount(1.9 ether, 0), 0);

--- a/test/CSModule.t.sol
+++ b/test/CSModule.t.sol
@@ -5577,15 +5577,9 @@ contract CsmSettleELRewardsStealingPenaltyAdvanced is CSMCommon {
         idsToSettle[0] = noId;
         uint256 amount = accounting.getBond(noId) + 1 ether;
 
-        // settle all current bond to make and edge case when there is no bond but a new lock is applied
-        csm.reportELRewardsStealingPenalty(
-            noId,
-            blockhash(block.number),
-            amount
-        );
-        csm.settleELRewardsStealingPenalty(idsToSettle);
-
-        accounting.getBond(noId);
+        // penalize all current bond to make an edge case when there is no bond but a new lock is applied
+        vm.prank(address(csm));
+        accounting.penalize(noId, amount);
 
         csm.reportELRewardsStealingPenalty(
             noId,

--- a/test/helpers/Fixtures.sol
+++ b/test/helpers/Fixtures.sol
@@ -46,7 +46,7 @@ contract Fixtures is StdCheats, Test {
             _account: address(stETH),
             _sharesAmount: 7059313073779349112833523
         });
-        burner = new BurnerMock();
+        burner = new BurnerMock(address(stETH));
         Stub elVault = new Stub();
         wstETH = new WstETHMock(address(stETH));
         wq = new WithdrawalQueueMock(address(wstETH), address(stETH));

--- a/test/helpers/mocks/BurnerMock.sol
+++ b/test/helpers/mocks/BurnerMock.sol
@@ -2,10 +2,25 @@
 // SPDX-License-Identifier: GPL-3.0
 
 pragma solidity 0.8.24;
+import "../../../src/interfaces/IStETH.sol";
 
 contract BurnerMock {
+    address public STETH;
+    error ZeroBurnAmount();
+
+    constructor(address _stETH) {
+        STETH = _stETH;
+    }
+
     function requestBurnShares(
         address _from,
         uint256 _sharesAmountToBurn
-    ) external {}
+    ) external {
+        IStETH(STETH).transferSharesFrom(
+            _from,
+            address(this),
+            _sharesAmountToBurn
+        );
+        if (_sharesAmountToBurn == 0) revert ZeroBurnAmount();
+    }
 }


### PR DESCRIPTION
…zero, so we need to skip this step

It broke assumption that the only case of zero settled amount is expired lock