### PR TITLE
Fix TODOs in CSModule

### DIFF
--- a/script/DeployBase.s.sol
+++ b/script/DeployBase.s.sol
@@ -339,7 +339,7 @@ abstract contract DeployBase is Script {
                 moduleType: config.moduleType,
                 lidoLocator: config.lidoLocatorAddress,
                 parametersRegistry: address(parametersRegistry),
-                _accounting: address(accounting),
+                accounting: address(accounting),
                 exitPenalties: address(exitPenalties)
             });
 

--- a/script/DeployImplementationsBase.s.sol
+++ b/script/DeployImplementationsBase.s.sol
@@ -192,7 +192,7 @@ abstract contract DeployImplementationsBase is DeployBase {
                 moduleType: config.moduleType,
                 lidoLocator: config.lidoLocatorAddress,
                 parametersRegistry: address(parametersRegistry),
-                _accounting: address(accounting),
+                accounting: address(accounting),
                 exitPenalties: address(exitPenalties)
             });
 

--- a/script/fork-helpers/SimulateVote.s.sol
+++ b/script/fork-helpers/SimulateVote.s.sol
@@ -25,6 +25,11 @@ import { ForkHelpersCommon } from "./Common.sol";
 import { DeployParams } from "../DeployBase.s.sol";
 
 contract SimulateVote is Script, ForkHelpersCommon {
+    bytes32 internal constant REPORT_EL_REWARDS_STEALING_PENALTY_ROLE =
+        keccak256("REPORT_EL_REWARDS_STEALING_PENALTY_ROLE");
+    bytes32 internal constant SETTLE_EL_REWARDS_STEALING_PENALTY_ROLE =
+        keccak256("SETTLE_EL_REWARDS_STEALING_PENALTY_ROLE");
+
     error WrongModuleType();
 
     function addModule() external {
@@ -248,6 +253,32 @@ contract SimulateVote is Script, ForkHelpersCommon {
         //         accounting.SET_BOND_CURVE_ROLE(),
         //         deploymentConfig.vettedGate
         //     );
+
+        // address generalDelayedPenaltyReporter = module.getRoleMember(
+        //     REPORT_EL_REWARDS_STEALING_PENALTY_ROLE,
+        //     1
+        // );
+        // module.revokeRole(
+        //     REPORT_EL_REWARDS_STEALING_PENALTY_ROLE,
+        //     generalDelayedPenaltyReporter
+        // );
+        // module.grantRole(
+        //     REPORT_GENERAL_DELAYED_PENALTY_ROLE,
+        //     generalDelayedPenaltyReporter
+        // );
+        //
+        // address generalDelayedPenaltySettler = module.getRoleMember(
+        //     SETTLE_EL_REWARDS_STEALING_PENALTY_ROLE,
+        //     1
+        // );
+        // module.revokeRole(
+        //     SETTLE_EL_REWARDS_STEALING_PENALTY_ROLE,
+        //     generalDelayedPenaltySettler
+        // );
+        // module.grantRole(
+        //     SETTLE_GENERAL_DELAYED_PENALTY_ROLE,
+        //     generalDelayedPenaltySettler
+        // );
 
         //     accounting.grantRole(accounting.MANAGE_BOND_CURVES_ROLE(), admin);
 

--- a/src/CSExitPenalties.sol
+++ b/src/CSExitPenalties.sol
@@ -52,7 +52,7 @@ contract CSExitPenalties is ICSExitPenalties, ExitTypes {
 
         MODULE = ICSModule(module);
         PARAMETERS_REGISTRY = ICSParametersRegistry(parametersRegistry);
-        ACCOUNTING = MODULE.accounting();
+        ACCOUNTING = MODULE.ACCOUNTING();
         STRIKES = strikes;
     }
 

--- a/src/CSModule.sol
+++ b/src/CSModule.sol
@@ -519,7 +519,6 @@ contract CSModule is
         _onlyNodeOperatorManager(nodeOperatorId, msg.sender);
         NodeOperator storage no = _nodeOperators[nodeOperatorId];
 
-        // TODO: consider moving to a helper function
         if (startIndex < no.totalDepositedKeys) {
             revert SigningKeysInvalidOffset();
         }
@@ -647,7 +646,6 @@ contract CSModule is
     ) external onlyRole(VERIFIER_ROLE) {
         _onlyExistingNodeOperator(nodeOperatorId);
         NodeOperator storage no = _nodeOperators[nodeOperatorId];
-        // TODO: consider moving to a helper function
         if (keyIndex >= no.totalDepositedKeys) {
             revert SigningKeysInvalidOffset();
         }
@@ -683,7 +681,6 @@ contract CSModule is
                 withdrawalInfo.nodeOperatorId
             ];
 
-            // TODO: consider moving to a helper function
             if (withdrawalInfo.keyIndex >= no.totalDepositedKeys) {
                 revert SigningKeysInvalidOffset();
             }

--- a/src/CSModule.sol
+++ b/src/CSModule.sol
@@ -40,10 +40,8 @@ contract CSModule is
     bytes32 public constant RESUME_ROLE = keccak256("RESUME_ROLE");
     bytes32 public constant STAKING_ROUTER_ROLE =
         keccak256("STAKING_ROUTER_ROLE");
-    // TODO: Revoke old role (REPORT_GENERAL_DELAYED_PENALTY_ROLE) and grant new role in the upgrade vote
     bytes32 public constant REPORT_GENERAL_DELAYED_PENALTY_ROLE =
         keccak256("REPORT_GENERAL_DELAYED_PENALTY_ROLE");
-    // TODO: Revoke old role (SETTLE_GENERAL_DELAYED_PENALTY_ROLE) and grant new role in the upgrade vote
     bytes32 public constant SETTLE_GENERAL_DELAYED_PENALTY_ROLE =
         keccak256("SETTLE_GENERAL_DELAYED_PENALTY_ROLE");
     bytes32 public constant VERIFIER_ROLE = keccak256("VERIFIER_ROLE");

--- a/src/CSModule.sol
+++ b/src/CSModule.sol
@@ -1287,7 +1287,6 @@ contract CSModule is
         return nodeOperatorId < _nodeOperatorsCount;
     }
 
-    /// TODO: Figure out if we can simplify this method by returning sequential IDs only.
     /// @inheritdoc IStakingModule
     function getNodeOperatorIds(
         uint256 offset,
@@ -1295,15 +1294,17 @@ contract CSModule is
     ) external view returns (uint256[] memory nodeOperatorIds) {
         uint256 nodeOperatorsCount = _nodeOperatorsCount;
         if (offset >= nodeOperatorsCount || limit == 0) {
-            return new uint256[](0);
+            return nodeOperatorIds;
         }
 
-        uint256 idsCount = limit < nodeOperatorsCount - offset
-            ? limit
-            : nodeOperatorsCount - offset;
-        nodeOperatorIds = new uint256[](idsCount);
-        for (uint256 i = 0; i < nodeOperatorIds.length; ++i) {
-            nodeOperatorIds[i] = offset + i;
+        unchecked {
+            uint256 idsCount = nodeOperatorsCount - offset;
+            if (idsCount > limit) idsCount = limit;
+
+            nodeOperatorIds = new uint256[](idsCount);
+            for (uint256 i; i < idsCount; ++i) {
+                nodeOperatorIds[i] = offset++;
+            }
         }
     }
 

--- a/src/CSModule.sol
+++ b/src/CSModule.sol
@@ -390,7 +390,6 @@ contract CSModule is
         STETH.transferShares(FEE_DISTRIBUTOR, totalShares);
     }
 
-    /// TODO: Figure out if we can remove the body of this function to save bytecode
     /// @inheritdoc IStakingModule
     function updateExitedValidatorsCount(
         bytes calldata nodeOperatorIds,

--- a/src/CSModule.sol
+++ b/src/CSModule.sol
@@ -113,7 +113,7 @@ contract CSModule is
         bytes32 moduleType,
         address lidoLocator,
         address parametersRegistry,
-        address _accounting,
+        address accounting,
         address exitPenalties
     ) {
         if (lidoLocator == address(0)) {
@@ -124,7 +124,7 @@ contract CSModule is
             revert ZeroParametersRegistryAddress();
         }
 
-        if (_accounting == address(0)) {
+        if (accounting == address(0)) {
             revert ZeroAccountingAddress();
         }
 
@@ -137,7 +137,7 @@ contract CSModule is
         STETH = IStETH(LIDO_LOCATOR.lido());
         PARAMETERS_REGISTRY = ICSParametersRegistry(parametersRegistry);
         QUEUE_LOWEST_PRIORITY = PARAMETERS_REGISTRY.QUEUE_LOWEST_PRIORITY();
-        ACCOUNTING = ICSAccounting(_accounting);
+        ACCOUNTING = ICSAccounting(accounting);
         EXIT_PENALTIES = ICSExitPenalties(exitPenalties);
         FEE_DISTRIBUTOR = address(ACCOUNTING.FEE_DISTRIBUTOR());
 
@@ -239,17 +239,17 @@ contract CSModule is
     ) external payable whenResumed {
         _checkCanAddKeys(nodeOperatorId, from);
 
-        ICSAccounting _accounting = accounting();
+        ICSAccounting accounting = _accounting();
 
         if (
             msg.value <
-            _accounting.getRequiredBondForNextKeys(nodeOperatorId, keysCount)
+            accounting.getRequiredBondForNextKeys(nodeOperatorId, keysCount)
         ) {
             revert InvalidAmount();
         }
 
         if (msg.value != 0) {
-            _accounting.depositETH{ value: msg.value }(from, nodeOperatorId);
+            accounting.depositETH{ value: msg.value }(from, nodeOperatorId);
         }
 
         _addKeysAndUpdateDepositableValidatorsCount(
@@ -271,15 +271,15 @@ contract CSModule is
     ) external whenResumed {
         _checkCanAddKeys(nodeOperatorId, from);
 
-        ICSAccounting _accounting = accounting();
+        ICSAccounting accounting = _accounting();
 
-        uint256 amount = _accounting.getRequiredBondForNextKeys(
+        uint256 amount = accounting.getRequiredBondForNextKeys(
             nodeOperatorId,
             keysCount
         );
 
         if (amount != 0) {
-            _accounting.depositStETH(from, nodeOperatorId, amount, permit);
+            accounting.depositStETH(from, nodeOperatorId, amount, permit);
         }
 
         _addKeysAndUpdateDepositableValidatorsCount(
@@ -301,15 +301,15 @@ contract CSModule is
     ) external whenResumed {
         _checkCanAddKeys(nodeOperatorId, from);
 
-        ICSAccounting _accounting = accounting();
+        ICSAccounting accounting = _accounting();
 
-        uint256 amount = _accounting.getRequiredBondForNextKeysWstETH(
+        uint256 amount = accounting.getRequiredBondForNextKeysWstETH(
             nodeOperatorId,
             keysCount
         );
 
         if (amount != 0) {
-            _accounting.depositWstETH(from, nodeOperatorId, amount, permit);
+            accounting.depositWstETH(from, nodeOperatorId, amount, permit);
         }
 
         _addKeysAndUpdateDepositableValidatorsCount(
@@ -541,7 +541,7 @@ contract CSModule is
         bool isFullyCharged = true;
 
         if (amountToCharge != 0) {
-            isFullyCharged = accounting().chargeFee(
+            isFullyCharged = _accounting().chargeFee(
                 nodeOperatorId,
                 amountToCharge
             );
@@ -735,7 +735,6 @@ contract CSModule is
                 penaltyMultiplier
             );
 
-            ICSAccounting _accounting = accounting();
             bool chargeWithdrawalRequestFee = false;
 
             uint256 penaltySum;
@@ -788,10 +787,11 @@ contract CSModule is
                 }
             }
 
+            ICSAccounting accounting = _accounting();
             bool isFullyCoveredByBond = true;
 
             if (feeSum > 0) {
-                isFullyCoveredByBond = _accounting.chargeFee(
+                isFullyCoveredByBond = accounting.chargeFee(
                     withdrawalInfo.nodeOperatorId,
                     feeSum
                 );
@@ -799,7 +799,7 @@ contract CSModule is
 
             if (penaltySum > 0) {
                 // We still call `penalize` even if there's no bond left, for the lock to be created.
-                isFullyCoveredByBond = _accounting.penalize(
+                isFullyCoveredByBond = accounting.penalize(
                     withdrawalInfo.nodeOperatorId,
                     penaltySum
                 );
@@ -1192,7 +1192,7 @@ contract CSModule is
     {
         _onlyExistingNodeOperator(nodeOperatorId);
         NodeOperator storage no = _nodeOperators[nodeOperatorId];
-        uint256 totalUnbondedKeys = accounting().getUnbondedKeysCountToEject(
+        uint256 totalUnbondedKeys = _accounting().getUnbondedKeysCountToEject(
             nodeOperatorId
         );
         uint256 totalNonDepositedKeys = no.totalAddedKeys -
@@ -1336,12 +1336,6 @@ contract CSModule is
             );
     }
 
-    /// TODO: Make this internal
-    /// @dev This function is used to get the accounting contract from immutables to save bytecode and for backwards compatibility
-    function accounting() public view returns (ICSAccounting) {
-        return ACCOUNTING;
-    }
-
     function supportsInterface(
         bytes4 interfaceId
     ) public view override(AccessControlEnumerableUpgradeable) returns (bool) {
@@ -1464,7 +1458,7 @@ contract CSModule is
 
         uint32 totalDepositedKeys = no.totalDepositedKeys;
         uint256 newCount = no.totalVettedKeys - totalDepositedKeys;
-        uint256 unbondedKeys = accounting().getUnbondedKeysCount(
+        uint256 unbondedKeys = _accounting().getUnbondedKeysCount(
             nodeOperatorId
         );
 
@@ -1680,7 +1674,12 @@ contract CSModule is
     function _getBondCurveId(
         uint256 nodeOperatorId
     ) internal view returns (uint256) {
-        return accounting().getBondCurveId(nodeOperatorId);
+        return _accounting().getBondCurveId(nodeOperatorId);
+    }
+
+    /// @dev This function is used to get the accounting contract from immutables to save bytecode.
+    function _accounting() internal view returns (ICSAccounting) {
+        return ACCOUNTING;
     }
 
     function _onlyRecoverer() internal view override {

--- a/src/CSStrikes.sol
+++ b/src/CSStrikes.sol
@@ -62,7 +62,7 @@ contract CSStrikes is
         }
 
         MODULE = ICSModule(module);
-        ACCOUNTING = MODULE.accounting();
+        ACCOUNTING = MODULE.ACCOUNTING();
         EXIT_PENALTIES = ICSExitPenalties(exitPenalties);
         ORACLE = oracle;
         PARAMETERS_REGISTRY = ICSParametersRegistry(parametersRegistry);

--- a/src/CuratedGate.sol
+++ b/src/CuratedGate.sol
@@ -60,7 +60,7 @@ contract CuratedGate is
         if (operatorsData == address(0)) revert ZeroOperatorsDataAddress();
         MODULE = ICuratedModule(module);
         MODULE_ID = moduleId;
-        ACCOUNTING = MODULE.accounting();
+        ACCOUNTING = MODULE.ACCOUNTING();
         OPERATORS_DATA = IOperatorsData(operatorsData);
         _disableInitializers();
     }

--- a/src/PermissionlessGate.sol
+++ b/src/PermissionlessGate.sol
@@ -36,7 +36,7 @@ contract PermissionlessGate is
         }
 
         MODULE = ICSModule(module);
-        CURVE_ID = MODULE.accounting().DEFAULT_BOND_CURVE_ID();
+        CURVE_ID = MODULE.ACCOUNTING().DEFAULT_BOND_CURVE_ID();
 
         _grantRole(DEFAULT_ADMIN_ROLE, admin);
     }

--- a/src/VettedGate.sol
+++ b/src/VettedGate.sol
@@ -72,7 +72,7 @@ contract VettedGate is
         }
 
         MODULE = ICSModule(module);
-        ACCOUNTING = ICSAccounting(MODULE.accounting());
+        ACCOUNTING = ICSAccounting(MODULE.ACCOUNTING());
 
         _disableInitializers();
     }

--- a/src/interfaces/ICSModule.sol
+++ b/src/interfaces/ICSModule.sol
@@ -191,9 +191,6 @@ interface ICSModule is
 
     function QUEUE_LOWEST_PRIORITY() external view returns (uint256);
 
-    /// @notice Returns the address of the accounting contract
-    function accounting() external view returns (ICSAccounting);
-
     /// @notice Pause creation of the Node Operators and keys upload for `duration` seconds.
     ///         Existing NO management and reward claims are still available.
     ///         To pause reward claims use pause method on CSAccounting

--- a/src/lib/ValidatorCountsReport.sol
+++ b/src/lib/ValidatorCountsReport.sol
@@ -9,16 +9,21 @@ library ValidatorCountsReport {
     function safeCountOperators(
         bytes calldata ids,
         bytes calldata counts
-    ) internal pure returns (uint256) {
-        if (
-            counts.length / 16 != ids.length / 8 ||
-            ids.length % 8 != 0 ||
-            counts.length % 16 != 0
-        ) {
-            revert InvalidReportData();
+    ) internal pure returns (uint256 len) {
+        bool ok;
+
+        assembly ("memory-safe") {
+            len := div(ids.length, 8)
+
+            ok := and(
+                eq(ids.length, mul(len, 8)),
+                eq(counts.length, mul(len, 16))
+            )
         }
 
-        return ids.length / 8;
+        if (!ok) {
+            revert InvalidReportData();
+        }
     }
 
     function next(

--- a/test/fork/integration/misc/ProxyUpgrades.sol
+++ b/test/fork/integration/misc/ProxyUpgrades.sol
@@ -26,7 +26,7 @@ contract ProxyUpgrades is Test, Utilities, DeploymentFixtures {
             moduleType: "CSMv2",
             lidoLocator: address(module.LIDO_LOCATOR()),
             parametersRegistry: address(module.PARAMETERS_REGISTRY()),
-            _accounting: address(module.ACCOUNTING()),
+            accounting: address(module.ACCOUNTING()),
             exitPenalties: address(module.EXIT_PENALTIES())
         });
         vm.prank(proxy.proxy__getAdmin());
@@ -40,7 +40,7 @@ contract ProxyUpgrades is Test, Utilities, DeploymentFixtures {
             moduleType: "CSMv2",
             lidoLocator: address(module.LIDO_LOCATOR()),
             parametersRegistry: address(module.PARAMETERS_REGISTRY()),
-            _accounting: address(module.ACCOUNTING()),
+            accounting: address(module.ACCOUNTING()),
             exitPenalties: address(module.EXIT_PENALTIES())
         });
         address contractAdmin = module.getRoleMember(

--- a/test/unit/CSModule.t.sol
+++ b/test/unit/CSModule.t.sol
@@ -48,7 +48,7 @@ contract CSMCommon is ModuleFixtures {
             moduleType: "community-staking-module",
             lidoLocator: address(locator),
             parametersRegistry: address(parametersRegistry),
-            _accounting: address(accounting),
+            accounting: address(accounting),
             exitPenalties: address(exitPenalties)
         });
 
@@ -115,7 +115,7 @@ contract CSMCommonNoRoles is ModuleFixtures {
             moduleType: "community-staking-module",
             lidoLocator: address(locator),
             parametersRegistry: address(parametersRegistry),
-            _accounting: address(accounting),
+            accounting: address(accounting),
             exitPenalties: address(exitPenalties)
         });
 
@@ -146,7 +146,7 @@ contract CsmInitialize is CSMCommon {
             moduleType: "community-staking-module",
             lidoLocator: address(locator),
             parametersRegistry: address(parametersRegistry),
-            _accounting: address(accounting),
+            accounting: address(accounting),
             exitPenalties: address(exitPenalties)
         });
         assertEq(csm.getType(), "community-staking-module");
@@ -156,7 +156,6 @@ contract CsmInitialize is CSMCommon {
             address(parametersRegistry)
         );
         assertEq(address(csm.ACCOUNTING()), address(accounting));
-        assertEq(address(csm.accounting()), address(accounting));
         assertEq(address(csm.EXIT_PENALTIES()), address(exitPenalties));
     }
 
@@ -166,7 +165,7 @@ contract CsmInitialize is CSMCommon {
             moduleType: "community-staking-module",
             lidoLocator: address(0),
             parametersRegistry: address(parametersRegistry),
-            _accounting: address(accounting),
+            accounting: address(accounting),
             exitPenalties: address(exitPenalties)
         });
     }
@@ -179,7 +178,7 @@ contract CsmInitialize is CSMCommon {
             moduleType: "community-staking-module",
             lidoLocator: address(locator),
             parametersRegistry: address(0),
-            _accounting: address(accounting),
+            accounting: address(accounting),
             exitPenalties: address(exitPenalties)
         });
     }
@@ -190,7 +189,7 @@ contract CsmInitialize is CSMCommon {
             moduleType: "community-staking-module",
             lidoLocator: address(locator),
             parametersRegistry: address(parametersRegistry),
-            _accounting: address(0),
+            accounting: address(0),
             exitPenalties: address(exitPenalties)
         });
     }
@@ -201,7 +200,7 @@ contract CsmInitialize is CSMCommon {
             moduleType: "community-staking-module",
             lidoLocator: address(locator),
             parametersRegistry: address(parametersRegistry),
-            _accounting: address(accounting),
+            accounting: address(accounting),
             exitPenalties: address(0)
         });
     }
@@ -211,7 +210,7 @@ contract CsmInitialize is CSMCommon {
             moduleType: "community-staking-module",
             lidoLocator: address(locator),
             parametersRegistry: address(parametersRegistry),
-            _accounting: address(accounting),
+            accounting: address(accounting),
             exitPenalties: address(exitPenalties)
         });
 
@@ -224,7 +223,7 @@ contract CsmInitialize is CSMCommon {
             moduleType: "community-staking-module",
             lidoLocator: address(locator),
             parametersRegistry: address(parametersRegistry),
-            _accounting: address(accounting),
+            accounting: address(accounting),
             exitPenalties: address(exitPenalties)
         });
 
@@ -241,7 +240,7 @@ contract CsmInitialize is CSMCommon {
             moduleType: "community-staking-module",
             lidoLocator: address(locator),
             parametersRegistry: address(parametersRegistry),
-            _accounting: address(accounting),
+            accounting: address(accounting),
             exitPenalties: address(exitPenalties)
         });
 
@@ -255,7 +254,7 @@ contract CsmInitialize is CSMCommon {
             moduleType: "community-staking-module",
             lidoLocator: address(locator),
             parametersRegistry: address(parametersRegistry),
-            _accounting: address(accounting),
+            accounting: address(accounting),
             exitPenalties: address(exitPenalties)
         });
         _enableInitializers(address(csm));

--- a/test/unit/CSModule.t.sol
+++ b/test/unit/CSModule.t.sol
@@ -272,6 +272,11 @@ contract CSMCreateNodeOperator is ModuleCreateNodeOperator, CSMCommon {}
 
 contract CSMAddValidatorKeys is ModuleAddValidatorKeys, CSMCommon {}
 
+contract CSMAddValidatorKeysViaGate is
+    ModuleAddValidatorKeysViaGate,
+    CSMCommon
+{}
+
 contract CSMAddValidatorKeysNegative is
     ModuleAddValidatorKeysNegative,
     CSMCommon

--- a/test/unit/CuratedModule.t.sol
+++ b/test/unit/CuratedModule.t.sol
@@ -164,7 +164,6 @@ contract CuratedInitialize is CuratedCommon {
             address(parametersRegistry)
         );
         assertEq(address(module.ACCOUNTING()), address(accounting));
-        assertEq(address(module.accounting()), address(accounting));
         assertEq(address(module.EXIT_PENALTIES()), address(exitPenalties));
     }
 

--- a/test/unit/CuratedModule.t.sol
+++ b/test/unit/CuratedModule.t.sol
@@ -278,7 +278,14 @@ contract CuratedPauseAffectingTest is ModulePauseAffectingTest, CuratedCommon {}
 
 contract CuratedCreateNodeOperator is ModuleCreateNodeOperator, CuratedCommon {}
 
-//contract CuratedAddValidatorKeys is ModuleAddValidatorKeys, CuratedCommon {}
+// contract CuratedAddValidatorKeys is ModuleAddValidatorKeys, CuratedCommon {}
+// contract CuratedAddValidatorKeysViaGate is
+//     ModuleAddValidatorKeysViaGate,
+//     CuratedCommon
+// {
+//
+// }
+
 contract CuratedAddValidatorKeysNegative is
     ModuleAddValidatorKeysNegative,
     CuratedCommon
@@ -286,7 +293,7 @@ contract CuratedAddValidatorKeysNegative is
 
 }
 
-//contract CuratedObtainDepositData is ModuleObtainDepositData, CuratedCommon {}
+// contract CuratedObtainDepositData is ModuleObtainDepositData, CuratedCommon {}
 contract CuratedProposeNodeOperatorManagerAddressChange is
     ModuleProposeNodeOperatorManagerAddressChange,
     CuratedCommon

--- a/test/unit/ModuleAbstract.t.sol
+++ b/test/unit/ModuleAbstract.t.sol
@@ -7353,7 +7353,7 @@ abstract contract ModuleAccessControl is ModuleFixtures {
             moduleType: "community-staking-module",
             lidoLocator: address(locator),
             parametersRegistry: address(parametersRegistry),
-            _accounting: address(accounting),
+            accounting: address(accounting),
             exitPenalties: address(exitPenalties)
         });
         _enableInitializers(address(csm));
@@ -7374,7 +7374,7 @@ abstract contract ModuleAccessControl is ModuleFixtures {
             moduleType: "community-staking-module",
             lidoLocator: address(locator),
             parametersRegistry: address(parametersRegistry),
-            _accounting: address(accounting),
+            accounting: address(accounting),
             exitPenalties: address(exitPenalties)
         });
         bytes32 role = csm.DEFAULT_ADMIN_ROLE();
@@ -8749,7 +8749,7 @@ abstract contract ModuleCreateNodeOperators is ModuleFixtures {
                 }),
                 address(0)
             );
-            uint256 amount = module.accounting().getRequiredBondForNextKeys(
+            uint256 amount = module.ACCOUNTING().getRequiredBondForNextKeys(
                 noId,
                 keysCount
             );

--- a/test/unit/ModuleAbstract.t.sol
+++ b/test/unit/ModuleAbstract.t.sol
@@ -21,6 +21,8 @@ import { ERC20Testable } from "../helpers/ERCTestable.sol";
 import { PausableUntil } from "src/lib/utils/PausableUntil.sol";
 import { ICSAccounting } from "src/interfaces/ICSAccounting.sol";
 import { IStakingModule } from "src/interfaces/IStakingModule.sol";
+import { ILidoLocator } from "src/interfaces/ILidoLocator.sol";
+import { IWithdrawalQueue } from "src/interfaces/IWithdrawalQueue.sol";
 import { SigningKeys } from "src/lib/SigningKeys.sol";
 import { INOAddresses } from "src/lib/NOAddresses.sol";
 import { IGeneralPenalty } from "src/lib/GeneralPenaltyLib.sol";
@@ -797,103 +799,6 @@ abstract contract ModuleAddValidatorKeys is ModuleFixtures {
         assertEq(no.depositableValidatorsCount, 0);
     }
 
-    function test_AddValidatorKeysWstETH_createNodeOperatorRole()
-        public
-        assertInvariants
-        brutalizeMemory
-    {
-        module.grantRole(module.CREATE_NODE_OPERATOR_ROLE(), stranger);
-
-        vm.prank(stranger);
-        uint256 noId = module.createNodeOperator(
-            nodeOperator,
-            NodeOperatorManagementProperties({
-                managerAddress: address(0),
-                rewardAddress: address(0),
-                extendedManagerPermissions: false
-            }),
-            address(0)
-        );
-        uint256 toWrap = BOND_SIZE + 1 wei;
-        vm.deal(nodeOperator, toWrap);
-        vm.startPrank(nodeOperator);
-        stETH.submit{ value: toWrap }(address(0));
-        stETH.approve(address(wstETH), UINT256_MAX);
-        wstETH.wrap(toWrap);
-        vm.stopPrank();
-        (bytes memory keys, bytes memory signatures) = keysSignatures(1, 1);
-        uint256 nonce = module.getNonce();
-
-        vm.prank(stranger);
-        module.addValidatorKeysWstETH(
-            nodeOperator,
-            noId,
-            1,
-            keys,
-            signatures,
-            ICSAccounting.PermitInput({
-                value: 0,
-                deadline: 0,
-                v: 0,
-                r: 0,
-                s: 0
-            })
-        );
-        assertEq(module.getNonce(), nonce + 1);
-    }
-
-    function test_AddValidatorKeysWstETH_createNodeOperatorRole_MultipleOperators()
-        public
-        assertInvariants
-        brutalizeMemory
-    {
-        module.grantRole(module.CREATE_NODE_OPERATOR_ROLE(), stranger);
-
-        uint256[] memory ids = new uint256[](3);
-        for (uint256 i; i < ids.length; i++) {
-            vm.prank(stranger);
-            ids[i] = module.createNodeOperator(
-                nodeOperator,
-                NodeOperatorManagementProperties({
-                    managerAddress: address(0),
-                    rewardAddress: address(0),
-                    extendedManagerPermissions: false
-                }),
-                address(0)
-            );
-        }
-        shuffle(ids);
-
-        for (uint256 i; i < ids.length; i++) {
-            uint256 toWrap = BOND_SIZE + 2 wei;
-            vm.deal(nodeOperator, toWrap);
-            vm.startPrank(nodeOperator);
-            stETH.submit{ value: toWrap }(address(0));
-            stETH.approve(address(wstETH), UINT256_MAX);
-            wstETH.wrap(toWrap);
-            vm.stopPrank();
-            (bytes memory keys, bytes memory signatures) = keysSignatures(1, 1);
-            uint256 nonce = module.getNonce();
-
-            vm.prank(stranger);
-            module.addValidatorKeysWstETH(
-                nodeOperator,
-                ids[i],
-                1,
-                keys,
-                signatures,
-                ICSAccounting.PermitInput({
-                    value: 0,
-                    deadline: 0,
-                    v: 0,
-                    r: 0,
-                    s: 0
-                })
-            );
-            assertEq(module.getNonce(), nonce + 1);
-        }
-    }
-
     function test_AddValidatorKeysWstETH_withPermit()
         public
         assertInvariants
@@ -1059,96 +964,6 @@ abstract contract ModuleAddValidatorKeys is ModuleFixtures {
         assertEq(no.depositableValidatorsCount, 0);
     }
 
-    function test_AddValidatorKeysStETH_createNodeOperatorRole()
-        public
-        assertInvariants
-        brutalizeMemory
-    {
-        module.grantRole(module.CREATE_NODE_OPERATOR_ROLE(), stranger);
-
-        vm.prank(stranger);
-        uint256 noId = module.createNodeOperator(
-            nodeOperator,
-            NodeOperatorManagementProperties({
-                managerAddress: address(0),
-                rewardAddress: address(0),
-                extendedManagerPermissions: false
-            }),
-            address(0)
-        );
-        (bytes memory keys, bytes memory signatures) = keysSignatures(1, 1);
-
-        vm.deal(nodeOperator, BOND_SIZE + 1 wei);
-        vm.prank(nodeOperator);
-        stETH.submit{ value: BOND_SIZE + 1 wei }(address(0));
-        uint256 nonce = module.getNonce();
-
-        vm.prank(stranger);
-        module.addValidatorKeysStETH(
-            nodeOperator,
-            noId,
-            1,
-            keys,
-            signatures,
-            ICSAccounting.PermitInput({
-                value: BOND_SIZE,
-                deadline: 0,
-                v: 0,
-                r: 0,
-                s: 0
-            })
-        );
-        assertEq(module.getNonce(), nonce + 1);
-    }
-
-    function test_AddValidatorKeysStETH_createNodeOperatorRole_MultipleOperators()
-        public
-        assertInvariants
-        brutalizeMemory
-    {
-        module.grantRole(module.CREATE_NODE_OPERATOR_ROLE(), stranger);
-
-        uint256[] memory ids = new uint256[](3);
-        for (uint256 i; i < ids.length; i++) {
-            vm.prank(stranger);
-            ids[i] = module.createNodeOperator(
-                nodeOperator,
-                NodeOperatorManagementProperties({
-                    managerAddress: address(0),
-                    rewardAddress: address(0),
-                    extendedManagerPermissions: false
-                }),
-                address(0)
-            );
-        }
-        shuffle(ids);
-
-        for (uint256 i; i < ids.length; i++) {
-            (bytes memory keys, bytes memory signatures) = keysSignatures(1, 1);
-            vm.deal(nodeOperator, BOND_SIZE + 1 wei);
-            vm.prank(nodeOperator);
-            stETH.submit{ value: BOND_SIZE + 1 wei }(address(0));
-            uint256 nonce = module.getNonce();
-
-            vm.prank(stranger);
-            module.addValidatorKeysStETH(
-                nodeOperator,
-                ids[i],
-                1,
-                keys,
-                signatures,
-                ICSAccounting.PermitInput({
-                    value: BOND_SIZE,
-                    deadline: 0,
-                    v: 0,
-                    r: 0,
-                    s: 0
-                })
-            );
-            assertEq(module.getNonce(), nonce + 1);
-        }
-    }
-
     function test_AddValidatorKeysStETH_withPermit()
         public
         assertInvariants
@@ -1293,44 +1108,6 @@ abstract contract ModuleAddValidatorKeys is ModuleFixtures {
         assertEq(no.depositableValidatorsCount, 0);
     }
 
-    function test_AddValidatorKeysETH_createNodeOperatorRole_MultipleOperators()
-        public
-    {
-        module.grantRole(module.CREATE_NODE_OPERATOR_ROLE(), stranger);
-
-        uint256[] memory ids = new uint256[](3);
-        for (uint256 i; i < ids.length; i++) {
-            vm.prank(stranger);
-            ids[i] = module.createNodeOperator(
-                stranger,
-                NodeOperatorManagementProperties({
-                    managerAddress: address(0),
-                    rewardAddress: address(0),
-                    extendedManagerPermissions: false
-                }),
-                address(0)
-            );
-        }
-        shuffle(ids);
-
-        for (uint256 i; i < ids.length; i++) {
-            (bytes memory keys, bytes memory signatures) = keysSignatures(1, 1);
-            uint256 required = accounting.getRequiredBondForNextKeys(ids[i], 1);
-            vm.deal(stranger, required);
-            uint256 nonce = module.getNonce();
-
-            vm.prank(stranger);
-            module.addValidatorKeysETH{ value: required }(
-                nodeOperator,
-                ids[i],
-                1,
-                keys,
-                signatures
-            );
-            assertEq(module.getNonce(), nonce + 1);
-        }
-    }
-
     function test_AddValidatorKeysETH_withMoreEthThanRequired()
         public
         assertInvariants
@@ -1360,18 +1137,459 @@ abstract contract ModuleAddValidatorKeys is ModuleFixtures {
         );
         assertEq(module.getNonce(), nonce + 1);
     }
+}
 
-    function test_AddValidatorKeysETH_RevertWhenCalledFromAnotherExtension()
+contract GateWithTestCapabilities is Test, Utilities {
+    ICSModule private module;
+    ICSAccounting private accounting;
+
+    WstETHMock private wstETH;
+    LidoMock private stETH;
+
+    constructor(ICSModule _module) {
+        module = _module;
+        accounting = module.ACCOUNTING();
+        ILidoLocator locator = module.LIDO_LOCATOR();
+        stETH = LidoMock(locator.lido());
+        wstETH = WstETHMock(
+            IWithdrawalQueue(locator.withdrawalQueue()).WSTETH()
+        );
+        stETH.approve(address(wstETH), UINT256_MAX);
+    }
+
+    function createNodeOperatorWithKeysWithETHBond(
+        address owner,
+        uint256 keyCount,
+        bytes memory keys,
+        bytes memory sigs
+    ) external returns (uint256 noId) {
+        noId = module.createNodeOperator({
+            from: owner,
+            managementProperties: NodeOperatorManagementProperties({
+                managerAddress: owner,
+                rewardAddress: owner,
+                extendedManagerPermissions: false
+            }),
+            referrer: address(0)
+        });
+
+        uint256 required = accounting.getRequiredBondForNextKeys(
+            noId,
+            keyCount
+        );
+        vm.deal(address(this), required);
+
+        uint256 nonce = module.getNonce();
+
+        module.addValidatorKeysETH{ value: required }(
+            owner,
+            noId,
+            keyCount,
+            keys,
+            sigs
+        );
+
+        assertEq(module.getNonce(), ++nonce);
+    }
+
+    function batchCreateNodeOperatorWithKeysWithETHBond(
+        address owner,
+        uint256 operatorCount,
+        uint256 operatorKeyCount,
+        bytes memory keys,
+        bytes memory sigs
+    ) external returns (uint256[] memory ids) {
+        ids = new uint256[](operatorCount);
+        for (uint256 i; i < ids.length; i++) {
+            ids[i] = module.createNodeOperator(
+                owner,
+                NodeOperatorManagementProperties({
+                    managerAddress: owner,
+                    rewardAddress: owner,
+                    extendedManagerPermissions: false
+                }),
+                address(0)
+            );
+        }
+        uint256 firstId = ids[0];
+        shuffle(ids);
+
+        uint256 nonce = module.getNonce();
+
+        for (uint256 i; i < ids.length; i++) {
+            bytes memory _keys = slice(
+                keys,
+                ids[i] - firstId * 48,
+                operatorKeyCount * 48
+            );
+            bytes memory _sigs = slice(
+                sigs,
+                ids[i] - firstId * 96,
+                operatorKeyCount * 96
+            );
+
+            uint256 required = accounting.getRequiredBondForNextKeys(
+                ids[i],
+                operatorKeyCount
+            );
+            vm.deal(address(this), required);
+
+            module.addValidatorKeysETH{ value: required }(
+                owner,
+                ids[i],
+                operatorKeyCount,
+                _keys,
+                _sigs
+            );
+
+            assertEq(module.getNonce(), ++nonce);
+        }
+    }
+
+    function createNodeOperatorWithKeysWithStETHBond(
+        address owner,
+        uint256 keyCount,
+        bytes memory keys,
+        bytes memory sigs
+    ) external returns (uint256 noId) {
+        noId = module.createNodeOperator({
+            from: owner,
+            managementProperties: NodeOperatorManagementProperties({
+                managerAddress: owner,
+                rewardAddress: owner,
+                extendedManagerPermissions: false
+            }),
+            referrer: address(0)
+        });
+
+        uint256 required = accounting.getRequiredBondForNextKeys(
+            noId,
+            keyCount
+        );
+        uint256 toWrap = required + 1 wei;
+        vm.deal(address(this), toWrap);
+        stETH.submit{ value: toWrap }(address(0));
+
+        uint256 nonce = module.getNonce();
+
+        module.addValidatorKeysStETH(
+            owner,
+            noId,
+            keyCount,
+            keys,
+            sigs,
+            ICSAccounting.PermitInput({
+                value: 0,
+                deadline: 0,
+                v: 0,
+                r: 0,
+                s: 0
+            })
+        );
+
+        assertEq(module.getNonce(), ++nonce);
+    }
+
+    function batchCreateNodeOperatorWithKeysWithStETHBond(
+        address owner,
+        uint256 operatorCount,
+        uint256 operatorKeyCount,
+        bytes memory keys,
+        bytes memory sigs
+    ) external returns (uint256[] memory ids) {
+        ids = new uint256[](operatorCount);
+        for (uint256 i; i < ids.length; i++) {
+            ids[i] = module.createNodeOperator(
+                owner,
+                NodeOperatorManagementProperties({
+                    managerAddress: owner,
+                    rewardAddress: owner,
+                    extendedManagerPermissions: false
+                }),
+                address(0)
+            );
+        }
+        uint256 firstId = ids[0];
+        shuffle(ids);
+
+        uint256 nonce = module.getNonce();
+
+        for (uint256 i; i < ids.length; i++) {
+            bytes memory _keys = slice(
+                keys,
+                ids[i] - firstId * 48,
+                operatorKeyCount * 48
+            );
+            bytes memory _sigs = slice(
+                sigs,
+                ids[i] - firstId * 96,
+                operatorKeyCount * 96
+            );
+
+            uint256 required = accounting.getRequiredBondForNextKeys(
+                ids[i],
+                operatorKeyCount
+            );
+            uint256 ethAmountToSend = required + 1 wei;
+            vm.deal(address(this), ethAmountToSend);
+            stETH.submit{ value: ethAmountToSend }(address(0));
+
+            module.addValidatorKeysStETH(
+                owner,
+                ids[i],
+                operatorKeyCount,
+                _keys,
+                _sigs,
+                ICSAccounting.PermitInput({
+                    value: 0,
+                    deadline: 0,
+                    v: 0,
+                    r: 0,
+                    s: 0
+                })
+            );
+
+            assertEq(module.getNonce(), ++nonce);
+        }
+    }
+
+    function createNodeOperatorWithKeysWithWstETHBond(
+        address owner,
+        uint256 keyCount,
+        bytes memory keys,
+        bytes memory sigs
+    ) external returns (uint256 noId) {
+        noId = module.createNodeOperator({
+            from: owner,
+            managementProperties: NodeOperatorManagementProperties({
+                managerAddress: owner,
+                rewardAddress: owner,
+                extendedManagerPermissions: false
+            }),
+            referrer: address(0)
+        });
+
+        uint256 required = accounting.getRequiredBondForNextKeys(
+            noId,
+            keyCount
+        );
+        uint256 toWrap = required + 1 wei;
+        vm.deal(address(this), toWrap);
+
+        stETH.submit{ value: toWrap }(address(0));
+        wstETH.wrap(toWrap);
+
+        module.addValidatorKeysWstETH(
+            owner,
+            noId,
+            keyCount,
+            keys,
+            sigs,
+            ICSAccounting.PermitInput({
+                value: 0,
+                deadline: 0,
+                v: 0,
+                r: 0,
+                s: 0
+            })
+        );
+    }
+
+    function batchCreateNodeOperatorWithKeysWithWstETHBond(
+        address owner,
+        uint256 operatorCount,
+        uint256 operatorKeyCount,
+        bytes memory keys,
+        bytes memory sigs
+    ) external returns (uint256[] memory ids) {
+        ids = new uint256[](operatorCount);
+        for (uint256 i; i < ids.length; i++) {
+            ids[i] = module.createNodeOperator(
+                owner,
+                NodeOperatorManagementProperties({
+                    managerAddress: owner,
+                    rewardAddress: owner,
+                    extendedManagerPermissions: false
+                }),
+                address(0)
+            );
+        }
+        uint256 firstId = ids[0];
+        shuffle(ids);
+
+        uint256 nonce = module.getNonce();
+
+        for (uint256 i; i < ids.length; i++) {
+            bytes memory _keys = slice(
+                keys,
+                ids[i] - firstId * 48,
+                operatorKeyCount * 48
+            );
+            bytes memory _sigs = slice(
+                sigs,
+                ids[i] - firstId * 96,
+                operatorKeyCount * 96
+            );
+
+            uint256 required = accounting.getRequiredBondForNextKeys(
+                ids[i],
+                operatorKeyCount
+            );
+
+            uint256 toWrap = required + 1 wei;
+            vm.deal(address(this), toWrap);
+            stETH.submit{ value: toWrap }(address(0));
+            wstETH.wrap(toWrap);
+
+            module.addValidatorKeysWstETH(
+                owner,
+                ids[i],
+                operatorKeyCount,
+                _keys,
+                _sigs,
+                ICSAccounting.PermitInput({
+                    value: 0,
+                    deadline: 0,
+                    v: 0,
+                    r: 0,
+                    s: 0
+                })
+            );
+
+            assertEq(module.getNonce(), ++nonce);
+        }
+    }
+}
+
+abstract contract ModuleAddValidatorKeysViaGate is ModuleFixtures {
+    GateWithTestCapabilities internal gate;
+
+    // Using a modifier to avoid overriding setUp.
+    modifier withGate() {
+        gate = new GateWithTestCapabilities(module);
+        module.grantRole(module.CREATE_NODE_OPERATOR_ROLE(), address(gate));
+        _;
+    }
+
+    function test_GateAddValidatorKeysETH()
+        public
+        assertInvariants
+        brutalizeMemory
+        withGate
+    {
+        uint256 keyCount = 3;
+        (bytes memory keys, bytes memory sigs) = keysSignatures(keyCount);
+        gate.createNodeOperatorWithKeysWithETHBond(
+            nodeOperator,
+            keyCount,
+            keys,
+            sigs
+        );
+    }
+
+    function test_GateAddValidatorKeysETH_MultipleOperators()
+        public
+        assertInvariants
+        brutalizeMemory
+        withGate
+    {
+        uint256 operatorCount = 3;
+        uint256 operatorKeyCount = 1;
+        uint256 keyCount = operatorCount * operatorKeyCount;
+
+        (bytes memory keys, bytes memory sigs) = keysSignatures(keyCount);
+        gate.batchCreateNodeOperatorWithKeysWithETHBond(
+            nodeOperator,
+            operatorCount,
+            operatorKeyCount,
+            keys,
+            sigs
+        );
+    }
+
+    function test_GateAddValidatorKeysStETH()
+        public
+        assertInvariants
+        brutalizeMemory
+        withGate
+    {
+        uint256 keyCount = 3;
+        (bytes memory keys, bytes memory sigs) = keysSignatures(keyCount);
+        gate.createNodeOperatorWithKeysWithStETHBond(
+            nodeOperator,
+            keyCount,
+            keys,
+            sigs
+        );
+    }
+
+    function test_GateAddValidatorKeysStETH_MultipleOperators()
+        public
+        assertInvariants
+        brutalizeMemory
+        withGate
+    {
+        uint256 operatorCount = 3;
+        uint256 operatorKeyCount = 1;
+        uint256 keyCount = operatorCount * operatorKeyCount;
+
+        (bytes memory keys, bytes memory sigs) = keysSignatures(keyCount);
+        gate.batchCreateNodeOperatorWithKeysWithStETHBond(
+            nodeOperator,
+            operatorCount,
+            operatorKeyCount,
+            keys,
+            sigs
+        );
+    }
+
+    function test_GateAddValidatorKeysWstETH()
+        public
+        assertInvariants
+        brutalizeMemory
+        withGate
+    {
+        uint256 keyCount = 3;
+        (bytes memory keys, bytes memory sigs) = keysSignatures(keyCount);
+        gate.createNodeOperatorWithKeysWithWstETHBond(
+            nodeOperator,
+            keyCount,
+            keys,
+            sigs
+        );
+    }
+
+    function test_AddValidatorKeysWstETH_MultipleOperators()
+        public
+        assertInvariants
+        brutalizeMemory
+        withGate
+    {
+        uint256 operatorCount = 3;
+        uint256 operatorKeyCount = 1;
+        uint256 keyCount = operatorCount * operatorKeyCount;
+
+        (bytes memory keys, bytes memory sigs) = keysSignatures(keyCount);
+        gate.batchCreateNodeOperatorWithKeysWithWstETHBond(
+            nodeOperator,
+            operatorCount,
+            operatorKeyCount,
+            keys,
+            sigs
+        );
+    }
+
+    function test_AddValidatorKeysETH_RevertWhenCalledFromAnotherGate()
         public
         assertInvariants
     {
-        address extensionOne = nextAddress("EXTENSION_ONE");
-        address extensionTwo = nextAddress("EXTENSION_TWO");
+        address gateOne = nextAddress("GATE_ONE");
+        address gateTwo = nextAddress("GATE_TWO");
 
-        module.grantRole(module.CREATE_NODE_OPERATOR_ROLE(), extensionOne);
-        module.grantRole(module.CREATE_NODE_OPERATOR_ROLE(), extensionTwo);
+        module.grantRole(module.CREATE_NODE_OPERATOR_ROLE(), gateOne);
+        module.grantRole(module.CREATE_NODE_OPERATOR_ROLE(), gateTwo);
 
-        vm.prank(extensionOne);
+        vm.prank(gateOne);
         uint256 noId = module.createNodeOperator({
             from: nodeOperator,
             managementProperties: NodeOperatorManagementProperties({
@@ -1384,12 +1602,12 @@ abstract contract ModuleAddValidatorKeys is ModuleFixtures {
 
         (bytes memory keys, bytes memory signatures) = keysSignatures(1, 1);
         uint256 required = accounting.getRequiredBondForNextKeys(noId, 1);
-        vm.deal(extensionTwo, required);
+        vm.deal(gateTwo, required);
 
         {
             vm.expectRevert(ICSModule.CannotAddKeys.selector);
 
-            vm.prank(extensionTwo);
+            vm.prank(gateTwo);
             module.addValidatorKeysETH{ value: required }(
                 nodeOperator,
                 noId,
@@ -1400,17 +1618,17 @@ abstract contract ModuleAddValidatorKeys is ModuleFixtures {
         }
     }
 
-    function test_AddValidatorKeysStETH_RevertWhenCalledFromAnotherExtension()
+    function test_AddValidatorKeysStETH_RevertWhenCalledFromAnotherGate()
         public
         assertInvariants
     {
-        address extensionOne = nextAddress("EXTENSION_ONE");
-        address extensionTwo = nextAddress("EXTENSION_TWO");
+        address gateOne = nextAddress("GATE_ONE");
+        address gateTwo = nextAddress("GATE_TWO");
 
-        module.grantRole(module.CREATE_NODE_OPERATOR_ROLE(), extensionOne);
-        module.grantRole(module.CREATE_NODE_OPERATOR_ROLE(), extensionTwo);
+        module.grantRole(module.CREATE_NODE_OPERATOR_ROLE(), gateOne);
+        module.grantRole(module.CREATE_NODE_OPERATOR_ROLE(), gateTwo);
 
-        vm.prank(extensionOne);
+        vm.prank(gateOne);
         uint256 noId = module.createNodeOperator({
             from: nodeOperator,
             managementProperties: NodeOperatorManagementProperties({
@@ -1425,7 +1643,7 @@ abstract contract ModuleAddValidatorKeys is ModuleFixtures {
         {
             vm.expectRevert(ICSModule.CannotAddKeys.selector);
 
-            vm.prank(extensionTwo);
+            vm.prank(gateTwo);
             module.addValidatorKeysStETH(
                 nodeOperator,
                 noId,
@@ -1443,17 +1661,17 @@ abstract contract ModuleAddValidatorKeys is ModuleFixtures {
         }
     }
 
-    function test_AddValidatorKeysWstETH_RevertWhenCalledFromAnotherExtension()
+    function test_AddValidatorKeysWstETH_RevertWhenCalledFromAnotherGate()
         public
         assertInvariants
     {
-        address extensionOne = nextAddress("EXTENSION_ONE");
-        address extensionTwo = nextAddress("EXTENSION_TWO");
+        address gateOne = nextAddress("GATE_ONE");
+        address gateTwo = nextAddress("GATE_TWO");
 
-        module.grantRole(module.CREATE_NODE_OPERATOR_ROLE(), extensionOne);
-        module.grantRole(module.CREATE_NODE_OPERATOR_ROLE(), extensionTwo);
+        module.grantRole(module.CREATE_NODE_OPERATOR_ROLE(), gateOne);
+        module.grantRole(module.CREATE_NODE_OPERATOR_ROLE(), gateTwo);
 
-        vm.prank(extensionOne);
+        vm.prank(gateOne);
         uint256 noId = module.createNodeOperator({
             from: nodeOperator,
             managementProperties: NodeOperatorManagementProperties({
@@ -1468,7 +1686,7 @@ abstract contract ModuleAddValidatorKeys is ModuleFixtures {
         {
             vm.expectRevert(ICSModule.CannotAddKeys.selector);
 
-            vm.prank(extensionTwo);
+            vm.prank(gateTwo);
             module.addValidatorKeysWstETH(
                 nodeOperator,
                 noId,
@@ -1486,95 +1704,53 @@ abstract contract ModuleAddValidatorKeys is ModuleFixtures {
         }
     }
 
-    function test_AddValidatorKeysETH_RevertWhenCalledTwice()
+    function test_GateAddValidatorKeysETH_RevertWhenCalledTwice()
         public
         assertInvariants
+        withGate
     {
-        module.grantRole(module.CREATE_NODE_OPERATOR_ROLE(), stranger);
-
-        vm.prank(stranger);
-        uint256 noId = module.createNodeOperator({
-            from: nodeOperator,
-            managementProperties: NodeOperatorManagementProperties({
-                managerAddress: nodeOperator,
-                rewardAddress: nodeOperator,
-                extendedManagerPermissions: false
-            }),
-            referrer: address(0)
-        });
-
-        (bytes memory keys, bytes memory signatures) = keysSignatures(1, 1);
-        uint256 required = accounting.getRequiredBondForNextKeys(noId, 1);
-        vm.deal(stranger, required);
-
-        vm.prank(stranger);
-        module.addValidatorKeysETH{ value: required }(
+        (bytes memory keys, bytes memory sigs) = keysSignatures(1);
+        uint256 noId = gate.createNodeOperatorWithKeysWithETHBond(
             nodeOperator,
-            noId,
             1,
             keys,
-            signatures
+            sigs
         );
+
+        (keys, sigs) = keysSignatures(1, 1);
 
         {
             vm.expectRevert(ICSModule.CannotAddKeys.selector);
 
-            vm.prank(stranger);
-            module.addValidatorKeysETH(nodeOperator, noId, 1, keys, signatures);
+            vm.prank(address(gate));
+            module.addValidatorKeysETH(nodeOperator, noId, 1, keys, sigs);
         }
     }
 
-    function test_AddValidatorKeysStETH_RevertWhenCalledTwice()
+    function test_GateAddValidatorKeysStETH_RevertWhenCalledTwice()
         public
         assertInvariants
+        withGate
     {
-        module.grantRole(module.CREATE_NODE_OPERATOR_ROLE(), stranger);
-
-        vm.prank(stranger);
-        uint256 noId = module.createNodeOperator({
-            from: nodeOperator,
-            managementProperties: NodeOperatorManagementProperties({
-                managerAddress: nodeOperator,
-                rewardAddress: nodeOperator,
-                extendedManagerPermissions: false
-            }),
-            referrer: address(0)
-        });
-
-        (bytes memory keys, bytes memory signatures) = keysSignatures(1, 1);
-        uint256 required = accounting.getRequiredBondForNextKeys(noId, 1);
-        uint256 toWrap = required + 1 wei;
-        vm.deal(stranger, toWrap);
-
-        vm.prank(stranger);
-        stETH.submit{ value: toWrap }(address(0));
-
-        vm.prank(stranger);
-        module.addValidatorKeysStETH(
+        (bytes memory keys, bytes memory sigs) = keysSignatures(1);
+        uint256 noId = gate.createNodeOperatorWithKeysWithStETHBond(
             nodeOperator,
-            noId,
             1,
             keys,
-            signatures,
-            ICSAccounting.PermitInput({
-                value: 0,
-                deadline: 0,
-                v: 0,
-                r: 0,
-                s: 0
-            })
+            sigs
         );
 
+        (keys, sigs) = keysSignatures(1, 1);
         {
             vm.expectRevert(ICSModule.CannotAddKeys.selector);
 
-            vm.prank(stranger);
+            vm.prank(address(gate));
             module.addValidatorKeysStETH(
                 nodeOperator,
                 noId,
                 1,
                 keys,
-                signatures,
+                sigs,
                 ICSAccounting.PermitInput({
                     value: 0,
                     deadline: 0,
@@ -1586,60 +1762,31 @@ abstract contract ModuleAddValidatorKeys is ModuleFixtures {
         }
     }
 
-    function test_AddValidatorKeysWstETH_RevertWhenCalledTwice()
+    function test_GateAddValidatorKeysWstETH_RevertWhenCalledTwice()
         public
         assertInvariants
+        withGate
     {
-        module.grantRole(module.CREATE_NODE_OPERATOR_ROLE(), stranger);
-
-        vm.prank(stranger);
-        uint256 noId = module.createNodeOperator({
-            from: nodeOperator,
-            managementProperties: NodeOperatorManagementProperties({
-                managerAddress: nodeOperator,
-                rewardAddress: nodeOperator,
-                extendedManagerPermissions: false
-            }),
-            referrer: address(0)
-        });
-
-        (bytes memory keys, bytes memory signatures) = keysSignatures(1, 1);
-        uint256 required = accounting.getRequiredBondForNextKeys(noId, 1);
-        uint256 toWrap = required + 1 wei;
-        vm.deal(stranger, toWrap);
-
-        vm.startPrank(stranger);
-        stETH.submit{ value: toWrap }(address(0));
-        stETH.approve(address(wstETH), UINT256_MAX);
-        wstETH.wrap(toWrap);
-        vm.stopPrank();
-
-        vm.prank(stranger);
-        module.addValidatorKeysWstETH(
+        (bytes memory keys, bytes memory sigs) = keysSignatures(1);
+        uint256 noId = gate.createNodeOperatorWithKeysWithWstETHBond(
             nodeOperator,
-            noId,
             1,
             keys,
-            signatures,
-            ICSAccounting.PermitInput({
-                value: 0,
-                deadline: 0,
-                v: 0,
-                r: 0,
-                s: 0
-            })
+            sigs
         );
+
+        (keys, sigs) = keysSignatures(1, 1);
 
         {
             vm.expectRevert(ICSModule.CannotAddKeys.selector);
 
-            vm.prank(stranger);
+            vm.prank(address(gate));
             module.addValidatorKeysWstETH(
                 nodeOperator,
                 noId,
                 1,
                 keys,
-                signatures,
+                sigs,
                 ICSAccounting.PermitInput({
                     value: 0,
                     deadline: 0,


### PR DESCRIPTION
## Description

Noteworthy changes:

- `accounting` function is removed from the CSModule
- `safeCountOperators` uses assembly now, needs a thorough look
- tests failing in isolation mode were fixed

## Checklist

- [x] Appropriate PR labels applied
- [x] Test coverage maintained (`just coverage`)
  - [x] No need to add/update tests
  - [ ] Tests are added/updated
- [x] Documentation maintained
  - [x] No need to update
  - [ ] Updated
