### PR TITLE
feat: change node operator addresses in CM

### DIFF
--- a/src/CSModule.sol
+++ b/src/CSModule.sol
@@ -92,7 +92,7 @@ contract CSModule is
     bool internal _publicRelease;
 
     uint256 private _nonce;
-    mapping(uint256 => NodeOperator) private _nodeOperators;
+    mapping(uint256 => NodeOperator) internal _nodeOperators;
     /// @dev see _keyPointer function for details of noKeyIndexPacked structure
     mapping(uint256 noKeyIndexPacked => bool) private _isValidatorWithdrawn;
     /// @dev DEPRECATED! No writes expected after CSM v2

--- a/src/CuratedModule.sol
+++ b/src/CuratedModule.sol
@@ -3,10 +3,16 @@
 
 pragma solidity 0.8.24;
 
+import { ICuratedModule } from "./interfaces/ICuratedModule.sol";
+import { IStakingModule } from "./interfaces/IStakingModule.sol";
+
 import { CSModule } from "./CSModule.sol";
 
-contract CuratedModule is CSModule {
-    error NotImplemented();
+import { NOAddresses } from "./lib/NOAddresses.sol";
+
+contract CuratedModule is ICuratedModule, CSModule {
+    bytes32 public constant NODE_OWNER_ADMIN_ROLE =
+        keccak256("NODE_OWNER_ADMIN_ROLE");
 
     constructor(
         bytes32 moduleType,
@@ -25,14 +31,29 @@ contract CuratedModule is CSModule {
     {}
 
     function obtainDepositData(
-        uint256 /* depositsCount */,
+        uint256,
+        /* depositsCount */
         bytes calldata /* depositCalldata */
     )
         external
-        override
+        override(CSModule, IStakingModule)
         onlyRole(STAKING_ROUTER_ROLE)
         returns (bytes memory publicKeys, bytes memory signatures)
     {
-        revert NotImplemented();
+        revert ICuratedModule.NotImplemented();
+    }
+
+    /// @inheritdoc ICuratedModule
+    function changeNodeOperatorAddresses(
+        uint256 nodeOperatorId,
+        address managerAddress,
+        address rewardAddress
+    ) external onlyRole(NODE_OWNER_ADMIN_ROLE) {
+        NOAddresses.changeNodeOperatorAddresses(
+            _nodeOperators,
+            nodeOperatorId,
+            managerAddress,
+            rewardAddress
+        );
     }
 }

--- a/src/interfaces/ICuratedModule.sol
+++ b/src/interfaces/ICuratedModule.sol
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: 2025 Lido <info@lido.fi>
+// SPDX-License-Identifier: GPL-3.0
+
+pragma solidity 0.8.24;
+
+import { ICSModule } from "./ICSModule.sol";
+
+interface ICuratedModule is ICSModule {
+    error NotImplemented();
+
+    function NODE_OWNER_ADMIN_ROLE() external view returns (bytes32);
+
+    /// @notice Change both reward and manager addresses of a node operator.
+    /// @param nodeOperatorId ID of the Node Operator
+    /// @param newRewardAddress New reward address
+    /// @param newManagerAddress New manager address
+    function changeNodeOperatorAddresses(
+        uint256 nodeOperatorId,
+        address newManagerAddress,
+        address newRewardAddress
+    ) external;
+}

--- a/src/lib/NOAddresses.sol
+++ b/src/lib/NOAddresses.sol
@@ -36,6 +36,7 @@ interface INOAddresses {
     error SenderIsNotRewardAddress();
     error SenderIsNotProposedAddress();
     error MethodCallIsNotAllowed();
+    error ZeroManagerAddress();
     error ZeroRewardAddress();
 }
 
@@ -239,6 +240,53 @@ library NOAddresses {
             nodeOperatorId,
             oldAddress,
             newAddress
+        );
+    }
+
+    /// @notice Change both reward and manager addresses of a node operator.
+    /// @dev XXX: Use with caution! No check of the caller.
+    /// @param nodeOperatorId ID of the Node Operator
+    /// @param newManagerAddress New manager address
+    /// @param newRewardAddress New reward address
+    function changeNodeOperatorAddresses(
+        mapping(uint256 => NodeOperator) storage nodeOperators,
+        uint256 nodeOperatorId,
+        address newManagerAddress,
+        address newRewardAddress
+    ) external {
+        NodeOperator storage no = nodeOperators[nodeOperatorId];
+        if (no.managerAddress == address(0)) {
+            revert ICSModule.NodeOperatorDoesNotExist();
+        }
+
+        if (
+            newManagerAddress == no.managerAddress &&
+            newRewardAddress == no.rewardAddress
+        ) {
+            revert INOAddresses.SameAddress();
+        }
+
+        if (newManagerAddress == address(0)) {
+            revert INOAddresses.ZeroManagerAddress();
+        }
+        if (newRewardAddress == address(0)) {
+            revert INOAddresses.ZeroRewardAddress();
+        }
+
+        address oldManagerAddress = no.managerAddress;
+        address oldRewardAddress = no.rewardAddress;
+        no.managerAddress = newManagerAddress;
+        no.rewardAddress = newRewardAddress;
+
+        emit INOAddresses.NodeOperatorManagerAddressChanged(
+            nodeOperatorId,
+            oldManagerAddress,
+            newManagerAddress
+        );
+        emit INOAddresses.NodeOperatorRewardAddressChanged(
+            nodeOperatorId,
+            oldRewardAddress,
+            newRewardAddress
         );
     }
 }


### PR DESCRIPTION
## Description

Add a dedicated role that can change both manager and reward addresses.

## Checklist

- [x] Appropriate PR labels applied
- [ ] Test coverage maintained (`just coverage`)
  - [ ] No need to add/update tests
  - [ ] Tests are added/updated
- [x] Documentation maintained
  - [x] No need to update
  - [ ] Updated
