### PR TITLE
chore: move linters to dev dependencies

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -81,7 +81,7 @@ jobs:
           cache-dependency-path: "**/yarn.lock"
 
       - name: Install dependencies
-        run: just deps
+        run: just deps-dev
 
       - name: Linters check
         run: just lint

--- a/Justfile
+++ b/Justfile
@@ -35,7 +35,10 @@ clean:
     rm -rf cache broadcast out node_modules
 
 deps:
-    yarn install --immutable
+    yarn workspaces focus --all --production
+
+deps-dev:
+    yarn workspaces focus --all && npx husky install
 
 lint-solhint:
     yarn lint:solhint

--- a/package.json
+++ b/package.json
@@ -11,16 +11,17 @@
     "lint:check": "prettier --check **.sol && yarn lint:solhint",
     "lint:fix": "prettier --write **.sol",
     "generate:diffyscan": "node script/generateDiffyscanContracts.js",
-    "gindex": "node script/gindex.mjs",
-    "postinstall": "husky install"
+    "gindex": "node script/gindex.mjs"
   },
-  "devDependencies": {
+  "dependencies": {
     "@lodestar/types": "^1.18.1",
     "@openzeppelin/contracts": "5.0.2",
     "@openzeppelin/contracts-upgradeable": "5.0.2",
     "@openzeppelin/merkle-tree": "^1.0.6",
     "ds-test": "https://github.com/dapphub/ds-test",
-    "forge-std": "https://github.com/foundry-rs/forge-std.git#v1.7.6",
+    "forge-std": "https://github.com/foundry-rs/forge-std.git#v1.7.6"
+  },
+  "devDependencies": {
     "husky": "^8.0.3",
     "lint-staged": "^14.0.1",
     "prettier": "^3.0.3",


### PR DESCRIPTION
Note that both `yarn install` and `yarn install --immutable` install **all** dependencies, including the development ones. Use `yarn workspaces focus --all --production` instead.