### PR TITLE
Revert "chore: BaseOracle consensus versions setter check"

### DIFF
--- a/src/lib/base-oracle/BaseOracle.sol
+++ b/src/lib/base-oracle/BaseOracle.sol
@@ -75,6 +75,7 @@ abstract contract BaseOracle is
     error AddressCannotBeZero();
     error AddressCannotBeSame();
     error VersionCannotBeSame();
+    error VersionCannotBeZero();
     error UnexpectedChainConfig();
     error SenderIsNotTheConsensusContract();
     error InitialRefSlotCannotBeLessThanProcessingOne(
@@ -398,6 +399,7 @@ abstract contract BaseOracle is
     function _setConsensusVersion(uint256 version) internal {
         uint256 prevVersion = CONSENSUS_VERSION_POSITION.getStorageUint256();
         if (version == prevVersion) revert VersionCannotBeSame();
+        if (version == 0) revert VersionCannotBeZero();
         CONSENSUS_VERSION_POSITION.setStorageUint256(version);
         emit ConsensusVersionSet(version, prevVersion);
     }

--- a/src/lib/base-oracle/BaseOracle.sol
+++ b/src/lib/base-oracle/BaseOracle.sol
@@ -74,7 +74,7 @@ abstract contract BaseOracle is
 
     error AddressCannotBeZero();
     error AddressCannotBeSame();
-    error InvalidConsensusVersionIncrement();
+    error VersionCannotBeSame();
     error UnexpectedChainConfig();
     error SenderIsNotTheConsensusContract();
     error InitialRefSlotCannotBeLessThanProcessingOne(
@@ -397,8 +397,7 @@ abstract contract BaseOracle is
 
     function _setConsensusVersion(uint256 version) internal {
         uint256 prevVersion = CONSENSUS_VERSION_POSITION.getStorageUint256();
-        if (version != prevVersion + 1)
-            revert InvalidConsensusVersionIncrement();
+        if (version == prevVersion) revert VersionCannotBeSame();
         CONSENSUS_VERSION_POSITION.setStorageUint256(version);
         emit ConsensusVersionSet(version, prevVersion);
     }


### PR DESCRIPTION
This reverts commit bd178baf6caff2f9ff7824701df72ff3a5daf66a.

Consensus version is a flag for off-chain tooling, indicating what code to execute to reach consensus. It can be moved back and forth, and off-chain tooling will determine supported combinations of an oracle contract's and a consensus' versions. The only version value restricted to use is `0`.