### PR TITLE
feat: Built-in reward splits

### DIFF
--- a/src/interfaces/ICSAccounting.sol
+++ b/src/interfaces/ICSAccounting.sol
@@ -26,6 +26,11 @@ interface ICSAccounting is
         bytes32 s;
     }
 
+    struct FeeSplit {
+        address recipient;
+        uint256 share; // in basis points
+    }
+
     event BondLockCompensated(uint256 indexed nodeOperatorId, uint256 amount);
     event ChargePenaltyRecipientSet(address chargePenaltyRecipient);
 
@@ -84,6 +89,15 @@ interface ICSAccounting is
     /// @notice Set min cooldown for additional bond reserve removal
     function setBondReserveMinPeriod(uint256 period) external;
 
+    /// @notice Set fee splits for the given Node Operator
+    /// @param nodeOperatorId ID of the Node Operator
+    /// @param feeSplits Array of FeeSplit structs defining recipients and their shares in basis points
+    ///                  Total shares must be <= 10_000 (100%). Remainder goes to the Node Operator's bond
+    function setFeeSplits(
+        uint256 nodeOperatorId,
+        FeeSplit[] calldata feeSplits
+    ) external;
+
     /// @notice Add a new bond curve
     /// @param bondCurve Bond curve definition to add
     /// @return id Id of the added curve
@@ -129,6 +143,13 @@ interface ICSAccounting is
         uint256 nodeOperatorId,
         uint256 additionalKeys
     ) external view returns (uint256);
+
+    /// @notice Set fee splits for the given Node Operator
+    /// @param nodeOperatorId ID of the Node Operator
+    /// @return Array of FeeSplit structs defining recipients and their shares in basis points
+    function getFeeSplits(
+        uint256 nodeOperatorId
+    ) external view returns (FeeSplit[] memory);
 
     /// @notice Get the number of the unbonded keys
     /// @param nodeOperatorId ID of the Node Operator

--- a/src/lib/FeeSplits.sol
+++ b/src/lib/FeeSplits.sol
@@ -1,0 +1,80 @@
+// SPDX-FileCopyrightText: 2025 Lido <info@lido.fi>
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity 0.8.24;
+
+import { ICSAccounting } from "../interfaces/ICSAccounting.sol";
+import { ILido } from "../interfaces/ILido.sol";
+
+/// Library for managing FeeSplits
+/// @dev the only use of this to be a library is to save CSAccounting contract size via delegatecalls
+interface IFeeSplits {
+    event FeeSplitsSet(
+        uint256 indexed nodeOperatorId,
+        ICSAccounting.FeeSplit[] feeSplits
+    );
+
+    error TooManySplits();
+    error TooManySplitShares();
+    error ZeroSplitRecipient();
+    error ZeroSplitShare();
+}
+
+library FeeSplits {
+    uint256 internal constant MAX_BP = 10_000;
+    uint256 public constant MAX_FEE_SPLITS = 5;
+
+    function setFeeSplits(
+        mapping(uint256 => ICSAccounting.FeeSplit[]) storage feeSplitsStorage,
+        uint256 nodeOperatorId,
+        ICSAccounting.FeeSplit[] calldata feeSplits
+    ) external {
+        if (feeSplits.length > MAX_FEE_SPLITS) {
+            revert IFeeSplits.TooManySplits();
+        }
+
+        uint256 totalShare = 0;
+        for (uint256 i = 0; i < feeSplits.length; i++) {
+            totalShare += feeSplits[i].share;
+        }
+        // totalShare might be lower than MAX_BP. The remainder goes to the Node Operator's bond
+        if (totalShare > MAX_BP) {
+            revert IFeeSplits.TooManySplitShares();
+        }
+
+        delete feeSplitsStorage[nodeOperatorId];
+        for (uint256 i = 0; i < feeSplits.length; i++) {
+            if (feeSplits[i].recipient == address(0)) {
+                revert IFeeSplits.ZeroSplitRecipient();
+            }
+            if (feeSplits[i].share == 0) {
+                revert IFeeSplits.ZeroSplitShare();
+            }
+
+            feeSplitsStorage[nodeOperatorId].push(feeSplits[i]);
+        }
+
+        emit IFeeSplits.FeeSplitsSet(nodeOperatorId, feeSplits);
+    }
+
+    function splitAndTransferFees(
+        mapping(uint256 => ICSAccounting.FeeSplit[]) storage feeSplitsStorage,
+        ILido lido,
+        uint256 nodeOperatorId,
+        uint256 amount
+    ) external returns (uint256 reminder) {
+        reminder = amount;
+        ICSAccounting.FeeSplit[] memory feeSplits = feeSplitsStorage[
+            nodeOperatorId
+        ];
+        if (feeSplits.length != 0) {
+            for (uint256 i = 0; i < feeSplits.length; i++) {
+                ICSAccounting.FeeSplit memory feeSplit = feeSplits[i];
+                uint256 splitAmount = (amount * feeSplit.share) / MAX_BP;
+                if (splitAmount != 0) {
+                    lido.transferShares(feeSplit.recipient, splitAmount);
+                    reminder -= splitAmount;
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Description

Add built-in reward splitters. This change makes it easier to handle the allocation of the reward part to infra providers like Obol and SSV

## Checklist

- [x] Appropriate PR labels applied
- [x] Test coverage maintained (`just coverage`)
  - [x] Tests are added/updated
- [x] Documentation maintained
  - [x] Updated
