### PR TITLE
feat: Remove publicRelease and slashing-related stuff

### DIFF
--- a/script/DeployBase.s.sol
+++ b/script/DeployBase.s.sol
@@ -107,7 +107,6 @@ struct DeployParams {
     // Module
     bytes32 moduleType;
     uint256 minSlashingPenaltyQuotient;
-    uint256 maxKeysPerOperatorEA;
     address elRewardsStealingReporter;
     // CSParameters
     uint256 keyRemovalCharge;
@@ -208,7 +207,6 @@ abstract contract DeployBase is Script {
             CSModule csmImpl = new CSModule({
                 moduleType: config.moduleType,
                 minSlashingPenaltyQuotient: config.minSlashingPenaltyQuotient,
-                maxKeysPerOperatorEA: config.maxKeysPerOperatorEA,
                 lidoLocator: config.lidoLocatorAddress,
                 parametersRegistry: address(parametersRegistry)
             });

--- a/script/DeployBase.s.sol
+++ b/script/DeployBase.s.sol
@@ -106,7 +106,6 @@ struct DeployParams {
     address chargePenaltyRecipient;
     // Module
     bytes32 moduleType;
-    uint256 minSlashingPenaltyQuotient;
     address elRewardsStealingReporter;
     // CSParameters
     uint256 keyRemovalCharge;
@@ -206,7 +205,6 @@ abstract contract DeployBase is Script {
 
             CSModule csmImpl = new CSModule({
                 moduleType: config.moduleType,
-                minSlashingPenaltyQuotient: config.minSlashingPenaltyQuotient,
                 lidoLocator: config.lidoLocatorAddress,
                 parametersRegistry: address(parametersRegistry)
             });

--- a/script/DeployHolesky.s.sol
+++ b/script/DeployHolesky.s.sol
@@ -65,7 +65,6 @@ contract DeployHolesky is DeployBase {
             .setResetBondCurveAddress = 0xc4DAB3a3ef68C6DFd8614a870D64D475bA44F164; // Dev team EOA
         // Module
         config.moduleType = "community-onchain-v1";
-        config.minSlashingPenaltyQuotient = 32;
         config
             .elRewardsStealingReporter = 0xc4DAB3a3ef68C6DFd8614a870D64D475bA44F164; // Dev team EOA
         config

--- a/script/DeployHolesky.s.sol
+++ b/script/DeployHolesky.s.sol
@@ -66,7 +66,6 @@ contract DeployHolesky is DeployBase {
         // Module
         config.moduleType = "community-onchain-v1";
         config.minSlashingPenaltyQuotient = 32;
-        config.maxKeysPerOperatorEA = 10;
         config
             .elRewardsStealingReporter = 0xc4DAB3a3ef68C6DFd8614a870D64D475bA44F164; // Dev team EOA
         config

--- a/script/DeployImplementationsBase.s.sol
+++ b/script/DeployImplementationsBase.s.sol
@@ -67,7 +67,6 @@ abstract contract DeployImplementationsBase is DeployBase {
 
             CSModule csmImpl = new CSModule({
                 moduleType: config.moduleType,
-                minSlashingPenaltyQuotient: config.minSlashingPenaltyQuotient,
                 lidoLocator: config.lidoLocatorAddress,
                 parametersRegistry: address(parametersRegistry)
             });

--- a/script/DeployImplementationsBase.s.sol
+++ b/script/DeployImplementationsBase.s.sol
@@ -68,7 +68,6 @@ abstract contract DeployImplementationsBase is DeployBase {
             CSModule csmImpl = new CSModule({
                 moduleType: config.moduleType,
                 minSlashingPenaltyQuotient: config.minSlashingPenaltyQuotient,
-                maxKeysPerOperatorEA: config.maxKeysPerOperatorEA,
                 lidoLocator: config.lidoLocatorAddress,
                 parametersRegistry: address(parametersRegistry)
             });

--- a/script/DeployMainnet.s.sol
+++ b/script/DeployMainnet.s.sol
@@ -64,7 +64,6 @@ contract DeployMainnet is DeployBase {
         // Module
         config.moduleType = "community-onchain-v1"; // Just a unique type name to be used by the off-chain tooling
         config.minSlashingPenaltyQuotient = 32;
-        config.maxKeysPerOperatorEA = 12; // 12 EA vals will result in approx 16 ETH worth of bond
         config
             .elRewardsStealingReporter = 0xC52fC3081123073078698F1EAc2f1Dc7Bd71880f; // CSM Committee MS
         // CSParameters

--- a/script/DeployMainnet.s.sol
+++ b/script/DeployMainnet.s.sol
@@ -63,7 +63,6 @@ contract DeployMainnet is DeployBase {
             .chargePenaltyRecipient = 0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c; // locator.treasury()
         // Module
         config.moduleType = "community-onchain-v1"; // Just a unique type name to be used by the off-chain tooling
-        config.minSlashingPenaltyQuotient = 32;
         config
             .elRewardsStealingReporter = 0xC52fC3081123073078698F1EAc2f1Dc7Bd71880f; // CSM Committee MS
         // CSParameters

--- a/script/fork-helpers/PauseResume.s.sol
+++ b/script/fork-helpers/PauseResume.s.sol
@@ -27,12 +27,6 @@ contract PauseResume is Script, DeploymentFixtures, ForkHelpersCommon {
         vm.stopBroadcast();
     }
 
-    function publicRelease() external broadcastCSMAdmin {
-        csm.activatePublicRelease();
-
-        assertTrue(csm.publicRelease());
-    }
-
     function pauseCSM() external broadcastCSMAdmin {
         csm.grantRole(csm.PAUSE_ROLE(), csmAdmin);
         csm.pauseFor(type(uint256).max);

--- a/src/interfaces/ICSModule.sol
+++ b/src/interfaces/ICSModule.sol
@@ -55,10 +55,8 @@ interface ICSModule is IQueueLib, INOAddresses, IAssetRecovererLib {
 
     error AlreadyWithdrawn();
     error AlreadyEjected();
-    error AlreadyActivated();
 
     error InvalidAmount();
-    error MaxSigningKeysCountExceeded();
 
     error NotSupported();
     error ZeroLocatorAddress();
@@ -118,7 +116,6 @@ interface ICSModule is IQueueLib, INOAddresses, IAssetRecovererLib {
         bytes pubkey
     );
 
-    event PublicRelease();
     event KeyRemovalChargeApplied(uint256 indexed nodeOperatorId);
     event ELRewardsStealingPenaltyReported(
         uint256 indexed nodeOperatorId,
@@ -138,11 +135,6 @@ interface ICSModule is IQueueLib, INOAddresses, IAssetRecovererLib {
     function INITIAL_SLASHING_PENALTY() external view returns (uint256);
 
     function LIDO_LOCATOR() external view returns (ILidoLocator);
-
-    function MAX_SIGNING_KEYS_PER_OPERATOR_BEFORE_PUBLIC_RELEASE()
-        external
-        view
-        returns (uint256);
 
     function PAUSE_ROLE() external view returns (bytes32);
 
@@ -191,11 +183,6 @@ interface ICSModule is IQueueLib, INOAddresses, IAssetRecovererLib {
 
     /// @notice Public release mode status
     function publicRelease() external view returns (bool);
-
-    /// @notice Activate public release mode
-    ///         Enable permissionless creation of the Node Operators
-    ///         Remove the keys limit for the Node Operators
-    function activatePublicRelease() external;
 
     /// @notice Permissioned method to add a new Node Operator
     ///         Should be called by `*Gate.sol` contracts. See `PermissionlessGate.sol` and `VettedGate.sol` for examples

--- a/src/interfaces/ICSModule.sol
+++ b/src/interfaces/ICSModule.sol
@@ -132,8 +132,6 @@ interface ICSModule is IQueueLib, INOAddresses, IAssetRecovererLib {
     );
     event ELRewardsStealingPenaltySettled(uint256 indexed nodeOperatorId);
 
-    function INITIAL_SLASHING_PENALTY() external view returns (uint256);
-
     function LIDO_LOCATOR() external view returns (ILidoLocator);
 
     function PAUSE_ROLE() external view returns (bytes32);
@@ -487,17 +485,6 @@ interface ICSModule is IQueueLib, INOAddresses, IAssetRecovererLib {
         uint256 keyIndex,
         uint256 strikesCount
     ) external;
-
-    /// @notice DEPRECATED! Check if the given Node Operator's key is reported as slashed
-    /// @notice Since pectra update the contract doesn't store slashing flag of a withdrawn
-    /// validator
-    /// @param nodeOperatorId ID of the Node Operator
-    /// @param keyIndex Index of the key to check
-    /// @return Validator reported as slashed flag
-    function isValidatorSlashed(
-        uint256 nodeOperatorId,
-        uint256 keyIndex
-    ) external view returns (bool);
 
     /// @notice Check if the given Node Operator's key is reported as withdrawn
     /// @param nodeOperatorId ID of the Node Operator

--- a/test/CSModule.t.sol
+++ b/test/CSModule.t.sol
@@ -70,7 +70,6 @@ abstract contract CSMFixtures is Test, Fixtures, Utilities, InvariantAsserts {
     modifier assertInvariants() {
         _;
         vm.pauseGasMetering();
-        assertCSMMaxKeys(csm);
         assertCSMEnqueuedCount(csm);
         assertCSMKeys(csm);
         vm.resumeGasMetering();
@@ -271,7 +270,7 @@ abstract contract CSMFixtures is Test, Fixtures, Utilities, InvariantAsserts {
     }
 }
 
-contract CSMCommonNoPublicRelease is CSMFixtures {
+contract CSMCommon is CSMFixtures {
     function setUp() public virtual {
         nodeOperator = nextAddress("NODE_OPERATOR");
         stranger = nextAddress("STRANGER");
@@ -287,7 +286,6 @@ contract CSMCommonNoPublicRelease is CSMFixtures {
         csm = new CSModule({
             moduleType: "community-staking-module",
             minSlashingPenaltyQuotient: 32,
-            maxKeysPerOperatorEA: 10,
             lidoLocator: address(locator),
             parametersRegistry: address(parametersRegistry)
         });
@@ -351,13 +349,6 @@ contract CSMCommonNoPublicRelease is CSMFixtures {
     }
 }
 
-contract CSMCommon is CSMCommonNoPublicRelease {
-    function setUp() public virtual override {
-        super.setUp();
-        csm.activatePublicRelease();
-    }
-}
-
 contract CSMCommonNoRoles is CSMFixtures {
     address internal actor;
 
@@ -376,7 +367,6 @@ contract CSMCommonNoRoles is CSMFixtures {
         csm = new CSModule({
             moduleType: "community-staking-module",
             minSlashingPenaltyQuotient: 32,
-            maxKeysPerOperatorEA: 10,
             lidoLocator: address(locator),
             parametersRegistry: address(parametersRegistry)
         });
@@ -458,12 +448,10 @@ contract CsmInitialize is CSMCommon {
         CSModule csm = new CSModule({
             moduleType: "community-staking-module",
             minSlashingPenaltyQuotient: 32,
-            maxKeysPerOperatorEA: 10,
             lidoLocator: address(locator),
             parametersRegistry: address(parametersRegistry)
         });
         assertEq(csm.getType(), "community-staking-module");
-        assertEq(csm.MAX_SIGNING_KEYS_PER_OPERATOR_BEFORE_PUBLIC_RELEASE(), 10);
         assertEq(address(csm.LIDO_LOCATOR()), address(locator));
         assertEq(
             address(csm.PARAMETERS_REGISTRY()),
@@ -476,7 +464,6 @@ contract CsmInitialize is CSMCommon {
         new CSModule({
             moduleType: "community-staking-module",
             minSlashingPenaltyQuotient: 32,
-            maxKeysPerOperatorEA: 10,
             lidoLocator: address(0),
             parametersRegistry: address(parametersRegistry)
         });
@@ -489,7 +476,6 @@ contract CsmInitialize is CSMCommon {
         new CSModule({
             moduleType: "community-staking-module",
             minSlashingPenaltyQuotient: 32,
-            maxKeysPerOperatorEA: 10,
             lidoLocator: address(locator),
             parametersRegistry: address(0)
         });
@@ -499,7 +485,6 @@ contract CsmInitialize is CSMCommon {
         CSModule csm = new CSModule({
             moduleType: "community-staking-module",
             minSlashingPenaltyQuotient: 32,
-            maxKeysPerOperatorEA: 10,
             lidoLocator: address(locator),
             parametersRegistry: address(parametersRegistry)
         });
@@ -515,7 +500,6 @@ contract CsmInitialize is CSMCommon {
         CSModule csm = new CSModule({
             moduleType: "community-staking-module",
             minSlashingPenaltyQuotient: 32,
-            maxKeysPerOperatorEA: 10,
             lidoLocator: address(locator),
             parametersRegistry: address(parametersRegistry)
         });
@@ -526,7 +510,6 @@ contract CsmInitialize is CSMCommon {
             admin: address(this)
         });
         assertEq(csm.getType(), "community-staking-module");
-        assertEq(csm.MAX_SIGNING_KEYS_PER_OPERATOR_BEFORE_PUBLIC_RELEASE(), 10);
         assertEq(address(csm.LIDO_LOCATOR()), address(locator));
         assertEq(address(csm.accounting()), address(accounting));
         assertTrue(csm.isPaused());
@@ -536,7 +519,6 @@ contract CsmInitialize is CSMCommon {
         CSModule csm = new CSModule({
             moduleType: "community-staking-module",
             minSlashingPenaltyQuotient: 32,
-            maxKeysPerOperatorEA: 10,
             lidoLocator: address(locator),
             parametersRegistry: address(parametersRegistry)
         });
@@ -550,7 +532,6 @@ contract CsmInitialize is CSMCommon {
         CSModule csm = new CSModule({
             moduleType: "community-staking-module",
             minSlashingPenaltyQuotient: 32,
-            maxKeysPerOperatorEA: 10,
             lidoLocator: address(locator),
             parametersRegistry: address(parametersRegistry)
         });
@@ -5833,7 +5814,6 @@ contract CSMAccessControl is CSMCommonNoRoles {
         CSModule csm = new CSModule({
             moduleType: "community-staking-module",
             minSlashingPenaltyQuotient: 32,
-            maxKeysPerOperatorEA: 10,
             lidoLocator: address(locator),
             parametersRegistry: address(parametersRegistry)
         });
@@ -5854,7 +5834,6 @@ contract CSMAccessControl is CSMCommonNoRoles {
         CSModule csm = new CSModule({
             moduleType: "community-staking-module",
             minSlashingPenaltyQuotient: 32,
-            maxKeysPerOperatorEA: 10,
             lidoLocator: address(locator),
             parametersRegistry: address(parametersRegistry)
         });
@@ -5864,23 +5843,6 @@ contract CSMAccessControl is CSMCommonNoRoles {
         vm.startPrank(stranger);
         expectRoleRevert(stranger, adminRole);
         csm.grantRole(role, stranger);
-    }
-
-    function test_adminRole_activatePublicRelease() public {
-        bytes32 role = csm.DEFAULT_ADMIN_ROLE();
-        vm.prank(admin);
-        csm.grantRole(role, actor);
-
-        vm.prank(actor);
-        csm.activatePublicRelease();
-    }
-
-    function test_adminRole_activatePublicRelease_revert() public {
-        bytes32 role = csm.DEFAULT_ADMIN_ROLE();
-
-        vm.prank(stranger);
-        expectRoleRevert(stranger, role);
-        csm.activatePublicRelease();
     }
 
     function test_createNodeOperatorRole() public {
@@ -5936,7 +5898,6 @@ contract CSMAccessControl is CSMCommonNoRoles {
     }
 
     function test_reportELRewardsStealingPenaltyRole() public {
-        csm.activatePublicRelease();
         uint256 noId = createNodeOperator();
         bytes32 role = csm.REPORT_EL_REWARDS_STEALING_PENALTY_ROLE();
         vm.prank(admin);
@@ -5951,7 +5912,6 @@ contract CSMAccessControl is CSMCommonNoRoles {
     }
 
     function test_reportELRewardsStealingPenaltyRole_revert() public {
-        csm.activatePublicRelease();
         uint256 noId = createNodeOperator();
         bytes32 role = csm.REPORT_EL_REWARDS_STEALING_PENALTY_ROLE();
 
@@ -5965,7 +5925,6 @@ contract CSMAccessControl is CSMCommonNoRoles {
     }
 
     function test_settleELRewardsStealingPenaltyRole() public {
-        csm.activatePublicRelease();
         uint256 noId = createNodeOperator();
         bytes32 role = csm.SETTLE_EL_REWARDS_STEALING_PENALTY_ROLE();
         vm.prank(admin);
@@ -5976,7 +5935,6 @@ contract CSMAccessControl is CSMCommonNoRoles {
     }
 
     function test_settleELRewardsStealingPenaltyRole_revert() public {
-        csm.activatePublicRelease();
         uint256 noId = createNodeOperator();
         bytes32 role = csm.SETTLE_EL_REWARDS_STEALING_PENALTY_ROLE();
 
@@ -5986,7 +5944,6 @@ contract CSMAccessControl is CSMCommonNoRoles {
     }
 
     function test_verifierRole_submitWithdrawal() public {
-        csm.activatePublicRelease();
         uint256 noId = createNodeOperator();
         bytes32 role = csm.VERIFIER_ROLE();
 
@@ -6001,7 +5958,6 @@ contract CSMAccessControl is CSMCommonNoRoles {
     }
 
     function test_verifierRole_submitWithdrawal_revert() public {
-        csm.activatePublicRelease();
         uint256 noId = createNodeOperator();
         bytes32 role = csm.VERIFIER_ROLE();
 
@@ -6011,7 +5967,6 @@ contract CSMAccessControl is CSMCommonNoRoles {
     }
 
     function test_badPerformerEjectorRole_ejectBadPerformer() public {
-        csm.activatePublicRelease();
         uint256 noId = createNodeOperator();
         bytes32 role = csm.BAD_PERFORMER_EJECTOR_ROLE();
 
@@ -6108,7 +6063,6 @@ contract CSMStakingRouterAccessControl is CSMCommonNoRoles {
     }
 
     function test_stakingRouterRole_updateRefundedValidatorsCount() public {
-        csm.activatePublicRelease();
         uint256 noId = createNodeOperator();
         bytes32 role = csm.STAKING_ROUTER_ROLE();
         vm.prank(admin);
@@ -6122,7 +6076,6 @@ contract CSMStakingRouterAccessControl is CSMCommonNoRoles {
     function test_stakingRouterRole_updateRefundedValidatorsCount_revert()
         public
     {
-        csm.activatePublicRelease();
         uint256 noId = createNodeOperator();
         bytes32 role = csm.STAKING_ROUTER_ROLE();
 
@@ -6132,7 +6085,6 @@ contract CSMStakingRouterAccessControl is CSMCommonNoRoles {
     }
 
     function test_stakingRouterRole_updateTargetValidatorsLimits() public {
-        csm.activatePublicRelease();
         uint256 noId = createNodeOperator();
         bytes32 role = csm.STAKING_ROUTER_ROLE();
         vm.prank(admin);
@@ -6145,7 +6097,6 @@ contract CSMStakingRouterAccessControl is CSMCommonNoRoles {
     function test_stakingRouterRole_updateTargetValidatorsLimits_revert()
         public
     {
-        csm.activatePublicRelease();
         uint256 noId = createNodeOperator();
         bytes32 role = csm.STAKING_ROUTER_ROLE();
 
@@ -6212,7 +6163,6 @@ contract CSMStakingRouterAccessControl is CSMCommonNoRoles {
     }
 
     function test_stakingRouterRole_unsafeUpdateValidatorsCountRole() public {
-        csm.activatePublicRelease();
         uint256 noId = createNodeOperator();
         bytes32 role = csm.STAKING_ROUTER_ROLE();
         vm.prank(admin);
@@ -6225,7 +6175,6 @@ contract CSMStakingRouterAccessControl is CSMCommonNoRoles {
     function test_stakingRouterRole_unsafeUpdateValidatorsCountRole_revert()
         public
     {
-        csm.activatePublicRelease();
         uint256 noId = createNodeOperator();
         bytes32 role = csm.STAKING_ROUTER_ROLE();
 
@@ -6235,7 +6184,6 @@ contract CSMStakingRouterAccessControl is CSMCommonNoRoles {
     }
 
     function test_stakingRouterRole_unvetKeys() public {
-        csm.activatePublicRelease();
         createNodeOperator();
         bytes32 role = csm.STAKING_ROUTER_ROLE();
         vm.prank(admin);
@@ -6246,56 +6194,12 @@ contract CSMStakingRouterAccessControl is CSMCommonNoRoles {
     }
 
     function test_stakingRouterRole_unvetKeys_revert() public {
-        csm.activatePublicRelease();
         createNodeOperator();
         bytes32 role = csm.STAKING_ROUTER_ROLE();
 
         vm.prank(stranger);
         expectRoleRevert(stranger, role);
         csm.decreaseVettedSigningKeysCount(new bytes(0), new bytes(0));
-    }
-}
-
-contract CSMActivatePublicRelease is CSMCommonNoPublicRelease {
-    function test_activatePublicRelease() public assertInvariants {
-        vm.expectEmit(address(csm));
-        emit ICSModule.PublicRelease();
-        csm.activatePublicRelease();
-
-        assertTrue(csm.publicRelease());
-    }
-
-    function test_activatePublicRelease_RevertWhen_AlreadyActivated()
-        public
-        assertInvariants
-    {
-        csm.activatePublicRelease();
-
-        vm.expectRevert(ICSModule.AlreadyActivated.selector);
-        csm.activatePublicRelease();
-    }
-}
-
-contract CSMNoKeysLimit is CSMCommonNoPublicRelease {
-    function test_revertWhen_uploadMoreKeysThanAllowed() public {
-        uint256 noId = createNodeOperator(1);
-        uint256 keysCount = 10;
-        uint256 amount = accounting.getRequiredBondForNextKeys(noId, keysCount);
-        address managerAddress = csm.getNodeOperator(noId).managerAddress;
-        vm.deal(managerAddress, amount);
-        (bytes memory keys, bytes memory signatures) = keysSignatures(
-            keysCount
-        );
-
-        vm.expectRevert(ICSModule.MaxSigningKeysCountExceeded.selector);
-        vm.prank(managerAddress);
-        csm.addValidatorKeysETH{ value: amount }(
-            managerAddress,
-            noId,
-            keysCount,
-            keys,
-            signatures
-        );
     }
 }
 

--- a/test/CSModule.t.sol
+++ b/test/CSModule.t.sol
@@ -285,7 +285,6 @@ contract CSMCommon is CSMFixtures {
 
         csm = new CSModule({
             moduleType: "community-staking-module",
-            minSlashingPenaltyQuotient: 32,
             lidoLocator: address(locator),
             parametersRegistry: address(parametersRegistry)
         });
@@ -366,7 +365,6 @@ contract CSMCommonNoRoles is CSMFixtures {
 
         csm = new CSModule({
             moduleType: "community-staking-module",
-            minSlashingPenaltyQuotient: 32,
             lidoLocator: address(locator),
             parametersRegistry: address(parametersRegistry)
         });
@@ -447,7 +445,6 @@ contract CsmInitialize is CSMCommon {
     function test_constructor() public {
         CSModule csm = new CSModule({
             moduleType: "community-staking-module",
-            minSlashingPenaltyQuotient: 32,
             lidoLocator: address(locator),
             parametersRegistry: address(parametersRegistry)
         });
@@ -463,7 +460,6 @@ contract CsmInitialize is CSMCommon {
         vm.expectRevert(ICSModule.ZeroLocatorAddress.selector);
         new CSModule({
             moduleType: "community-staking-module",
-            minSlashingPenaltyQuotient: 32,
             lidoLocator: address(0),
             parametersRegistry: address(parametersRegistry)
         });
@@ -475,7 +471,6 @@ contract CsmInitialize is CSMCommon {
         vm.expectRevert(ICSModule.ZeroParametersRegistryAddress.selector);
         new CSModule({
             moduleType: "community-staking-module",
-            minSlashingPenaltyQuotient: 32,
             lidoLocator: address(locator),
             parametersRegistry: address(0)
         });
@@ -484,7 +479,6 @@ contract CsmInitialize is CSMCommon {
     function test_constructor_RevertWhen_InitOnImpl() public {
         CSModule csm = new CSModule({
             moduleType: "community-staking-module",
-            minSlashingPenaltyQuotient: 32,
             lidoLocator: address(locator),
             parametersRegistry: address(parametersRegistry)
         });
@@ -499,7 +493,6 @@ contract CsmInitialize is CSMCommon {
     function test_initialize() public {
         CSModule csm = new CSModule({
             moduleType: "community-staking-module",
-            minSlashingPenaltyQuotient: 32,
             lidoLocator: address(locator),
             parametersRegistry: address(parametersRegistry)
         });
@@ -518,7 +511,6 @@ contract CsmInitialize is CSMCommon {
     function test_initialize_RevertWhen_ZeroAccountingAddress() public {
         CSModule csm = new CSModule({
             moduleType: "community-staking-module",
-            minSlashingPenaltyQuotient: 32,
             lidoLocator: address(locator),
             parametersRegistry: address(parametersRegistry)
         });
@@ -531,7 +523,6 @@ contract CsmInitialize is CSMCommon {
     function test_initialize_RevertWhen_ZeroAdminAddress() public {
         CSModule csm = new CSModule({
             moduleType: "community-staking-module",
-            minSlashingPenaltyQuotient: 32,
             lidoLocator: address(locator),
             parametersRegistry: address(parametersRegistry)
         });
@@ -5539,70 +5530,6 @@ contract CsmSubmitWithdrawal is CSMCommon {
         csm.submitWithdrawal(noId, keyIndex, depositSize - 1 ether, false);
     }
 
-    function test_submitWithdrawal_slashedReported() public assertInvariants {
-        uint256 keyIndex = 0;
-        uint256 noId = createNodeOperator();
-        csm.obtainDepositData(1, "");
-
-        // Pretend someone called csm.submitInitialSlashing(noId, 0) before, so we have
-        // _isValidatorSlashed[...] == true in the module.
-        stdstore
-            .target(address(csm))
-            .sig(csm.isValidatorSlashed.selector)
-            .with_key(noId)
-            .with_key(keyIndex)
-            .checked_write(true);
-
-        assertTrue(csm.isValidatorSlashed(noId, keyIndex));
-
-        uint256 diffAfterInitialPenalty = 0.75432 ether;
-        uint256 exitBalance = DEPOSIT_SIZE -
-            csm.INITIAL_SLASHING_PENALTY() -
-            diffAfterInitialPenalty;
-
-        vm.expectCall(
-            address(accounting),
-            abi.encodeWithSelector(
-                accounting.penalize.selector,
-                noId,
-                diffAfterInitialPenalty
-            )
-        );
-        vm.expectCall(
-            address(accounting),
-            abi.encodeWithSelector(accounting.resetBondCurve.selector, noId)
-        );
-        csm.submitWithdrawal(noId, keyIndex, exitBalance, true);
-    }
-
-    function test_submitWithdrawal_slashedIsNotReported()
-        public
-        assertInvariants
-    {
-        uint256 keyIndex = 0;
-        uint256 noId = createNodeOperator();
-        csm.obtainDepositData(1, "");
-
-        assertFalse(csm.isValidatorSlashed(noId, keyIndex));
-
-        uint256 exitBalance = DEPOSIT_SIZE - csm.INITIAL_SLASHING_PENALTY();
-
-        vm.expectCall(
-            address(accounting),
-            abi.encodeWithSelector(
-                accounting.penalize.selector,
-                noId,
-                csm.INITIAL_SLASHING_PENALTY() + 0.05 ether
-            )
-        );
-        vm.expectCall(
-            address(accounting),
-            abi.encodeWithSelector(accounting.resetBondCurve.selector, noId)
-        );
-        csm.submitWithdrawal(noId, keyIndex, exitBalance - 0.05 ether, true);
-        assertFalse(csm.isValidatorSlashed(noId, keyIndex)); // We do not track it anymore.
-    }
-
     function test_submitWithdrawal_unbondedKeys() public assertInvariants {
         uint256 keyIndex = 0;
         uint256 noId = createNodeOperator(2);
@@ -5813,7 +5740,6 @@ contract CSMAccessControl is CSMCommonNoRoles {
     function test_adminRole() public {
         CSModule csm = new CSModule({
             moduleType: "community-staking-module",
-            minSlashingPenaltyQuotient: 32,
             lidoLocator: address(locator),
             parametersRegistry: address(parametersRegistry)
         });
@@ -5833,7 +5759,6 @@ contract CSMAccessControl is CSMCommonNoRoles {
     function test_adminRole_revert() public {
         CSModule csm = new CSModule({
             moduleType: "community-staking-module",
-            minSlashingPenaltyQuotient: 32,
             lidoLocator: address(locator),
             parametersRegistry: address(parametersRegistry)
         });

--- a/test/fork/deployment/InitialState.t.sol
+++ b/test/fork/deployment/InitialState.t.sol
@@ -24,7 +24,6 @@ contract ContractsInitialStateTest is Test, Utilities, DeploymentFixtures {
 
     function test_module_initialState() public view {
         assertTrue(csm.isPaused());
-        assertFalse(csm.publicRelease());
         assertEq(csm.getNodeOperatorsCount(), 0);
     }
 

--- a/test/fork/deployment/PostDeployment.t.sol
+++ b/test/fork/deployment/PostDeployment.t.sol
@@ -42,10 +42,6 @@ contract CSModuleDeploymentTest is Test, Utilities, DeploymentFixtures {
             csm.INITIAL_SLASHING_PENALTY(),
             32 ether / deployParams.minSlashingPenaltyQuotient
         );
-        assertEq(
-            csm.MAX_SIGNING_KEYS_PER_OPERATOR_BEFORE_PUBLIC_RELEASE(),
-            deployParams.maxKeysPerOperatorEA
-        );
         assertEq(address(csm.LIDO_LOCATOR()), deployParams.lidoLocatorAddress);
     }
 

--- a/test/fork/deployment/PostDeployment.t.sol
+++ b/test/fork/deployment/PostDeployment.t.sol
@@ -38,10 +38,6 @@ contract CSModuleDeploymentTest is Test, Utilities, DeploymentFixtures {
 
     function test_constructor() public view {
         assertEq(csm.getType(), deployParams.moduleType);
-        assertEq(
-            csm.INITIAL_SLASHING_PENALTY(),
-            32 ether / deployParams.minSlashingPenaltyQuotient
-        );
         assertEq(address(csm.LIDO_LOCATOR()), deployParams.lidoLocatorAddress);
     }
 

--- a/test/fork/deployment/Upgradability.sol
+++ b/test/fork/deployment/Upgradability.sol
@@ -25,8 +25,6 @@ contract UpgradabilityTest is Test, Utilities, DeploymentFixtures {
         CSModule newModule = new CSModule({
             moduleType: "CSMv2",
             minSlashingPenaltyQuotient: 32,
-            maxKeysPerOperatorEA: csm
-                .MAX_SIGNING_KEYS_PER_OPERATOR_BEFORE_PUBLIC_RELEASE(),
             lidoLocator: address(csm.LIDO_LOCATOR()),
             parametersRegistry: address(csm.PARAMETERS_REGISTRY())
         });
@@ -40,8 +38,6 @@ contract UpgradabilityTest is Test, Utilities, DeploymentFixtures {
         CSModule newModule = new CSModule({
             moduleType: "CSMv2",
             minSlashingPenaltyQuotient: 32,
-            maxKeysPerOperatorEA: csm
-                .MAX_SIGNING_KEYS_PER_OPERATOR_BEFORE_PUBLIC_RELEASE(),
             lidoLocator: address(csm.LIDO_LOCATOR()),
             parametersRegistry: address(csm.PARAMETERS_REGISTRY())
         });

--- a/test/fork/deployment/Upgradability.sol
+++ b/test/fork/deployment/Upgradability.sol
@@ -24,7 +24,6 @@ contract UpgradabilityTest is Test, Utilities, DeploymentFixtures {
         OssifiableProxy proxy = OssifiableProxy(payable(address(csm)));
         CSModule newModule = new CSModule({
             moduleType: "CSMv2",
-            minSlashingPenaltyQuotient: 32,
             lidoLocator: address(csm.LIDO_LOCATOR()),
             parametersRegistry: address(csm.PARAMETERS_REGISTRY())
         });
@@ -37,7 +36,6 @@ contract UpgradabilityTest is Test, Utilities, DeploymentFixtures {
         OssifiableProxy proxy = OssifiableProxy(payable(address(csm)));
         CSModule newModule = new CSModule({
             moduleType: "CSMv2",
-            minSlashingPenaltyQuotient: 32,
             lidoLocator: address(csm.LIDO_LOCATOR()),
             parametersRegistry: address(csm.PARAMETERS_REGISTRY())
         });

--- a/test/fork/integration/ClaimInTokens.t.sol
+++ b/test/fork/integration/ClaimInTokens.t.sol
@@ -37,7 +37,6 @@ contract ClaimIntegrationTest is
         uint256 noCount = csm.getNodeOperatorsCount();
         assertCSMKeys(csm);
         assertCSMEnqueuedCount(csm);
-        assertCSMMaxKeys(csm);
         assertAccountingTotalBondShares(noCount, lido, accounting);
         assertAccountingBurnerApproval(
             lido,
@@ -60,7 +59,6 @@ contract ClaimIntegrationTest is
         csm.grantRole(csm.STAKING_ROUTER_ROLE(), address(stakingRouter));
         vm.stopPrank();
         if (csm.isPaused()) csm.resume();
-        if (!csm.publicRelease()) csm.activatePublicRelease();
 
         handleStakingLimit();
         handleBunkerMode();

--- a/test/fork/integration/CreateAndDeposit.sol
+++ b/test/fork/integration/CreateAndDeposit.sol
@@ -38,7 +38,6 @@ contract IntegrationTestBase is
         uint256 noCount = csm.getNodeOperatorsCount();
         assertCSMKeys(csm);
         assertCSMEnqueuedCount(csm);
-        assertCSMMaxKeys(csm);
         assertAccountingTotalBondShares(noCount, lido, accounting);
         assertAccountingBurnerApproval(
             lido,
@@ -66,7 +65,6 @@ contract IntegrationTestBase is
         vm.stopPrank();
 
         if (csm.isPaused()) csm.resume();
-        if (!csm.publicRelease()) csm.activatePublicRelease();
 
         handleStakingLimit();
         handleBunkerMode();

--- a/test/fork/integration/GateSeal.t.sol
+++ b/test/fork/integration/GateSeal.t.sol
@@ -19,7 +19,6 @@ contract GateSealTest is Test, Utilities, DeploymentFixtures {
         csm.grantRole(csm.DEFAULT_ADMIN_ROLE(), address(this));
         vm.stopPrank();
         if (csm.isPaused()) csm.resume();
-        if (!csm.publicRelease()) csm.activatePublicRelease();
     }
 
     function test_sealAll() public {

--- a/test/fork/integration/Penalty.t.sol
+++ b/test/fork/integration/Penalty.t.sol
@@ -37,7 +37,6 @@ contract PenaltyIntegrationTest is
         uint256 noCount = csm.getNodeOperatorsCount();
         assertCSMKeys(csm);
         assertCSMEnqueuedCount(csm);
-        assertCSMMaxKeys(csm);
         assertAccountingTotalBondShares(noCount, lido, accounting);
         assertAccountingBurnerApproval(
             lido,
@@ -68,7 +67,6 @@ contract PenaltyIntegrationTest is
         );
         vm.stopPrank();
         if (csm.isPaused()) csm.resume();
-        if (!csm.publicRelease()) csm.activatePublicRelease();
 
         handleStakingLimit();
         handleBunkerMode();

--- a/test/fork/integration/RecoverTokens.t.sol
+++ b/test/fork/integration/RecoverTokens.t.sol
@@ -34,7 +34,6 @@ contract RecoverIntegrationTest is
         uint256 noCount = csm.getNodeOperatorsCount();
         assertCSMKeys(csm);
         assertCSMEnqueuedCount(csm);
-        assertCSMMaxKeys(csm);
         assertAccountingTotalBondShares(noCount, lido, accounting);
         assertAccountingBurnerApproval(
             lido,

--- a/test/fork/invariant/Invariants.t.sol
+++ b/test/fork/invariant/Invariants.t.sol
@@ -38,12 +38,6 @@ contract CSModuleInvariants is InvariantsBase {
         assertCSMEnqueuedCount(csm);
     }
 
-    function test_csmMaxKeys() public noGasMetering {
-        vm.skip(csm.publicRelease());
-
-        assertCSMMaxKeys(csm);
-    }
-
     function test_roles() public view {
         assertEq(
             csm.getRoleMemberCount(csm.DEFAULT_ADMIN_ROLE()),

--- a/test/fork/voting/StakingRouter.t.sol
+++ b/test/fork/voting/StakingRouter.t.sol
@@ -34,7 +34,6 @@ contract StakingRouterIntegrationTest is
         uint256 noCount = csm.getNodeOperatorsCount();
         assertCSMKeys(csm);
         assertCSMEnqueuedCount(csm);
-        assertCSMMaxKeys(csm);
         assertAccountingTotalBondShares(noCount, lido, accounting);
         assertAccountingBurnerApproval(
             lido,
@@ -57,7 +56,6 @@ contract StakingRouterIntegrationTest is
         csm.grantRole(csm.STAKING_ROUTER_ROLE(), address(stakingRouter));
         vm.stopPrank();
         if (csm.isPaused()) csm.resume();
-        if (!csm.publicRelease()) csm.activatePublicRelease();
 
         agent = stakingRouter.getRoleMember(
             stakingRouter.DEFAULT_ADMIN_ROLE(),

--- a/test/fork/voting/StatePostVote.t.sol
+++ b/test/fork/voting/StatePostVote.t.sol
@@ -33,7 +33,6 @@ contract ContractsStateTest is Test, Utilities, DeploymentFixtures {
 
     function test_moduleState() public view {
         assertFalse(csm.isPaused());
-        assertTrue(csm.publicRelease());
     }
 
     function test_moduleRoles() public view {

--- a/test/helpers/InvariantAsserts.sol
+++ b/test/helpers/InvariantAsserts.sol
@@ -125,21 +125,6 @@ contract InvariantAsserts is Test {
         }
     }
 
-    function assertCSMMaxKeys(CSModule csm) public view {
-        if (csm.publicRelease()) return;
-
-        uint256 noCount = csm.getNodeOperatorsCount();
-        NodeOperator memory no;
-        for (uint256 noId = 0; noId < noCount; noId++) {
-            no = csm.getNodeOperator(noId);
-
-            assertGe(
-                csm.MAX_SIGNING_KEYS_PER_OPERATOR_BEFORE_PUBLIC_RELEASE(),
-                no.totalAddedKeys
-            );
-        }
-    }
-
     function assertAccountingTotalBondShares(
         uint256 nodeOperatorsCount,
         IStETH steth,


### PR DESCRIPTION
- We are not expecting the necessity for the public release anymore. For the new deployments of CSM, if any, this mechanic might be returned. But so far, there are no planned releases of the CSM copies.
- CSM v2 will be deployed way after Pectra, and there will be no pending reported slashings by the time of the release