### PR TITLE
feat: Add custom rewards claimer

### DIFF
--- a/src/CSAccounting.sol
+++ b/src/CSAccounting.sol
@@ -49,6 +49,9 @@ contract CSAccounting is
     mapping(uint256 nodeOperatorId => uint256 pendingSharesToSplit)
         internal _pendingSharesToSplit;
 
+    mapping(uint256 nodeOperatorId => address rewardsClaimer)
+        internal _rewardsClaimers;
+
     modifier onlyModule() {
         if (msg.sender != address(MODULE)) {
             revert SenderIsNotModule();
@@ -425,6 +428,18 @@ contract CSAccounting is
         MODULE.updateDepositableValidatorsCount(nodeOperatorId);
     }
 
+    /// @inheritdoc ICSAccounting
+    function setCustomRewardsClaimer(
+        uint256 nodeOperatorId,
+        address rewardsClaimer
+    ) external {
+        _onlyNodeOperatorOwner(nodeOperatorId);
+        if (rewardsClaimer != _rewardsClaimers[nodeOperatorId]) {
+            _rewardsClaimers[nodeOperatorId] = rewardsClaimer;
+            emit CustomRewardsClaimerSet(nodeOperatorId, rewardsClaimer);
+        }
+    }
+
     /// @inheritdoc AssetRecoverer
     function recoverERC20(address token, uint256 amount) external override {
         _onlyRecoverer();
@@ -457,6 +472,13 @@ contract CSAccounting is
         uint256 nodeOperatorId
     ) external view returns (FeeSplit[] memory) {
         return _feeSplits[nodeOperatorId];
+    }
+
+    /// @inheritdoc ICSAccounting
+    function getCustomRewardsClaimer(
+        uint256 nodeOperatorId
+    ) external view returns (address) {
+        return _rewardsClaimers[nodeOperatorId];
     }
 
     /// @inheritdoc ICSAccounting
@@ -749,7 +771,9 @@ contract CSAccounting is
         }
 
         if (no.managerAddress != msg.sender && no.rewardAddress != msg.sender) {
-            revert SenderIsNotEligible();
+            if (_rewardsClaimers[nodeOperatorId] != msg.sender) {
+                revert SenderIsNotEligible();
+            }
         }
     }
 

--- a/src/CSAccounting.sol
+++ b/src/CSAccounting.sol
@@ -435,10 +435,11 @@ contract CSAccounting is
         address rewardsClaimer
     ) external {
         _onlyNodeOperatorOwner(nodeOperatorId);
-        if (rewardsClaimer != _rewardsClaimers[nodeOperatorId]) {
-            _rewardsClaimers[nodeOperatorId] = rewardsClaimer;
-            emit CustomRewardsClaimerSet(nodeOperatorId, rewardsClaimer);
+        if (rewardsClaimer == _rewardsClaimers[nodeOperatorId]) {
+            revert SameAddress();
         }
+        _rewardsClaimers[nodeOperatorId] = rewardsClaimer;
+        emit CustomRewardsClaimerSet(nodeOperatorId, rewardsClaimer);
     }
 
     /// @inheritdoc AssetRecoverer

--- a/src/interfaces/ICSAccounting.sol
+++ b/src/interfaces/ICSAccounting.sol
@@ -45,6 +45,7 @@ interface ICSAccounting is
     error NodeOperatorDoesNotExist();
     error ElRewardsVaultReceiveFailed();
     error InvalidBondCurvesLength();
+    error SameAddress();
 
     function PAUSE_ROLE() external view returns (bytes32);
 

--- a/src/interfaces/ICSAccounting.sol
+++ b/src/interfaces/ICSAccounting.sol
@@ -31,6 +31,10 @@ interface ICSAccounting is
 
     event BondLockCompensated(uint256 indexed nodeOperatorId, uint256 amount);
     event ChargePenaltyRecipientSet(address chargePenaltyRecipient);
+    event CustomRewardsClaimerSet(
+        uint256 indexed nodeOperatorId,
+        address rewardsClaimer
+    );
 
     error SenderIsNotModule();
     error SenderIsNotEligible();
@@ -111,6 +115,23 @@ interface ICSAccounting is
         uint256 curveId,
         BondCurveIntervalInput[] calldata bondCurve
     ) external;
+
+    /// @notice Set custom rewards claimer for the given Node Operator. This address will be able to claim rewards on behalf of the Node Operator.
+    ///         The rewards will be transferred to the Node Operator's reward address as usual.
+    /// @param nodeOperatorId ID of the Node Operator
+    /// @param rewardsClaimer Address allowed to claim rewards on behalf of the Node Operator
+    function setCustomRewardsClaimer(
+        uint256 nodeOperatorId,
+        address rewardsClaimer
+    ) external;
+
+    /// @notice Get the custom rewards claimer for the given Node Operator. This address is allowed to claim rewards on behalf of the Node Operator.
+    ///         The rewards are still transferred to the Node Operator's reward address as usual.
+    /// @param nodeOperatorId ID of the Node Operator
+    /// @return rewardsClaimer Address allowed to claim rewards on behalf of the Node Operator
+    function getCustomRewardsClaimer(
+        uint256 nodeOperatorId
+    ) external view returns (address);
 
     /// @notice Get the required bond in ETH (inc. missed and excess) for the given Node Operator to upload new deposit data
     /// @param nodeOperatorId ID of the Node Operator

--- a/test/unit/CSAccounting/ClaimRewards.t.sol
+++ b/test/unit/CSAccounting/ClaimRewards.t.sol
@@ -522,6 +522,47 @@ contract ClaimStETHRewardsTest is ClaimRewardsBaseTest {
         );
     }
 
+    function test_SenderIsRewardsClaimer() public override assertInvariants {
+        _operator({ ongoing: 16, withdrawn: 0 });
+        _deposit({ bond: 32 ether });
+        _rewards({ fee: 0.1 ether });
+
+        mock_getNodeOperatorOwner(rewardAddress);
+        vm.prank(rewardAddress);
+        accounting.setCustomRewardsClaimer(leaf.nodeOperatorId, rewardsClaimer);
+
+        uint256 bondSharesBefore = accounting.getBondShares(0);
+        vm.prank(rewardsClaimer);
+        accounting.claimRewardsStETH(
+            leaf.nodeOperatorId,
+            UINT256_MAX,
+            leaf.shares,
+            leaf.proof
+        );
+        uint256 bondSharesAfter = accounting.getBondShares(0);
+
+        assertEq(
+            stETH.balanceOf(rewardAddress),
+            stETHAsFee,
+            "reward address balance should be equal to fee reward"
+        );
+        assertEq(
+            bondSharesAfter,
+            bondSharesBefore,
+            "bond shares after claim should be equal to before"
+        );
+        assertEq(
+            stETH.sharesOf(address(accounting)),
+            bondSharesBefore,
+            "bond manager after claim should be equal to before"
+        );
+        assertEq(
+            accounting.totalBondShares(),
+            bondSharesBefore,
+            "total bond shares after claim should be equal to before"
+        );
+    }
+
     function test_RevertWhen_SenderIsNotEligible() public override {
         // Ensure there is claimable amount to trigger eligibility check
         _operator({ ongoing: 16, withdrawn: 0 });
@@ -1076,6 +1117,54 @@ contract ClaimWstETHRewardsTest is ClaimRewardsBaseTest {
         );
     }
 
+    function test_SenderIsRewardsClaimer() public override assertInvariants {
+        _operator({ ongoing: 16, withdrawn: 0 });
+        _deposit({ bond: 32 ether });
+        _rewards({ fee: 0.1 ether });
+
+        mock_getNodeOperatorOwner(rewardAddress);
+        vm.prank(rewardAddress);
+        accounting.setCustomRewardsClaimer(leaf.nodeOperatorId, rewardsClaimer);
+
+        uint256 bondSharesBefore = accounting.getBondShares(0);
+        vm.prank(rewardsClaimer);
+        accounting.claimRewardsWstETH(
+            leaf.nodeOperatorId,
+            UINT256_MAX,
+            leaf.shares,
+            leaf.proof
+        );
+        uint256 bondSharesAfter = accounting.getBondShares(0);
+
+        assertApproxEqAbs(
+            wstETH.balanceOf(rewardAddress),
+            wstETHAsFee,
+            1 wei,
+            "reward address balance should be equal to fee reward"
+        );
+        assertApproxEqAbs(
+            bondSharesAfter,
+            bondSharesBefore,
+            1 wei,
+            "bond shares after claim should be equal to before"
+        );
+        assertEq(
+            wstETH.balanceOf(address(accounting)),
+            0,
+            "bond manager wstETH balance should be 0"
+        );
+        assertEq(
+            stETH.sharesOf(address(accounting)),
+            bondSharesAfter,
+            "bond manager after claim should be equal to after"
+        );
+        assertEq(
+            accounting.totalBondShares(),
+            bondSharesAfter,
+            "total bond shares after claim should be equal to after"
+        );
+    }
+
     function test_SenderIsRewardAddress() public override assertInvariants {
         _operator({ ongoing: 16, withdrawn: 0 });
         _deposit({ bond: 32 ether });
@@ -1569,6 +1658,43 @@ contract ClaimRewardsUnstETHTest is ClaimRewardsBaseTest {
             accounting.totalBondShares(),
             bondSharesAfter,
             "total bond shares should be equal to after"
+        );
+    }
+
+    function test_SenderIsRewardsClaimer() public override assertInvariants {
+        _operator({ ongoing: 16, withdrawn: 0 });
+        _deposit({ bond: 32 ether });
+        _rewards({ fee: 0.1 ether });
+
+        mock_getNodeOperatorOwner(rewardAddress);
+        vm.prank(rewardAddress);
+        accounting.setCustomRewardsClaimer(leaf.nodeOperatorId, rewardsClaimer);
+
+        uint256 bondSharesBefore = accounting.getBondShares(0);
+        vm.prank(rewardsClaimer);
+        accounting.claimRewardsUnstETH(
+            leaf.nodeOperatorId,
+            UINT256_MAX,
+            leaf.shares,
+            leaf.proof
+        );
+        uint256 bondSharesAfter = accounting.getBondShares(0);
+
+        assertApproxEqAbs(
+            bondSharesAfter,
+            bondSharesBefore,
+            1 wei,
+            "bond shares after claim should be equal to before"
+        );
+        assertEq(
+            stETH.sharesOf(rewardAddress),
+            0,
+            "rewardAddress shares should be 0"
+        );
+        assertEq(
+            accounting.totalBondShares(),
+            bondSharesAfter,
+            "total bond shares should not change"
         );
     }
 

--- a/test/unit/CSAccounting/Operations.t.sol
+++ b/test/unit/CSAccounting/Operations.t.sol
@@ -517,6 +517,44 @@ contract MiscTest is BaseTest {
             type(uint256).max
         );
     }
+
+    function test_setCustomRewardsClaimer() public {
+        mock_getNodeOperatorOwner(user);
+
+        vm.expectEmit(address(accounting));
+        emit ICSAccounting.CustomRewardsClaimerSet(0, address(1337));
+        vm.prank(user);
+        accounting.setCustomRewardsClaimer(0, address(1337));
+
+        address claimer = accounting.getCustomRewardsClaimer(0);
+        assertEq(claimer, address(1337));
+    }
+
+    function test_setCustomRewardsClaimer_noEmitOnSameAddress() public {
+        mock_getNodeOperatorOwner(user);
+
+        vm.prank(user);
+        accounting.setCustomRewardsClaimer(0, address(1337));
+
+        address claimer = accounting.getCustomRewardsClaimer(0);
+        assertEq(claimer, address(1337));
+
+        vm.recordLogs();
+        vm.prank(user);
+        accounting.setCustomRewardsClaimer(0, claimer);
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+        assertEq(logs.length, 0);
+    }
+
+    function test_setCustomRewardsClaimer_RevertWhen_SenderIsNotEligible()
+        public
+    {
+        mock_getNodeOperatorOwner(user);
+
+        vm.expectRevert(ICSAccounting.SenderIsNotEligible.selector);
+        vm.prank(stranger);
+        accounting.setCustomRewardsClaimer(0, address(1337));
+    }
 }
 
 contract NegativeRebaseTest is BaseTest {

--- a/test/unit/CSAccounting/Operations.t.sol
+++ b/test/unit/CSAccounting/Operations.t.sol
@@ -530,20 +530,15 @@ contract MiscTest is BaseTest {
         assertEq(claimer, address(1337));
     }
 
-    function test_setCustomRewardsClaimer_noEmitOnSameAddress() public {
+    function test_setCustomRewardsClaimer_RevertWhen_SameAddress() public {
         mock_getNodeOperatorOwner(user);
 
-        vm.prank(user);
+        vm.startPrank(user);
         accounting.setCustomRewardsClaimer(0, address(1337));
 
-        address claimer = accounting.getCustomRewardsClaimer(0);
-        assertEq(claimer, address(1337));
-
-        vm.recordLogs();
-        vm.prank(user);
-        accounting.setCustomRewardsClaimer(0, claimer);
-        Vm.Log[] memory logs = vm.getRecordedLogs();
-        assertEq(logs.length, 0);
+        vm.expectRevert(ICSAccounting.SameAddress.selector);
+        accounting.setCustomRewardsClaimer(0, address(1337));
+        vm.stopPrank();
     }
 
     function test_setCustomRewardsClaimer_RevertWhen_SenderIsNotEligible()

--- a/test/unit/CSAccounting/_Base.t.sol
+++ b/test/unit/CSAccounting/_Base.t.sol
@@ -348,10 +348,12 @@ abstract contract RewardsBaseTest is BondStateBaseTest {
     uint256 unstETHSharesAsFee;
 
     address internal rewardAddress;
+    address internal rewardsClaimer;
 
     function setUp() public override {
         super.setUp();
         rewardAddress = nextAddress("reward address");
+        rewardsClaimer = nextAddress("rewards claimer");
         mock_getNodeOperatorManagementProperties(user, rewardAddress, false);
     }
 
@@ -379,6 +381,8 @@ abstract contract ClaimRewardsBaseTest is RewardsBaseTest {
     function test_ExcessBondWithoutProof() public virtual;
 
     function test_SenderIsRewardAddress() public virtual;
+
+    function test_SenderIsRewardsClaimer() public virtual;
 
     function test_RevertWhen_SenderIsNotEligible() public virtual;
 


### PR DESCRIPTION
## Description

Adds the ability for the Node Operators to set a custom rewards claimer address. The address can initiate reward claims only. The rewards are still transferred to the `rewardAddress`

## Checklist

- [x] Appropriate PR labels applied
- [x] Test coverage maintained (`just coverage`)
  - [x] Tests are added/updated
- [x] Documentation maintained
  - [x] Updated
