### PR TITLE
chore: Add missing checks for key counts in `CSEjector.sol` methods

### DIFF
--- a/src/CSEjector.sol
+++ b/src/CSEjector.sol
@@ -80,6 +80,10 @@ contract CSEjector is
     ) external payable whenResumed {
         _onlyNodeOperatorOwner(nodeOperatorId);
 
+        if (keysCount == 0) {
+            revert NothingToEject();
+        }
+
         {
             // A key must be deposited to prevent ejecting unvetted keys that can intersect with
             // other modules.
@@ -141,6 +145,10 @@ contract CSEjector is
         address refundRecipient
     ) external payable whenResumed {
         _onlyNodeOperatorOwner(nodeOperatorId);
+
+        if (keyIndices.length == 0) {
+            revert NothingToEject();
+        }
 
         uint256 totalDepositedKeys = MODULE.getNodeOperatorTotalDepositedKeys(
             nodeOperatorId

--- a/src/interfaces/ICSEjector.sol
+++ b/src/interfaces/ICSEjector.sol
@@ -18,6 +18,7 @@ interface ICSEjector is IExitTypes {
     error NodeOperatorDoesNotExist();
     error SenderIsNotEligible();
     error SenderIsNotStrikes();
+    error NothingToEject();
 
     function PAUSE_ROLE() external view returns (bytes32);
 

--- a/test/CSEjector.t.sol
+++ b/test/CSEjector.t.sol
@@ -251,6 +251,23 @@ contract CSEjectorTestVoluntaryEject is CSEjectorTestBase {
         ejector.voluntaryEject(noId, keyIndex, 1, address(0));
     }
 
+    function test_voluntaryEject_revertWhen_NothingToEject() public {
+        uint256 keyIndex = 0;
+
+        csm.mock_setNodeOperatorsCount(1);
+        csm.mock_setNodeOperatorTotalDepositedKeys(1);
+        csm.mock_setNodeOperatorManagementProperties(
+            NodeOperatorManagementProperties(
+                address(this),
+                address(this),
+                false
+            )
+        );
+
+        vm.expectRevert(ICSEjector.NothingToEject.selector);
+        ejector.voluntaryEject(noId, keyIndex, 0, refundRecipient);
+    }
+
     function test_voluntaryEject_revertWhen_senderIsNotEligible() public {
         uint256 keyIndex = 0;
 
@@ -491,6 +508,22 @@ contract CSEjectorTestVoluntaryEjectByArray is CSEjectorTestBase {
 
         vm.expectRevert(ICSEjector.SenderIsNotEligible.selector);
         ejector.voluntaryEjectByArray(noId, indices, address(0));
+    }
+
+    function test_voluntaryEjectByArray_revertWhen_NothingToEject() public {
+        csm.mock_setNodeOperatorsCount(1);
+        csm.mock_setNodeOperatorTotalDepositedKeys(1);
+        csm.mock_setNodeOperatorManagementProperties(
+            NodeOperatorManagementProperties(
+                address(this),
+                address(this),
+                false
+            )
+        );
+
+        uint256[] memory indices = new uint256[](0);
+        vm.expectRevert(ICSEjector.NothingToEject.selector);
+        ejector.voluntaryEjectByArray(noId, indices, refundRecipient);
     }
 
     function test_voluntaryEjectByArray_revertWhen_NodeOperatorDoesNotExist()


### PR DESCRIPTION
## Description

Add missing checks for key counts in `CSEjector.sol` methods

## Checklist

- [x] Appropriate PR labels applied
- [x] Test coverage maintained (`just coverage`)
  - [x] Tests are added/updated
- [x] Documentation maintained
  - [x] No need to update
