### PR TITLE
feat: Set `targetLimit` on uncompensated penalties

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -2,7 +2,7 @@
 solc = "0.8.24"
 evm_version = "cancun"
 optimizer = true
-optimizer_runs = 200
+optimizer_runs = 100 # REVISE IN THE FUTURE
 bytecode_hash = "none" # The metadata hash removed from the bytecode (not the metadata itself).
 # uncomment this to inspect storage layouts in build artifacts
 # extra_output = ["storageLayout"]

--- a/src/abstract/CSBondCore.sol
+++ b/src/abstract/CSBondCore.sol
@@ -199,12 +199,17 @@ abstract contract CSBondCore is ICSBondCore {
     /// @dev Burn Node Operator's bond shares (stETH). Shares will be burned on the next stETH rebase
     /// @dev The contract that uses this implementation should be granted `Burner.REQUEST_BURN_SHARES_ROLE` and have stETH allowance for `Burner`
     /// @param amount Bond amount to burn in ETH (stETH)
-    function _burn(uint256 nodeOperatorId, uint256 amount) internal {
+    function _burn(
+        uint256 nodeOperatorId,
+        uint256 amount
+    ) internal returns (bool fullyBurned) {
         uint256 sharesToBurn = _sharesByEth(amount);
         uint256 burnedShares = _reduceBond(nodeOperatorId, sharesToBurn);
+        fullyBurned = burnedShares == sharesToBurn; // fully burned if the amount to burn is equal to the amount reduced
+
         // If no bond already or the amount to burn is zero
         if (burnedShares == 0) {
-            return;
+            return fullyBurned;
         }
 
         // TODO: Replace with `requestBurnMyShares` (https://github.com/lidofinance/core/pull/1142) in the next major release
@@ -212,6 +217,7 @@ abstract contract CSBondCore is ICSBondCore {
             address(this),
             burnedShares
         );
+
         emit BondBurned(
             nodeOperatorId,
             _ethByShares(sharesToBurn),
@@ -226,12 +232,14 @@ abstract contract CSBondCore is ICSBondCore {
         uint256 nodeOperatorId,
         uint256 amount,
         address recipient
-    ) internal {
+    ) internal returns (bool fullyCharged) {
         uint256 toChargeShares = _sharesByEth(amount);
         uint256 chargedShares = _reduceBond(nodeOperatorId, toChargeShares);
+        fullyCharged = chargedShares == toChargeShares; // fully charged if the amount to charge is equal to the amount reduced
+
         // If no bond already or the amount to charge is zero
         if (chargedShares == 0) {
-            return;
+            return fullyCharged;
         }
 
         uint256 chargedEth = LIDO.transferShares(recipient, chargedShares);

--- a/src/interfaces/ICSModule.sol
+++ b/src/interfaces/ICSModule.sol
@@ -165,6 +165,8 @@ interface ICSModule is
 
     function DEPOSIT_SIZE() external view returns (uint256);
 
+    function FORCED_TARGET_LIMIT_MODE_ID() external view returns (uint8);
+
     function LIDO_LOCATOR() external view returns (ILidoLocator);
 
     function STETH() external view returns (IStETH);
@@ -293,7 +295,7 @@ interface ICSModule is
         uint256 amount
     ) external;
 
-    /// @notice Settle locked bond for the given Node Operators
+    /// @notice Settles locked bond and sets the target limit to 0 or the given Node Operators
     /// @dev SETTLE_EL_REWARDS_STEALING_PENALTY_ROLE role is expected to be assigned to Easy Track
     /// @param nodeOperatorIds IDs of the Node Operators
     /// @param maxAmounts Maximum amounts to settle for each Node Operator

--- a/src/interfaces/IStakingModule.sol
+++ b/src/interfaces/IStakingModule.sol
@@ -173,6 +173,7 @@ interface IStakingModule {
     ) external;
 
     /// @notice Updates the limit of the validators that can be used for deposit
+    /// @dev Can be called by StakingRouter or accounting contract
     /// @param nodeOperatorId ID of the Node Operator
     /// @param targetLimitMode Target limit mode for the Node Operator (see https://hackmd.io/@lido/BJXRTxMRp)
     ///                        0 - disabled


### PR DESCRIPTION
## Description

Set `targetLimit = 0` for uncompensated penalties (penalty > bond) and uncompensated EL Rewards Stealing Penalty.

## Checklist

- [x] Appropriate PR labels applied
- [x] Test coverage maintained (`just coverage`)
  - [x] Tests are added/updated
- [x] Documentation maintained
  - [x] Updated
