### PR TITLE
feat: delayed exit penalty to charge

### DIFF
--- a/src/CSModule.sol
+++ b/src/CSModule.sol
@@ -761,22 +761,23 @@ contract CSModule is
                 penaltyMultiplier
             );
 
-            bool chargeWithdrawalRequestFee;
+            ICSAccounting _accounting = accounting();
+            bool chargeWithdrawalRequestFee = false;
+            bool bondCoveredCharges = true;
 
-            // It is safe to use unchecked for penalty sum because base penalties and fees are limited to uint248 in the
-            // MarkedUint248 structures used to store them, and the maximum multiplier is limited to 64, so
-            // `type(uint248).max * 64 * 2 < type(uint256).max`.
             ExitPenaltyInfo memory exitPenaltyInfo = EXIT_PENALTIES
                 .getExitPenaltyInfo(withdrawalInfo.nodeOperatorId, pubkey);
             if (exitPenaltyInfo.delayPenalty.isValue) {
-                unchecked {
-                    penaltySum +=
-                        exitPenaltyInfo.delayPenalty.value *
-                        penaltyMultiplier;
-                }
+                bondCoveredCharges = _accounting.chargeFee(
+                    withdrawalInfo.nodeOperatorId,
+                    exitPenaltyInfo.delayPenalty.value * penaltyMultiplier
+                );
                 chargeWithdrawalRequestFee = true;
             }
             if (exitPenaltyInfo.strikesPenalty.isValue) {
+                // It is safe to use unchecked for penalty sum because base penalties and fees are limited to uint248 in
+                // the MarkedUint248 structures used to store them, and the maximum multiplier is limited to 64, so
+                // `type(uint248).max * 64 < type(uint256).max`.
                 unchecked {
                     penaltySum +=
                         exitPenaltyInfo.strikesPenalty.value *
@@ -785,19 +786,17 @@ contract CSModule is
                 chargeWithdrawalRequestFee = true;
             }
 
-            ICSAccounting _accounting = accounting();
-            bool isFullyBurned = true;
-            bool isFullyCharged = true;
-
-            // The withdrawal request fee is taken only if the penalty is applied if no penalty, the
-            // fee has been paid by the node operator on the withdrawal trigger, or it is the DAO
-            // decision to withdraw the validator before that the withdrawal request becomes
-            // delayed.
+            // The withdrawal request fee is taken only if the penalty is applied. If no penalty
+            // is applied, the fee has been paid by the node operator on the withdrawal trigger,
+            // or it is the DAO decision to withdraw the validator before the withdrawal request
+            // becomes delayed.
             if (
+                bondCoveredCharges &&
                 chargeWithdrawalRequestFee &&
                 exitPenaltyInfo.withdrawalRequestFee.value != 0
             ) {
-                isFullyCharged = _accounting.chargeFee(
+                // We do not call the method if there is no bond left after the first call to the `chargeFee`.
+                bondCoveredCharges = _accounting.chargeFee(
                     withdrawalInfo.nodeOperatorId,
                     exitPenaltyInfo.withdrawalRequestFee.value
                 );
@@ -807,7 +806,7 @@ contract CSModule is
                 // Slashing penalty doesn't scale because all the losses are already accounted.
                 penaltySum += withdrawalInfo.slashingPenalty;
             } else if (withdrawalInfo.exitBalance < MIN_ACTIVATION_BALANCE) {
-                // type(uint248).max * 64 * 2 + 32 * 10**18 < type(uint256).max
+                // type(uint248).max * 64 + 32 * 10**18 < type(uint256).max
                 unchecked {
                     penaltySum +=
                         MIN_ACTIVATION_BALANCE -
@@ -816,13 +815,14 @@ contract CSModule is
             }
 
             if (penaltySum > 0) {
-                isFullyBurned = _accounting.penalize(
+                // We still call `penalize` even if there's no bond left, for the lock to be created.
+                bondCoveredCharges = _accounting.penalize(
                     withdrawalInfo.nodeOperatorId,
                     penaltySum
                 );
             }
 
-            if (!isFullyCharged || !isFullyBurned) {
+            if (!bondCoveredCharges) {
                 _onUncompensatedPenalty(withdrawalInfo.nodeOperatorId);
             }
 
@@ -853,7 +853,8 @@ contract CSModule is
     /// @inheritdoc IStakingModule
     function reportValidatorExitDelay(
         uint256 nodeOperatorId,
-        uint256 /* proofSlotTimestamp */,
+        uint256,
+        /* proofSlotTimestamp */
         bytes calldata publicKey,
         uint256 eligibleToExitInSec
     ) external onlyRole(STAKING_ROUTER_ROLE) {
@@ -1323,7 +1324,8 @@ contract CSModule is
     /// @inheritdoc IStakingModule
     function isValidatorExitDelayPenaltyApplicable(
         uint256 nodeOperatorId,
-        uint256 /* proofSlotTimestamp */,
+        uint256,
+        /* proofSlotTimestamp */
         bytes calldata publicKey,
         uint256 eligibleToExitInSec
     ) external view returns (bool) {

--- a/test/unit/ModuleAbstract.t.sol
+++ b/test/unit/ModuleAbstract.t.sol
@@ -5988,7 +5988,7 @@ abstract contract ModuleSubmitWithdrawals is ModuleFixtures {
         vm.expectCall(
             address(accounting),
             abi.encodeWithSelector(
-                accounting.penalize.selector,
+                accounting.chargeFee.selector,
                 noId,
                 exitDelayPenaltyAmount
             )
@@ -6036,7 +6036,7 @@ abstract contract ModuleSubmitWithdrawals is ModuleFixtures {
         vm.expectCall(
             address(accounting),
             abi.encodeWithSelector(
-                accounting.penalize.selector,
+                accounting.chargeFee.selector,
                 noId,
                 exitDelayPenaltyAmount
             )
@@ -6081,7 +6081,7 @@ abstract contract ModuleSubmitWithdrawals is ModuleFixtures {
         vm.expectCall(
             address(accounting),
             abi.encodeWithSelector(
-                accounting.penalize.selector,
+                accounting.chargeFee.selector,
                 noId,
                 penalty * multiplier
             )
@@ -6120,7 +6120,7 @@ abstract contract ModuleSubmitWithdrawals is ModuleFixtures {
         vm.expectCall(
             address(accounting),
             abi.encodeWithSelector(
-                accounting.penalize.selector,
+                accounting.chargeFee.selector,
                 noId,
                 penalty * multiplier
             )
@@ -6299,189 +6299,6 @@ abstract contract ModuleSubmitWithdrawals is ModuleFixtures {
         module.submitWithdrawals(withdrawalInfo);
     }
 
-    function test_submitWithdrawals_allPenalties() public assertInvariants {
-        uint256 keyIndex = 0;
-        uint256 noId = createNodeOperator();
-        module.obtainDepositData(1, "");
-
-        uint256 balanceShortage = (BOND_SIZE - 1 ether) / 3;
-        uint256 exitDelayPenaltyAmount = (BOND_SIZE - 1 ether) / 3;
-        uint256 strikesPenaltyAmount = (BOND_SIZE - 1 ether) / 3;
-
-        exitPenalties.mock_setDelayedExitPenaltyInfo(
-            ExitPenaltyInfo({
-                delayPenalty: MarkedUint248(
-                    uint248(exitDelayPenaltyAmount),
-                    true
-                ),
-                strikesPenalty: MarkedUint248(
-                    uint248(strikesPenaltyAmount),
-                    true
-                ),
-                withdrawalRequestFee: MarkedUint248(0, false)
-            })
-        );
-
-        ValidatorWithdrawalInfo[]
-            memory withdrawalInfo = new ValidatorWithdrawalInfo[](1);
-
-        withdrawalInfo[0] = ValidatorWithdrawalInfo(
-            noId,
-            keyIndex,
-            module.MIN_ACTIVATION_BALANCE() - balanceShortage,
-            0
-        );
-
-        vm.expectCall(
-            address(accounting),
-            abi.encodeWithSelector(
-                accounting.penalize.selector,
-                noId,
-                balanceShortage + exitDelayPenaltyAmount + strikesPenaltyAmount
-            )
-        );
-        module.submitWithdrawals(withdrawalInfo);
-
-        NodeOperator memory no = module.getNodeOperator(noId);
-        assertEq(no.totalWithdrawnKeys, 1);
-        // There should be no target limit if the penalty is covered by the bond.
-        assertEq(no.targetLimit, 0);
-        assertEq(no.targetLimitMode, 0);
-    }
-
-    function test_submitWithdrawals_allPenaltiesHugeSum()
-        public
-        assertInvariants
-    {
-        uint256 keyIndex = 0;
-        uint256 noId = createNodeOperator();
-        module.obtainDepositData(1, "");
-
-        uint256 balanceShortage = (BOND_SIZE + 1 ether) / 3;
-        uint256 exitDelayPenaltyAmount = (BOND_SIZE + 1 ether) / 3;
-        uint256 strikesPenaltyAmount = (BOND_SIZE + 1 ether) / 3;
-
-        exitPenalties.mock_setDelayedExitPenaltyInfo(
-            ExitPenaltyInfo({
-                delayPenalty: MarkedUint248(
-                    uint248(exitDelayPenaltyAmount),
-                    true
-                ),
-                strikesPenalty: MarkedUint248(
-                    uint248(strikesPenaltyAmount),
-                    true
-                ),
-                withdrawalRequestFee: MarkedUint248(0, false)
-            })
-        );
-
-        ValidatorWithdrawalInfo[]
-            memory withdrawalInfo = new ValidatorWithdrawalInfo[](1);
-
-        withdrawalInfo[0] = ValidatorWithdrawalInfo(
-            noId,
-            keyIndex,
-            module.MIN_ACTIVATION_BALANCE() - balanceShortage,
-            0
-        );
-
-        vm.expectCall(
-            address(accounting),
-            abi.encodeWithSelector(
-                accounting.penalize.selector,
-                noId,
-                balanceShortage + exitDelayPenaltyAmount + strikesPenaltyAmount
-            )
-        );
-        module.submitWithdrawals(withdrawalInfo);
-
-        NodeOperator memory no = module.getNodeOperator(noId);
-        assertEq(no.totalWithdrawnKeys, 1);
-        // There should be target limit if the penalty is not covered by the bond.
-        assertEq(no.targetLimit, 0);
-        assertEq(no.targetLimitMode, 2);
-    }
-
-    function test_submitWithdrawals_allPenaltiesWithMultiplier()
-        public
-        assertInvariants
-    {
-        uint256 keyIndex = 0;
-        uint256 noId = createNodeOperator();
-        module.obtainDepositData(1, "");
-
-        uint248 delayPenalty = 2 ether;
-        uint248 strikesPenalty = 3 ether;
-        uint256 multiplier = 3;
-
-        exitPenalties.mock_setDelayedExitPenaltyInfo(
-            ExitPenaltyInfo({
-                delayPenalty: MarkedUint248(delayPenalty, true),
-                strikesPenalty: MarkedUint248(strikesPenalty, true),
-                withdrawalRequestFee: MarkedUint248(0, false)
-            })
-        );
-
-        ValidatorWithdrawalInfo[]
-            memory withdrawalInfo = new ValidatorWithdrawalInfo[](1);
-        withdrawalInfo[0] = ValidatorWithdrawalInfo(
-            noId,
-            keyIndex,
-            module.MIN_ACTIVATION_BALANCE() * multiplier + 1 ether,
-            0
-        );
-
-        vm.expectCall(
-            address(accounting),
-            abi.encodeWithSelector(
-                accounting.penalize.selector,
-                noId,
-                delayPenalty * multiplier + strikesPenalty * multiplier
-            )
-        );
-        module.submitWithdrawals(withdrawalInfo);
-    }
-
-    function test_submitWithdrawals_allPenaltiesAtMaxWithMultiplier()
-        public
-        assertInvariants
-    {
-        uint256 keyIndex = 0;
-        uint256 noId = createNodeOperator();
-        module.obtainDepositData(1, "");
-
-        uint248 delayPenalty = type(uint248).max;
-        uint248 strikesPenalty = type(uint248).max;
-        uint256 multiplier = module.MAX_PENALTY_MULTIPLIER();
-
-        exitPenalties.mock_setDelayedExitPenaltyInfo(
-            ExitPenaltyInfo({
-                delayPenalty: MarkedUint248(delayPenalty, true),
-                strikesPenalty: MarkedUint248(strikesPenalty, true),
-                withdrawalRequestFee: MarkedUint248(0, false)
-            })
-        );
-
-        ValidatorWithdrawalInfo[]
-            memory withdrawalInfo = new ValidatorWithdrawalInfo[](1);
-        withdrawalInfo[0] = ValidatorWithdrawalInfo(
-            noId,
-            keyIndex,
-            module.MIN_ACTIVATION_BALANCE() * multiplier + 1000 ether,
-            0
-        );
-
-        vm.expectCall(
-            address(accounting),
-            abi.encodeWithSelector(
-                accounting.penalize.selector,
-                noId,
-                delayPenalty * multiplier + strikesPenalty * multiplier
-            )
-        );
-        module.submitWithdrawals(withdrawalInfo);
-    }
-
     function test_submitWithdrawals_slashingPenaltyApplied()
         public
         assertInvariants
@@ -6611,10 +6428,8 @@ abstract contract ModuleSubmitWithdrawals is ModuleFixtures {
         uint256 noId = createNodeOperator();
         module.obtainDepositData(1, "");
 
-        uint256 exitDelayPenaltyAmount = BOND_SIZE - 1 ether;
-        uint256 withdrawalRequestFeeAmount = BOND_SIZE -
-            exitDelayPenaltyAmount -
-            0.1 ether;
+        uint256 exitDelayPenaltyAmount = 0.7 ether;
+        uint256 withdrawalRequestFeeAmount = 0.3 ether;
 
         exitPenalties.mock_setDelayedExitPenaltyInfo(
             ExitPenaltyInfo({
@@ -6643,7 +6458,7 @@ abstract contract ModuleSubmitWithdrawals is ModuleFixtures {
         vm.expectCall(
             address(accounting),
             abi.encodeWithSelector(
-                accounting.penalize.selector,
+                accounting.chargeFee.selector,
                 noId,
                 exitDelayPenaltyAmount
             )
@@ -6703,12 +6518,13 @@ abstract contract ModuleSubmitWithdrawals is ModuleFixtures {
         vm.expectCall(
             address(accounting),
             abi.encodeWithSelector(
-                accounting.penalize.selector,
+                accounting.chargeFee.selector,
                 noId,
                 exitDelayPenaltyAmount
             )
         );
-        vm.expectCall(
+        // All bond was burned by the first call to `chargeFee`.
+        expectNoCall(
             address(accounting),
             abi.encodeWithSelector(
                 accounting.chargeFee.selector,
@@ -6763,7 +6579,7 @@ abstract contract ModuleSubmitWithdrawals is ModuleFixtures {
         vm.expectCall(
             address(accounting),
             abi.encodeWithSelector(
-                accounting.penalize.selector,
+                accounting.chargeFee.selector,
                 noId,
                 exitDelayPenaltyAmount
             )
@@ -6975,9 +6791,9 @@ abstract contract ModuleSubmitWithdrawals is ModuleFixtures {
         uint256 noId = createNodeOperator();
         module.obtainDepositData(1, "");
 
-        uint256 exitDelayPenaltyAmount = (BOND_SIZE - 1 ether) / 2;
-        uint256 strikesPenaltyAmount = (BOND_SIZE - 1 ether) / 2;
-        uint256 withdrawalRequestFeeAmount = strikesPenaltyAmount - 0.1 ether;
+        uint256 exitDelayPenaltyAmount = 0.17 ether;
+        uint256 strikesPenaltyAmount = 0.31 ether;
+        uint256 withdrawalRequestFeeAmount = 0.42 ether;
 
         exitPenalties.mock_setDelayedExitPenaltyInfo(
             ExitPenaltyInfo({
@@ -7009,9 +6825,17 @@ abstract contract ModuleSubmitWithdrawals is ModuleFixtures {
         vm.expectCall(
             address(accounting),
             abi.encodeWithSelector(
+                accounting.chargeFee.selector,
+                noId,
+                exitDelayPenaltyAmount
+            )
+        );
+        vm.expectCall(
+            address(accounting),
+            abi.encodeWithSelector(
                 accounting.penalize.selector,
                 noId,
-                exitDelayPenaltyAmount + strikesPenaltyAmount
+                strikesPenaltyAmount
             )
         );
         vm.expectCall(
@@ -7033,15 +6857,14 @@ abstract contract ModuleSubmitWithdrawals is ModuleFixtures {
 
     function test_submitWithdrawals_chargeWithdrawalFee_DelayAndStrikesPenalties_AllHuge()
         public
-        assertInvariants
     {
         uint256 keyIndex = 0;
         uint256 noId = createNodeOperator();
         module.obtainDepositData(1, "");
 
-        uint256 exitDelayPenaltyAmount = BOND_SIZE + 1 ether;
-        uint256 strikesPenaltyAmount = BOND_SIZE + 1 ether;
-        uint256 withdrawalRequestFeeAmount = BOND_SIZE + 1 ether;
+        uint256 exitDelayPenaltyAmount = BOND_SIZE + 17 ether;
+        uint256 strikesPenaltyAmount = BOND_SIZE + 31 ether;
+        uint256 withdrawalRequestFeeAmount = BOND_SIZE + 42 ether;
 
         exitPenalties.mock_setDelayedExitPenaltyInfo(
             ExitPenaltyInfo({
@@ -7073,12 +6896,21 @@ abstract contract ModuleSubmitWithdrawals is ModuleFixtures {
         vm.expectCall(
             address(accounting),
             abi.encodeWithSelector(
-                accounting.penalize.selector,
+                accounting.chargeFee.selector,
                 noId,
-                exitDelayPenaltyAmount + strikesPenaltyAmount
+                exitDelayPenaltyAmount
             )
         );
         vm.expectCall(
+            address(accounting),
+            abi.encodeWithSelector(
+                accounting.penalize.selector,
+                noId,
+                strikesPenaltyAmount
+            )
+        );
+        // All bond was burned by the first call to the `chargeFee`.
+        expectNoCall(
             address(accounting),
             abi.encodeWithSelector(
                 accounting.chargeFee.selector,


### PR DESCRIPTION
## Description

Instead of burning the penalty for a delayed exit, the module now sends funds to the treasury in order to cover operational costs related to managing the delay, such as gas costs for proving the delay, communication with the node operator, etc.

## Checklist

- [x] Appropriate PR labels applied
- [x] Test coverage maintained (`just coverage`)
  - [ ] No need to add/update tests
  - [x] Tests are added/updated
- [ ] Documentation maintained
  - [x] No need to update
  - [ ] Updated
