### PR TITLE
chore: add return values for claim* methods

### DIFF
--- a/src/CSAccounting.sol
+++ b/src/CSAccounting.sol
@@ -233,11 +233,12 @@ contract CSAccounting is
         address rewardAddress,
         uint256 cumulativeFeeShares,
         bytes32[] calldata rewardsProof
-    ) external whenResumed onlyCSM {
+    ) external whenResumed onlyCSM returns (uint256) {
         if (rewardsProof.length != 0) {
             _pullFeeRewards(nodeOperatorId, cumulativeFeeShares, rewardsProof);
         }
-        CSBondCore._claimStETH(nodeOperatorId, stETHAmount, rewardAddress);
+        return
+            CSBondCore._claimStETH(nodeOperatorId, stETHAmount, rewardAddress);
     }
 
     /// @inheritdoc ICSAccounting
@@ -247,11 +248,16 @@ contract CSAccounting is
         address rewardAddress,
         uint256 cumulativeFeeShares,
         bytes32[] calldata rewardsProof
-    ) external whenResumed onlyCSM {
+    ) external whenResumed onlyCSM returns (uint256) {
         if (rewardsProof.length != 0) {
             _pullFeeRewards(nodeOperatorId, cumulativeFeeShares, rewardsProof);
         }
-        CSBondCore._claimWstETH(nodeOperatorId, wstETHAmount, rewardAddress);
+        return
+            CSBondCore._claimWstETH(
+                nodeOperatorId,
+                wstETHAmount,
+                rewardAddress
+            );
     }
 
     /// @inheritdoc ICSAccounting
@@ -261,11 +267,16 @@ contract CSAccounting is
         address rewardAddress,
         uint256 cumulativeFeeShares,
         bytes32[] calldata rewardsProof
-    ) external whenResumed onlyCSM {
+    ) external whenResumed onlyCSM returns (uint256) {
         if (rewardsProof.length != 0) {
             _pullFeeRewards(nodeOperatorId, cumulativeFeeShares, rewardsProof);
         }
-        CSBondCore._claimUnstETH(nodeOperatorId, stEthAmount, rewardAddress);
+        return
+            CSBondCore._claimUnstETH(
+                nodeOperatorId,
+                stEthAmount,
+                rewardAddress
+            );
     }
 
     /// @inheritdoc ICSAccounting

--- a/src/CSModule.sol
+++ b/src/CSModule.sol
@@ -327,10 +327,10 @@ contract CSModule is
         uint256 stETHAmount,
         uint256 cumulativeFeeShares,
         bytes32[] calldata rewardsProof
-    ) external {
+    ) external returns (uint256 claimedShares) {
         _onlyNodeOperatorManagerOrRewardAddresses(nodeOperatorId);
 
-        accounting.claimRewardsStETH({
+        claimedShares = accounting.claimRewardsStETH({
             nodeOperatorId: nodeOperatorId,
             stETHAmount: stETHAmount,
             rewardAddress: _nodeOperators[nodeOperatorId].rewardAddress,
@@ -351,10 +351,10 @@ contract CSModule is
         uint256 wstETHAmount,
         uint256 cumulativeFeeShares,
         bytes32[] calldata rewardsProof
-    ) external {
+    ) external returns (uint256 claimedWstETHAmount) {
         _onlyNodeOperatorManagerOrRewardAddresses(nodeOperatorId);
 
-        accounting.claimRewardsWstETH({
+        claimedWstETHAmount = accounting.claimRewardsWstETH({
             nodeOperatorId: nodeOperatorId,
             wstETHAmount: wstETHAmount,
             rewardAddress: _nodeOperators[nodeOperatorId].rewardAddress,
@@ -375,10 +375,10 @@ contract CSModule is
         uint256 stEthAmount,
         uint256 cumulativeFeeShares,
         bytes32[] calldata rewardsProof
-    ) external {
+    ) external returns (uint256 requestId) {
         _onlyNodeOperatorManagerOrRewardAddresses(nodeOperatorId);
 
-        accounting.claimRewardsUnstETH({
+        requestId = accounting.claimRewardsUnstETH({
             nodeOperatorId: nodeOperatorId,
             stEthAmount: stEthAmount,
             rewardAddress: _nodeOperators[nodeOperatorId].rewardAddress,

--- a/src/interfaces/ICSAccounting.sol
+++ b/src/interfaces/ICSAccounting.sol
@@ -205,6 +205,7 @@ interface ICSAccounting is
     /// @param rewardAddress Reward address of the node operator
     /// @param cumulativeFeeShares Cumulative fee stETH shares for the Node Operator
     /// @param rewardsProof Merkle proof of the rewards
+    /// @return shares Amount of stETH shares claimed
     /// @dev It's impossible to use single-leaf proof via this method, so this case should be treated carefully by
     /// off-chain tooling, e.g. to make sure a tree has at least 2 leafs.
     function claimRewardsStETH(
@@ -213,7 +214,7 @@ interface ICSAccounting is
         address rewardAddress,
         uint256 cumulativeFeeShares,
         bytes32[] calldata rewardsProof
-    ) external;
+    ) external returns (uint256 shares);
 
     /// @notice Claim full reward (fee + bond) in wstETH for the given Node Operator available for this moment.
     ///         `rewardsProof` and `cumulativeFeeShares` might be empty in order to claim only excess bond
@@ -223,6 +224,7 @@ interface ICSAccounting is
     /// @param rewardAddress Reward address of the node operator
     /// @param cumulativeFeeShares Cumulative fee stETH shares for the Node Operator
     /// @param rewardsProof Merkle proof of the rewards
+    /// @return claimedWstETHAmount Amount of wstETH claimed
     /// @dev It's impossible to use single-leaf proof via this method, so this case should be treated carefully by
     /// off-chain tooling, e.g. to make sure a tree has at least 2 leafs.
     function claimRewardsWstETH(
@@ -231,7 +233,7 @@ interface ICSAccounting is
         address rewardAddress,
         uint256 cumulativeFeeShares,
         bytes32[] calldata rewardsProof
-    ) external;
+    ) external returns (uint256 claimedWstETHAmount);
 
     /// @notice Request full reward (fee + bond) in Withdrawal NFT (unstETH) for the given Node Operator available for this moment.
     ///         `rewardsProof` and `cumulativeFeeShares` might be empty in order to claim only excess bond
@@ -242,6 +244,7 @@ interface ICSAccounting is
     /// @param rewardAddress Reward address of the node operator
     /// @param cumulativeFeeShares Cumulative fee stETH shares for the Node Operator
     /// @param rewardsProof Merkle proof of the rewards
+    /// @return requestId Withdrawal NFT ID
     /// @dev It's impossible to use single-leaf proof via this method, so this case should be treated carefully by
     /// off-chain tooling, e.g. to make sure a tree has at least 2 leafs.
     function claimRewardsUnstETH(
@@ -250,7 +253,7 @@ interface ICSAccounting is
         address rewardAddress,
         uint256 cumulativeFeeShares,
         bytes32[] calldata rewardsProof
-    ) external;
+    ) external returns (uint256 requestId);
 
     /// @notice Lock bond in ETH for the given Node Operator
     /// @dev Called by CSM exclusively

--- a/src/interfaces/ICSModule.sol
+++ b/src/interfaces/ICSModule.sol
@@ -294,12 +294,13 @@ interface ICSModule is IQueueLib, INOAddresses, IAssetRecovererLib {
     /// @param stETHAmount Amount of stETH to claim
     /// @param cumulativeFeeShares Optional. Cumulative fee stETH shares for the Node Operator
     /// @param rewardsProof Optional. Merkle proof of the rewards
+    /// @return claimedShares Amount of claimed stETH shares
     function claimRewardsStETH(
         uint256 nodeOperatorId,
         uint256 stETHAmount,
         uint256 cumulativeFeeShares,
         bytes32[] memory rewardsProof
-    ) external;
+    ) external returns (uint256 claimedShares);
 
     /// @notice Request full reward (fees + bond rewards) in Withdrawal NFT (unstETH) for the given Node Operator
     /// @notice Amounts less than `MIN_STETH_WITHDRAWAL_AMOUNT` (see LidoWithdrawalQueue contract) are not allowed
@@ -311,12 +312,13 @@ interface ICSModule is IQueueLib, INOAddresses, IAssetRecovererLib {
     /// @param stEthAmount Amount of ETH to request
     /// @param cumulativeFeeShares Optional. Cumulative fee stETH shares for the Node Operator
     /// @param rewardsProof Optional. Merkle proof of the rewards
+    /// @return requestId Withdrawal NFT ID
     function claimRewardsUnstETH(
         uint256 nodeOperatorId,
         uint256 stEthAmount,
         uint256 cumulativeFeeShares,
         bytes32[] memory rewardsProof
-    ) external;
+    ) external returns (uint256 requestId);
 
     /// @notice Claim full reward (fees + bond rewards) in wstETH for the given Node Operator
     /// @notice If `wstETHAmount` exceeds the current claimable amount, the claimable amount will be used instead
@@ -325,12 +327,13 @@ interface ICSModule is IQueueLib, INOAddresses, IAssetRecovererLib {
     /// @param wstETHAmount Amount of wstETH to claim
     /// @param cumulativeFeeShares Optional. Cumulative fee stETH shares for the Node Operator
     /// @param rewardsProof Optional. Merkle proof of the rewards
+    /// @return claimedWstETHAmount Amount of claimed wstETH
     function claimRewardsWstETH(
         uint256 nodeOperatorId,
         uint256 wstETHAmount,
         uint256 cumulativeFeeShares,
         bytes32[] memory rewardsProof
-    ) external;
+    ) external returns (uint256 claimedWstETHAmount);
 
     /// @notice Set bond curve for the node operator
     ///         Permissioned


### PR DESCRIPTION
it helps to simplify accounting for extensions that want to redeclare claim methods