### PR TITLE
chore: Move EL stealing stuff to external lib

### DIFF
--- a/src/CSModule.sol
+++ b/src/CSModule.sol
@@ -22,6 +22,7 @@ import { PausableUntil } from "./lib/utils/PausableUntil.sol";
 import { QueueLib, Batch } from "./lib/QueueLib.sol";
 import { ValidatorCountsReport } from "./lib/ValidatorCountsReport.sol";
 import { NOAddresses } from "./lib/NOAddresses.sol";
+import { GeneralPenalty } from "./lib/GeneralPenaltyLib.sol";
 import { TransientUintUintMap, TransientUintUintMapLib } from "./lib/TransientUintUintMapLib.sol";
 import { SigningKeys } from "./lib/SigningKeys.sol";
 
@@ -573,7 +574,6 @@ contract CSModule is
         });
     }
 
-    /// TODO: Consider moving to the external library to save bytecode
     /// @inheritdoc ICSModule
     function reportELRewardsStealingPenalty(
         uint256 nodeOperatorId,
@@ -581,47 +581,22 @@ contract CSModule is
         uint256 amount
     ) external onlyRole(REPORT_EL_REWARDS_STEALING_PENALTY_ROLE) {
         _onlyExistingNodeOperator(nodeOperatorId);
-        if (amount == 0) {
-            revert InvalidAmount();
-        }
-
-        uint256 curveId = _getBondCurveId(nodeOperatorId);
-        uint256 additionalFine = PARAMETERS_REGISTRY
-            .getElRewardsStealingAdditionalFine(curveId);
-        accounting().lockBondETH(nodeOperatorId, amount + additionalFine);
-
-        emit ELRewardsStealingPenaltyReported(
+        GeneralPenalty.reportELRewardsStealingPenalty(
             nodeOperatorId,
             blockHash,
             amount
         );
-
-        // Nonce should be updated if depositableValidators change
-        _updateDepositableValidatorsCount({
-            nodeOperatorId: nodeOperatorId,
-            incrementNonceIfUpdated: true
-        });
     }
 
-    /// TODO: Consider moving to the external library to save bytecode
     /// @inheritdoc ICSModule
     function cancelELRewardsStealingPenalty(
         uint256 nodeOperatorId,
         uint256 amount
     ) external onlyRole(REPORT_EL_REWARDS_STEALING_PENALTY_ROLE) {
         _onlyExistingNodeOperator(nodeOperatorId);
-        accounting().releaseLockedBondETH(nodeOperatorId, amount);
-
-        emit ELRewardsStealingPenaltyCancelled(nodeOperatorId, amount);
-
-        // Nonce should be updated if depositableValidators change
-        _updateDepositableValidatorsCount({
-            nodeOperatorId: nodeOperatorId,
-            incrementNonceIfUpdated: true
-        });
+        GeneralPenalty.cancelELRewardsStealingPenalty(nodeOperatorId, amount);
     }
 
-    /// TODO: Consider moving to the external library to save bytecode
     /// @inheritdoc ICSModule
     function settleELRewardsStealingPenalty(
         uint256[] calldata nodeOperatorIds,
@@ -630,18 +605,17 @@ contract CSModule is
         if (nodeOperatorIds.length != maxAmounts.length) {
             revert InvalidInput();
         }
-        ICSAccounting _accounting = accounting();
+
         for (uint256 i; i < nodeOperatorIds.length; ++i) {
             uint256 nodeOperatorId = nodeOperatorIds[i];
             _onlyExistingNodeOperator(nodeOperatorId);
 
-            uint256 locked = _accounting.getActualLockedBond(nodeOperatorId);
-            if (locked == 0 || locked > maxAmounts[i]) {
-                continue; // skip this NO if the locked bond is greater than the max amount or there is no locked bond
-            }
+            bool settled = GeneralPenalty.settleELRewardsStealingPenalty(
+                nodeOperatorId,
+                maxAmounts[i]
+            );
 
-            _accounting.settleLockedBondETH(nodeOperatorId);
-            emit ELRewardsStealingPenaltySettled(nodeOperatorId);
+            if (!settled) continue;
 
             _onUncompensatedPenalty(nodeOperatorId);
 
@@ -653,23 +627,12 @@ contract CSModule is
         }
     }
 
-    /// TODO: Consider moving to the external library to save bytecode
     /// @inheritdoc ICSModule
     function compensateELRewardsStealingPenalty(
         uint256 nodeOperatorId
     ) external payable {
         _onlyNodeOperatorManager(nodeOperatorId, msg.sender);
-        accounting().compensateLockedBondETH{ value: msg.value }(
-            nodeOperatorId
-        );
-
-        emit ELRewardsStealingPenaltyCompensated(nodeOperatorId, msg.value);
-
-        // Nonce should be updated if depositableValidators change
-        _updateDepositableValidatorsCount({
-            nodeOperatorId: nodeOperatorId,
-            incrementNonceIfUpdated: true
-        });
+        GeneralPenalty.compensateELRewardsStealingPenalty(nodeOperatorId);
     }
 
     /// @inheritdoc ICSModule

--- a/src/interfaces/ICSModule.sol
+++ b/src/interfaces/ICSModule.sol
@@ -143,20 +143,6 @@ interface ICSModule is
     );
 
     event KeyRemovalChargeApplied(uint256 indexed nodeOperatorId);
-    event ELRewardsStealingPenaltyReported(
-        uint256 indexed nodeOperatorId,
-        bytes32 proposedBlockHash,
-        uint256 stolenAmount
-    );
-    event ELRewardsStealingPenaltyCancelled(
-        uint256 indexed nodeOperatorId,
-        uint256 amount
-    );
-    event ELRewardsStealingPenaltyCompensated(
-        uint256 indexed nodeOperatorId,
-        uint256 amount
-    );
-    event ELRewardsStealingPenaltySettled(uint256 indexed nodeOperatorId);
 
     function PAUSE_ROLE() external view returns (bytes32);
 

--- a/src/lib/GeneralPenaltyLib.sol
+++ b/src/lib/GeneralPenaltyLib.sol
@@ -1,0 +1,104 @@
+// SPDX-FileCopyrightText: 2025 Lido <info@lido.fi>
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity 0.8.24;
+
+import { ICSModule } from "../interfaces/ICSModule.sol";
+import { ICSAccounting } from "../interfaces/ICSAccounting.sol";
+
+/// Library for General Penalty logic
+/// @dev the only use of this to be a library is to save CSModule contract size via delegatecalls
+interface IGeneralPenalty {
+    event ELRewardsStealingPenaltyReported(
+        uint256 indexed nodeOperatorId,
+        bytes32 proposedBlockHash,
+        uint256 stolenAmount
+    );
+    event ELRewardsStealingPenaltyCancelled(
+        uint256 indexed nodeOperatorId,
+        uint256 amount
+    );
+    event ELRewardsStealingPenaltyCompensated(
+        uint256 indexed nodeOperatorId,
+        uint256 amount
+    );
+    event ELRewardsStealingPenaltySettled(uint256 indexed nodeOperatorId);
+}
+
+library GeneralPenalty {
+    function reportELRewardsStealingPenalty(
+        uint256 nodeOperatorId,
+        bytes32 blockHash,
+        uint256 amount
+    ) external {
+        if (amount == 0) {
+            revert ICSModule.InvalidAmount();
+        }
+
+        ICSModule module = ICSModule(address(this));
+        ICSAccounting accounting = module.ACCOUNTING();
+
+        uint256 curveId = accounting.getBondCurveId(nodeOperatorId);
+        uint256 additionalFine = module
+            .PARAMETERS_REGISTRY()
+            .getElRewardsStealingAdditionalFine(curveId);
+
+        accounting.lockBondETH(nodeOperatorId, amount + additionalFine);
+
+        emit IGeneralPenalty.ELRewardsStealingPenaltyReported(
+            nodeOperatorId,
+            blockHash,
+            amount
+        );
+
+        module.updateDepositableValidatorsCount(nodeOperatorId);
+    }
+
+    function cancelELRewardsStealingPenalty(
+        uint256 nodeOperatorId,
+        uint256 amount
+    ) external {
+        ICSModule module = ICSModule(address(this));
+        ICSAccounting accounting = module.ACCOUNTING();
+
+        accounting.releaseLockedBondETH(nodeOperatorId, amount);
+
+        emit IGeneralPenalty.ELRewardsStealingPenaltyCancelled(
+            nodeOperatorId,
+            amount
+        );
+
+        module.updateDepositableValidatorsCount(nodeOperatorId);
+    }
+
+    function settleELRewardsStealingPenalty(
+        uint256 nodeOperatorId,
+        uint256 maxAmount
+    ) external returns (bool) {
+        ICSAccounting accounting = ICSModule(address(this)).ACCOUNTING();
+        uint256 locked = accounting.getActualLockedBond(nodeOperatorId);
+        if (locked == 0 || locked > maxAmount) {
+            return false; // skip this NO if the locked bond is greater than the max amount or there is no locked bond
+        }
+
+        accounting.settleLockedBondETH(nodeOperatorId);
+        emit IGeneralPenalty.ELRewardsStealingPenaltySettled(nodeOperatorId);
+
+        return true;
+    }
+
+    function compensateELRewardsStealingPenalty(
+        uint256 nodeOperatorId
+    ) external {
+        ICSModule module = ICSModule(address(this));
+        ICSAccounting accounting = module.ACCOUNTING();
+
+        accounting.compensateLockedBondETH{ value: msg.value }(nodeOperatorId);
+
+        emit IGeneralPenalty.ELRewardsStealingPenaltyCompensated(
+            nodeOperatorId,
+            msg.value
+        );
+
+        module.updateDepositableValidatorsCount(nodeOperatorId);
+    }
+}

--- a/test/unit/ModuleAbstract.t.sol
+++ b/test/unit/ModuleAbstract.t.sol
@@ -23,6 +23,7 @@ import { ICSAccounting } from "src/interfaces/ICSAccounting.sol";
 import { IStakingModule } from "src/interfaces/IStakingModule.sol";
 import { SigningKeys } from "src/lib/SigningKeys.sol";
 import { INOAddresses } from "src/lib/NOAddresses.sol";
+import { IGeneralPenalty } from "src/lib/GeneralPenaltyLib.sol";
 import { CSBondLock } from "src/abstract/CSBondLock.sol";
 import { ICSExitPenalties, ExitPenaltyInfo, MarkedUint248 } from "src/interfaces/ICSExitPenalties.sol";
 import { IAssetRecovererLib } from "src/lib/AssetRecovererLib.sol";
@@ -5108,7 +5109,7 @@ abstract contract ModuleReportELRewardsStealingPenalty is ModuleFixtures {
         uint256 nonce = module.getNonce();
 
         vm.expectEmit(address(module));
-        emit ICSModule.ELRewardsStealingPenaltyReported(
+        emit IGeneralPenalty.ELRewardsStealingPenaltyReported(
             noId,
             blockhash(block.number),
             BOND_SIZE / 2
@@ -5233,7 +5234,7 @@ abstract contract ModuleCancelELRewardsStealingPenalty is ModuleFixtures {
         uint256 nonce = module.getNonce();
 
         vm.expectEmit(address(module));
-        emit ICSModule.ELRewardsStealingPenaltyCancelled(
+        emit IGeneralPenalty.ELRewardsStealingPenaltyCancelled(
             noId,
             BOND_SIZE /
                 2 +
@@ -5270,7 +5271,10 @@ abstract contract ModuleCancelELRewardsStealingPenalty is ModuleFixtures {
         uint256 nonce = module.getNonce();
 
         vm.expectEmit(address(module));
-        emit ICSModule.ELRewardsStealingPenaltyCancelled(noId, BOND_SIZE / 2);
+        emit IGeneralPenalty.ELRewardsStealingPenaltyCancelled(
+            noId,
+            BOND_SIZE / 2
+        );
         module.cancelELRewardsStealingPenalty(noId, BOND_SIZE / 2);
 
         uint256 lockedBond = accounting.getActualLockedBond(noId);
@@ -5301,7 +5305,7 @@ abstract contract ModuleSettleELRewardsStealingPenaltyBasic is ModuleFixtures {
         );
 
         vm.expectEmit(address(module));
-        emit ICSModule.ELRewardsStealingPenaltySettled(noId);
+        emit IGeneralPenalty.ELRewardsStealingPenaltySettled(noId);
         module.settleELRewardsStealingPenalty(
             UintArr(noId),
             UintArr(type(uint256).max)
@@ -5405,9 +5409,9 @@ abstract contract ModuleSettleELRewardsStealingPenaltyBasic is ModuleFixtures {
         );
 
         vm.expectEmit(address(module));
-        emit ICSModule.ELRewardsStealingPenaltySettled(firstNoId);
+        emit IGeneralPenalty.ELRewardsStealingPenaltySettled(firstNoId);
         vm.expectEmit(address(module));
-        emit ICSModule.ELRewardsStealingPenaltySettled(secondNoId);
+        emit IGeneralPenalty.ELRewardsStealingPenaltySettled(secondNoId);
         module.settleELRewardsStealingPenalty(
             UintArr(firstNoId, secondNoId),
             UintArr(type(uint256).max, type(uint256).max)
@@ -5446,7 +5450,7 @@ abstract contract ModuleSettleELRewardsStealingPenaltyBasic is ModuleFixtures {
         );
 
         vm.expectEmit(address(module));
-        emit ICSModule.ELRewardsStealingPenaltySettled(secondNoId);
+        emit IGeneralPenalty.ELRewardsStealingPenaltySettled(secondNoId);
         module.settleELRewardsStealingPenalty(
             idsToSettle,
             UintArr(amount, type(uint256).max)
@@ -5538,7 +5542,7 @@ abstract contract ModuleSettleELRewardsStealingPenaltyBasic is ModuleFixtures {
         );
 
         vm.expectEmit(address(module));
-        emit ICSModule.ELRewardsStealingPenaltySettled(secondNoId);
+        emit IGeneralPenalty.ELRewardsStealingPenaltySettled(secondNoId);
         module.settleELRewardsStealingPenalty(
             UintArr(firstNoId, secondNoId),
             UintArr(type(uint256).max, type(uint256).max)
@@ -5574,7 +5578,7 @@ abstract contract ModuleSettleELRewardsStealingPenaltyBasic is ModuleFixtures {
         );
 
         vm.expectEmit(address(module));
-        emit ICSModule.ELRewardsStealingPenaltySettled(secondNoId);
+        emit IGeneralPenalty.ELRewardsStealingPenaltySettled(secondNoId);
         module.settleELRewardsStealingPenalty(
             idsToSettle,
             UintArr(type(uint256).max, type(uint256).max, type(uint256).max)
@@ -5653,7 +5657,7 @@ abstract contract ModuleSettleELRewardsStealingPenaltyAdvanced is
         );
 
         vm.expectEmit(address(module));
-        emit ICSModule.ELRewardsStealingPenaltySettled(secondNoId);
+        emit IGeneralPenalty.ELRewardsStealingPenaltySettled(secondNoId);
         module.settleELRewardsStealingPenalty(
             UintArr(firstNoId, secondNoId),
             UintArr(type(uint256).max, type(uint256).max)
@@ -5684,7 +5688,7 @@ abstract contract ModuleSettleELRewardsStealingPenaltyAdvanced is
             amount
         );
         vm.expectEmit(address(module));
-        emit ICSModule.ELRewardsStealingPenaltySettled(noId);
+        emit IGeneralPenalty.ELRewardsStealingPenaltySettled(noId);
         module.settleELRewardsStealingPenalty(
             UintArr(noId),
             UintArr(type(uint256).max)
@@ -5708,7 +5712,10 @@ abstract contract ModuleCompensateELRewardsStealingPenalty is ModuleFixtures {
         uint256 nonce = module.getNonce();
 
         vm.expectEmit(address(module));
-        emit ICSModule.ELRewardsStealingPenaltyCompensated(noId, amount + fine);
+        emit IGeneralPenalty.ELRewardsStealingPenaltyCompensated(
+            noId,
+            amount + fine
+        );
 
         vm.expectCall(
             address(accounting),
@@ -5744,7 +5751,7 @@ abstract contract ModuleCompensateELRewardsStealingPenalty is ModuleFixtures {
         uint256 nonce = module.getNonce();
 
         vm.expectEmit(address(module));
-        emit ICSModule.ELRewardsStealingPenaltyCompensated(noId, amount);
+        emit IGeneralPenalty.ELRewardsStealingPenaltyCompensated(noId, amount);
 
         vm.expectCall(
             address(accounting),


### PR DESCRIPTION
## Description

Step 1 of remaking the EL rewards stealing penalty into a general penalty

## Checklist

- [x] Appropriate PR labels applied
- [x] Test coverage maintained (`just coverage`)
  - [x] Tests are added/updated
- [x] Documentation maintained
  - [x] No need to update
