### PR TITLE
chore: move deposit* methods to accounting

### DIFF
--- a/src/CSModule.sol
+++ b/src/CSModule.sol
@@ -255,60 +255,6 @@ contract CSModule is
     }
 
     /// @inheritdoc ICSModule
-    function depositETH(uint256 nodeOperatorId) external payable {
-        _onlyExistingNodeOperator(nodeOperatorId);
-        accounting.depositETH{ value: msg.value }(msg.sender, nodeOperatorId);
-
-        // Due to new bond nonce update might be required
-        _updateDepositableValidatorsCount({
-            nodeOperatorId: nodeOperatorId,
-            incrementNonceIfUpdated: true
-        });
-    }
-
-    /// @inheritdoc ICSModule
-    function depositStETH(
-        uint256 nodeOperatorId,
-        uint256 stETHAmount,
-        ICSAccounting.PermitInput calldata permit
-    ) external {
-        _onlyExistingNodeOperator(nodeOperatorId);
-        accounting.depositStETH(
-            msg.sender,
-            nodeOperatorId,
-            stETHAmount,
-            permit
-        );
-
-        // Due to new bond nonce update might be required
-        _updateDepositableValidatorsCount({
-            nodeOperatorId: nodeOperatorId,
-            incrementNonceIfUpdated: true
-        });
-    }
-
-    /// @inheritdoc ICSModule
-    function depositWstETH(
-        uint256 nodeOperatorId,
-        uint256 wstETHAmount,
-        ICSAccounting.PermitInput calldata permit
-    ) external {
-        _onlyExistingNodeOperator(nodeOperatorId);
-        accounting.depositWstETH(
-            msg.sender,
-            nodeOperatorId,
-            wstETHAmount,
-            permit
-        );
-
-        // Due to new bond nonce update might be required
-        _updateDepositableValidatorsCount({
-            nodeOperatorId: nodeOperatorId,
-            incrementNonceIfUpdated: true
-        });
-    }
-
-    /// @inheritdoc ICSModule
     function claimRewardsStETH(
         uint256 nodeOperatorId,
         uint256 stETHAmount,

--- a/src/interfaces/ICSAccounting.sol
+++ b/src/interfaces/ICSAccounting.sol
@@ -178,6 +178,17 @@ interface ICSAccounting is
         PermitInput calldata permit
     ) external;
 
+    /// @notice Unwrap the user's wstETH and deposit stETH to the bond for the given Node Operator
+    /// @dev Permissionless. Enqueues Node Operator's keys if needed
+    /// @param nodeOperatorId ID of the Node Operator
+    /// @param wstETHAmount Amount of wstETH to deposit
+    /// @param permit wstETH permit for the contract
+    function depositWstETH(
+        uint256 nodeOperatorId,
+        uint256 wstETHAmount,
+        PermitInput calldata permit
+    ) external;
+
     /// @notice Deposit user's stETH to the bond for the given Node Operator
     /// @dev Called by CSM exclusively
     /// @param from Address to deposit stETH from
@@ -191,11 +202,27 @@ interface ICSAccounting is
         PermitInput calldata permit
     ) external;
 
+    /// @notice Deposit user's stETH to the bond for the given Node Operator
+    /// @dev Permissionless. Enqueues Node Operator's keys if needed
+    /// @param nodeOperatorId ID of the Node Operator
+    /// @param stETHAmount Amount of stETH to deposit
+    /// @param permit stETH permit for the contract
+    function depositStETH(
+        uint256 nodeOperatorId,
+        uint256 stETHAmount,
+        PermitInput calldata permit
+    ) external;
+
     /// @notice Stake user's ETH with Lido and deposit stETH to the bond
     /// @dev Called by CSM exclusively
     /// @param from Address to stake ETH and deposit stETH from
     /// @param nodeOperatorId ID of the Node Operator
     function depositETH(address from, uint256 nodeOperatorId) external payable;
+
+    /// @notice Stake user's ETH with Lido and deposit stETH to the bond
+    /// @dev Permissionless. Enqueues Node Operator's keys if needed
+    /// @param nodeOperatorId ID of the Node Operator
+    function depositETH(uint256 nodeOperatorId) external payable;
 
     /// @notice Claim full reward (fee + bond) in stETH for the given Node Operator with desirable value.
     ///         `rewardsProof` and `cumulativeFeeShares` might be empty in order to claim only excess bond

--- a/src/interfaces/ICSModule.sol
+++ b/src/interfaces/ICSModule.sol
@@ -248,30 +248,6 @@ interface ICSModule is IQueueLib, INOAddresses, IAssetRecovererLib {
         ICSAccounting.PermitInput memory permit
     ) external;
 
-    /// @notice Stake user's ETH with Lido and make a deposit in stETH to the bond of the existing Node Operator
-    /// @param nodeOperatorId ID of the Node Operator
-    function depositETH(uint256 nodeOperatorId) external payable;
-
-    /// @notice Deposit user's stETH to the bond of the existing Node Operator
-    /// @param nodeOperatorId ID of the Node Operator
-    /// @param stETHAmount Amount of stETH to deposit
-    /// @param permit Optional. Permit to use stETH as bond
-    function depositStETH(
-        uint256 nodeOperatorId,
-        uint256 stETHAmount,
-        ICSAccounting.PermitInput memory permit
-    ) external;
-
-    /// @notice Unwrap the user's wstETH and make a deposit in stETH to the bond of the existing Node Operator
-    /// @param nodeOperatorId ID of the Node Operator
-    /// @param wstETHAmount Amount of wstETH to deposit
-    /// @param permit Optional. Permit to use wstETH as bond
-    function depositWstETH(
-        uint256 nodeOperatorId,
-        uint256 wstETHAmount,
-        ICSAccounting.PermitInput memory permit
-    ) external;
-
     /// @notice Claim full reward (fees + bond rewards) in stETH for the given Node Operator
     /// @notice If `stETHAmount` exceeds the current claimable amount, the claimable amount will be used instead
     /// @notice If `rewardsProof` is not provided, only excess bond (bond rewards) will be available for claim

--- a/test/fork/integration/ClaimInTokens.t.sol
+++ b/test/fork/integration/ClaimInTokens.t.sol
@@ -93,7 +93,7 @@ contract ClaimIntegrationTest is
         vm.startPrank(user);
         vm.deal(user, amount);
 
-        csm.depositETH{ value: amount }(defaultNoId);
+        accounting.depositETH{ value: amount }(defaultNoId);
         vm.stopPrank();
 
         uint256 noSharesBefore = lido.sharesOf(nodeOperator);
@@ -152,7 +152,7 @@ contract ClaimIntegrationTest is
         vm.startPrank(user);
         vm.deal(user, amount);
 
-        csm.depositETH{ value: amount }(defaultNoId);
+        accounting.depositETH{ value: amount }(defaultNoId);
         vm.stopPrank();
 
         uint256 balanceBefore = wstETH.balanceOf(nodeOperator);
@@ -225,7 +225,7 @@ contract ClaimIntegrationTest is
         vm.startPrank(user);
         vm.deal(user, amount);
 
-        csm.depositETH{ value: amount }(defaultNoId);
+        accounting.depositETH{ value: amount }(defaultNoId);
         vm.stopPrank();
 
         uint256 accountingSharesBefore = lido.sharesOf(address(accounting));

--- a/test/fork/integration/CreateAndDeposit.sol
+++ b/test/fork/integration/CreateAndDeposit.sol
@@ -427,7 +427,7 @@ contract DepositIntegrationTest is IntegrationTestBase {
         uint256 preTotalShares = accounting.totalBondShares();
 
         lido.approve(address(accounting), type(uint256).max);
-        csm.depositStETH(
+        accounting.depositStETH(
             defaultNoId,
             32 ether,
             ICSAccounting.PermitInput({
@@ -452,7 +452,7 @@ contract DepositIntegrationTest is IntegrationTestBase {
         uint256 preTotalShares = accounting.totalBondShares();
 
         uint256 shares = lido.getSharesByPooledEth(32 ether);
-        csm.depositETH{ value: 32 ether }(defaultNoId);
+        accounting.depositETH{ value: 32 ether }(defaultNoId);
 
         assertEq(user.balance, 0);
         assertEq(accounting.getBondShares(defaultNoId), shares + preShares);
@@ -474,7 +474,7 @@ contract DepositIntegrationTest is IntegrationTestBase {
         uint256 preTotalShares = accounting.totalBondShares();
 
         wstETH.approve(address(accounting), type(uint256).max);
-        csm.depositWstETH(
+        accounting.depositWstETH(
             defaultNoId,
             wstETHAmount,
             ICSAccounting.PermitInput({
@@ -509,7 +509,7 @@ contract DepositIntegrationTest is IntegrationTestBase {
         uint256 preShares = accounting.getBondShares(defaultNoId);
         uint256 preTotalShares = accounting.totalBondShares();
 
-        csm.depositStETH(
+        accounting.depositStETH(
             defaultNoId,
             32 ether,
             ICSAccounting.PermitInput({
@@ -550,7 +550,7 @@ contract DepositIntegrationTest is IntegrationTestBase {
         uint256 preShares = accounting.getBondShares(defaultNoId);
         uint256 preTotalShares = accounting.totalBondShares();
 
-        csm.depositWstETH(
+        accounting.depositWstETH(
             defaultNoId,
             wstETHAmount,
             ICSAccounting.PermitInput({


### PR DESCRIPTION
make an alternative permissionless implementation for them