### PR TITLE
tests: improve coverage for ejector, strikes, fee distributor

### DIFF
--- a/test/helpers/mocks/CSMMock.sol
+++ b/test/helpers/mocks/CSMMock.sol
@@ -19,7 +19,8 @@ contract CSMMock is Utilities, Fixtures {
     NodeOperator internal mockNodeOperator;
     uint256 internal nodeOperatorsCount;
     uint256 internal nodeOperatorTotalDepositedKeys;
-    bool internal isValidatorWithdrawnMock;
+    mapping(uint256 => mapping(uint256 => bool))
+        internal isValidatorWithdrawnByKey;
     IAccounting public immutable ACCOUNTING;
     IParametersRegistry public immutable PARAMETERS_REGISTRY;
     LidoLocatorMock public immutable LIDO_LOCATOR;
@@ -82,15 +83,19 @@ contract CSMMock is Utilities, Fixtures {
                 : managementProperties.rewardAddress;
     }
 
-    function mock_setIsValidatorWithdrawn(bool value) external {
-        isValidatorWithdrawnMock = value;
+    function mock_setIsValidatorWithdrawn(
+        uint256 nodeOperatorId,
+        uint256 keyIndex,
+        bool value
+    ) external {
+        isValidatorWithdrawnByKey[nodeOperatorId][keyIndex] = value;
     }
 
     function isValidatorWithdrawn(
-        uint256,
-        uint256
+        uint256 nodeOperatorId,
+        uint256 keyIndex
     ) external view returns (bool) {
-        return isValidatorWithdrawnMock;
+        return isValidatorWithdrawnByKey[nodeOperatorId][keyIndex];
     }
 
     function mock_setNodeOperatorsCount(uint256 count) external {

--- a/test/unit/Ejector.t.sol
+++ b/test/unit/Ejector.t.sol
@@ -129,6 +129,26 @@ contract EjectorTestMisc is EjectorTestBase {
         vm.prank(address(1337));
         ejector.recoverEther();
     }
+
+    function test_recovererRole_revertWhen_noRole() public {
+        bytes32 role = ejector.RECOVERER_ROLE();
+
+        expectRoleRevert(stranger, role);
+        vm.prank(stranger);
+        ejector.recoverEther();
+
+        expectRoleRevert(stranger, role);
+        vm.prank(stranger);
+        ejector.recoverERC20(address(1), 1);
+
+        expectRoleRevert(stranger, role);
+        vm.prank(stranger);
+        ejector.recoverERC721(address(1), 1);
+
+        expectRoleRevert(stranger, role);
+        vm.prank(stranger);
+        ejector.recoverERC1155(address(1), 1);
+    }
 }
 
 contract EjectorTestVoluntaryEject is EjectorTestBase {
@@ -212,6 +232,52 @@ contract EjectorTestVoluntaryEject is EjectorTestBase {
             });
         }
         ejector.voluntaryEject(NO_ID, keyIndex, keysCount, refundRecipient);
+    }
+
+    function test_voluntaryEject_withOffset() public {
+        uint256 startFrom = 1;
+        uint256 keysCount = 2;
+        bytes memory pubkeys = csm.getSigningKeys(0, startFrom, keysCount);
+
+        csm.mock_setNodeOperatorsCount(1);
+        csm.mock_setNodeOperatorTotalDepositedKeys(3);
+        csm.mock_setNodeOperatorManagementProperties(
+            NodeOperatorManagementProperties(
+                address(this),
+                address(this),
+                false
+            )
+        );
+
+        ValidatorData[] memory expectedExitsData = new ValidatorData[](
+            keysCount
+        );
+        bytes[] memory emittedPubkeys = new bytes[](keysCount);
+        for (uint256 i; i < keysCount; ++i) {
+            bytes memory pubkey = slice(pubkeys, 48 * i, 48);
+            expectedExitsData[i] = ValidatorData(0, NO_ID, pubkey);
+            emittedPubkeys[i] = pubkey;
+        }
+        uint256 exitType = ejector.VOLUNTARY_EXIT_TYPE_ID();
+
+        vm.expectCall(
+            address(twg),
+            abi.encodeWithSelector(
+                ITriggerableWithdrawalsGateway.triggerFullWithdrawals.selector,
+                expectedExitsData,
+                refundRecipient,
+                exitType
+            )
+        );
+        for (uint256 i; i < keysCount; ++i) {
+            vm.expectEmit(address(ejector));
+            emit IEjector.VoluntaryEjectionRequested({
+                nodeOperatorId: NO_ID,
+                pubkey: emittedPubkeys[i],
+                refundRecipient: refundRecipient
+            });
+        }
+        ejector.voluntaryEject(NO_ID, startFrom, keysCount, refundRecipient);
     }
 
     function test_voluntaryEject_refund() public {
@@ -365,12 +431,24 @@ contract EjectorTestVoluntaryEject is EjectorTestBase {
         ejector.voluntaryEject(NO_ID, keyIndex, 1, address(0));
     }
 
+    function test_voluntaryEject_revertWhen_paused() public {
+        uint256 keyIndex = 0;
+
+        vm.startPrank(admin);
+        ejector.grantRole(ejector.PAUSE_ROLE(), admin);
+        ejector.pauseFor(100);
+        vm.stopPrank();
+
+        vm.expectRevert(PausableUntil.ResumedExpected.selector);
+        ejector.voluntaryEject(NO_ID, keyIndex, 1, refundRecipient);
+    }
+
     function test_voluntaryEject_revertWhen_alreadyWithdrawn() public {
         uint256 keyIndex = 0;
 
         csm.mock_setNodeOperatorTotalDepositedKeys(1);
         csm.mock_setNodeOperatorsCount(1);
-        csm.mock_setIsValidatorWithdrawn(true);
+        csm.mock_setIsValidatorWithdrawn(NO_ID, keyIndex, true);
         csm.mock_setNodeOperatorManagementProperties(
             NodeOperatorManagementProperties(
                 address(this),
@@ -381,6 +459,25 @@ contract EjectorTestVoluntaryEject is EjectorTestBase {
 
         vm.expectRevert(IEjector.AlreadyWithdrawn.selector);
         ejector.voluntaryEject(NO_ID, keyIndex, 1, address(0));
+    }
+
+    function test_voluntaryEject_revertWhen_withdrawnKeyInsideRange() public {
+        uint256 keyIndex = 0;
+        uint256 keysCount = 3;
+
+        csm.mock_setNodeOperatorTotalDepositedKeys(keysCount);
+        csm.mock_setNodeOperatorsCount(1);
+        csm.mock_setIsValidatorWithdrawn(NO_ID, keyIndex + 2, true);
+        csm.mock_setNodeOperatorManagementProperties(
+            NodeOperatorManagementProperties(
+                address(this),
+                address(this),
+                false
+            )
+        );
+
+        vm.expectRevert(IEjector.AlreadyWithdrawn.selector);
+        ejector.voluntaryEject(NO_ID, keyIndex, keysCount, refundRecipient);
     }
 }
 
@@ -469,6 +566,57 @@ contract EjectorTestVoluntaryEjectByArray is EjectorTestBase {
                 refundRecipient: refundRecipient
             });
         }
+        ejector.voluntaryEjectByArray(NO_ID, indices, refundRecipient);
+    }
+
+    function test_voluntaryEjectByArray_nonSequentialIndices() public {
+        uint256 keysCount = 5;
+        bytes memory pubkeys = csm.getSigningKeys(0, 0, keysCount);
+
+        csm.mock_setNodeOperatorsCount(1);
+        csm.mock_setNodeOperatorTotalDepositedKeys(keysCount);
+        csm.mock_setNodeOperatorManagementProperties(
+            NodeOperatorManagementProperties(
+                address(this),
+                address(this),
+                false
+            )
+        );
+
+        uint256[] memory indices = new uint256[](3);
+        indices[0] = 0;
+        indices[1] = 2;
+        indices[2] = 4;
+
+        ValidatorData[] memory expectedExitsData = new ValidatorData[](
+            indices.length
+        );
+        bytes[] memory emittedPubkeys = new bytes[](indices.length);
+        for (uint256 i; i < indices.length; ++i) {
+            bytes memory pubkey = slice(pubkeys, 48 * indices[i], 48);
+            expectedExitsData[i] = ValidatorData(0, NO_ID, pubkey);
+            emittedPubkeys[i] = pubkey;
+        }
+        uint256 exitType = ejector.VOLUNTARY_EXIT_TYPE_ID();
+
+        vm.expectCall(
+            address(twg),
+            abi.encodeWithSelector(
+                ITriggerableWithdrawalsGateway.triggerFullWithdrawals.selector,
+                expectedExitsData,
+                refundRecipient,
+                exitType
+            )
+        );
+        for (uint256 i; i < indices.length; ++i) {
+            vm.expectEmit(address(ejector));
+            emit IEjector.VoluntaryEjectionRequested({
+                nodeOperatorId: NO_ID,
+                pubkey: emittedPubkeys[i],
+                refundRecipient: refundRecipient
+            });
+        }
+
         ejector.voluntaryEjectByArray(NO_ID, indices, refundRecipient);
     }
 
@@ -664,7 +812,7 @@ contract EjectorTestVoluntaryEjectByArray is EjectorTestBase {
 
         csm.mock_setNodeOperatorTotalDepositedKeys(1);
         csm.mock_setNodeOperatorsCount(1);
-        csm.mock_setIsValidatorWithdrawn(true);
+        csm.mock_setIsValidatorWithdrawn(NO_ID, keyIndex, true);
         csm.mock_setNodeOperatorManagementProperties(
             NodeOperatorManagementProperties(
                 address(this),
@@ -747,7 +895,7 @@ contract EjectorTestEjectBadPerformer is EjectorTestBase {
         uint256 keyIndex = 0;
 
         csm.mock_setNodeOperatorTotalDepositedKeys(1);
-        csm.mock_setIsValidatorWithdrawn(true);
+        csm.mock_setIsValidatorWithdrawn(NO_ID, keyIndex, true);
 
         vm.prank(address(strikes));
         vm.expectRevert(IEjector.AlreadyWithdrawn.selector);

--- a/test/unit/FeeDistributor.t.sol
+++ b/test/unit/FeeDistributor.t.sol
@@ -138,6 +138,14 @@ contract FeeDistributorInitTest is FeeDistributorTestBase {
         feeDistributor.initialize(address(this), address(0));
     }
 
+    function test_initialize_RevertWhen_calledTwice() public {
+        _enableInitializers(address(feeDistributor));
+        feeDistributor.initialize(address(this), rebateRecipient);
+
+        vm.expectRevert(Initializable.InvalidInitialization.selector);
+        feeDistributor.initialize(address(this), rebateRecipient);
+    }
+
     function test_finalizeUpgradeV2() public {
         _enableInitializers(address(feeDistributor));
 
@@ -154,6 +162,14 @@ contract FeeDistributorInitTest is FeeDistributorTestBase {
 
         vm.expectRevert(IFeeDistributor.ZeroRebateRecipientAddress.selector);
         feeDistributor.finalizeUpgradeV2(address(0));
+    }
+
+    function test_finalizeUpgradeV2_RevertWhen_calledTwice() public {
+        _enableInitializers(address(feeDistributor));
+        feeDistributor.finalizeUpgradeV2(rebateRecipient);
+
+        vm.expectRevert(Initializable.InvalidInitialization.selector);
+        feeDistributor.finalizeUpgradeV2(rebateRecipient);
     }
 }
 
@@ -211,13 +227,17 @@ contract FeeDistributorTest is FeeDistributorTestBase {
         emit IFeeDistributor.OperatorFeeDistributed(nodeOperatorId, shares);
 
         vm.prank(address(accounting));
-        feeDistributor.distributeFees({
+        uint256 returned = feeDistributor.distributeFees({
             proof: proof,
             nodeOperatorId: nodeOperatorId,
             cumulativeFeeShares: shares
         });
 
+        assertEq(returned, shares);
         assertEq(stETH.sharesOf(address(accounting)), shares);
+        assertEq(feeDistributor.distributedShares(nodeOperatorId), shares);
+        assertEq(feeDistributor.totalClaimableShares(), 0);
+        assertEq(feeDistributor.pendingSharesToDistribute(), 0);
     }
 
     function test_getFeesToDistribute_notDistributedYet()
@@ -309,6 +329,35 @@ contract FeeDistributorTest is FeeDistributorTestBase {
         });
     }
 
+    function test_getFeesToDistribute_RevertWhen_InvalidProofContents() public {
+        uint256 nodeOperatorId = 42;
+        uint256 shares = 100;
+        uint256 refSlot = 154;
+        tree.pushLeaf(abi.encode(nodeOperatorId, shares));
+        tree.pushLeaf(abi.encode(type(uint64).max, 0));
+        bytes32[] memory proof = tree.getProof(0);
+        bytes32 root = tree.root();
+
+        stETH.mintShares(address(feeDistributor), shares);
+        vm.prank(oracle);
+        feeDistributor.processOracleReport(
+            root,
+            someCIDv0(),
+            someCIDv0(),
+            shares,
+            0,
+            refSlot
+        );
+
+        // tamper the proof leaf by changing cumulativeFeeShares
+        vm.expectRevert(IFeeDistributor.InvalidProof.selector);
+        feeDistributor.getFeesToDistribute({
+            proof: proof,
+            nodeOperatorId: nodeOperatorId,
+            cumulativeFeeShares: shares + 1
+        });
+    }
+
     function test_getHistoricalDistributionData() public {
         uint256 shares = 100;
         uint256 rebate = 10;
@@ -357,6 +406,9 @@ contract FeeDistributorTest is FeeDistributorTestBase {
             refSlot
         );
 
+        uint256 initialHistoryLength = feeDistributor
+            .distributionDataHistoryCount();
+
         shares = 120;
         rebate = 10;
         refSlot = 155;
@@ -376,6 +428,7 @@ contract FeeDistributorTest is FeeDistributorTestBase {
         );
 
         uint256 historyLength = feeDistributor.distributionDataHistoryCount();
+        assertEq(historyLength, initialHistoryLength + 1);
 
         IFeeDistributor.DistributionData memory data = feeDistributor
             .getHistoricalDistributionData(historyLength - 1);
@@ -386,6 +439,10 @@ contract FeeDistributorTest is FeeDistributorTestBase {
         assertEq(data.logCid, logCid);
         assertEq(data.distributed, shares);
         assertEq(data.rebate, rebate);
+
+        // previous record remains intact
+        data = feeDistributor.getHistoricalDistributionData(historyLength - 2);
+        assertEq(data.refSlot, 154);
     }
 
     function test_hashLeaf() public assertInvariants {
@@ -669,6 +726,17 @@ contract FeeDistributorTest is FeeDistributorTestBase {
 
         Vm.Log[] memory entries = vm.getRecordedLogs();
         assertEq(entries.length, 2);
+
+        IFeeDistributor.DistributionData memory last = feeDistributor
+            .getHistoricalDistributionData(
+                feeDistributor.distributionDataHistoryCount() - 1
+            );
+        assertEq(last.treeRoot, treeRootOld);
+        assertEq(last.treeCid, treeCidOld);
+        assertEq(last.logCid, logCid);
+        assertEq(last.distributed, shares);
+        assertEq(last.rebate, rebate);
+        assertEq(last.refSlot, refSlot);
 
         assertEq(feeDistributor.treeRoot(), treeRootOld);
         assertEq(feeDistributor.treeCid(), treeCidOld);
@@ -1062,5 +1130,17 @@ contract FeeDistributorAssetRecovererTest is FeeDistributorTestBase {
         vm.prank(recoverer);
         vm.expectRevert(IAssetRecovererLib.NotAllowedToRecover.selector);
         feeDistributor.recoverERC20(address(stETH), 1000);
+    }
+
+    function test_recoverERC721_RevertWhen_Unauthorized() public {
+        expectRoleRevert(stranger, feeDistributor.RECOVERER_ROLE());
+        vm.prank(stranger);
+        feeDistributor.recoverERC721(address(1), 1);
+    }
+
+    function test_recoverERC1155_RevertWhen_Unauthorized() public {
+        expectRoleRevert(stranger, feeDistributor.RECOVERER_ROLE());
+        vm.prank(stranger);
+        feeDistributor.recoverERC1155(address(1), 1);
     }
 }

--- a/test/unit/ValidatorStrikes.t.sol
+++ b/test/unit/ValidatorStrikes.t.sol
@@ -221,6 +221,14 @@ contract ValidatorStrikesTest is ValidatorStrikesTestBase {
         assertEq(address(strikes.ejector()), ejector);
     }
 
+    function test_setEjector_RevertWhen_notAdmin() public {
+        ejector = address(new EjectorMock(address(module)));
+
+        expectRoleRevert(stranger, strikes.DEFAULT_ADMIN_ROLE());
+        vm.prank(stranger);
+        strikes.setEjector(ejector);
+    }
+
     function test_setEjector_RevertWhen_ZeroEjectorAddress() public {
         vm.expectRevert(IValidatorStrikes.ZeroEjectorAddress.selector);
         vm.prank(admin);
@@ -376,6 +384,37 @@ contract ValidatorStrikesProofTest is ValidatorStrikesTestBase {
     }
 
     Leaf[] internal leaves;
+
+    function _singleLeaf(
+        uint256 leafIndex
+    )
+        internal
+        view
+        returns (
+            Leaf memory leaf,
+            IValidatorStrikes.KeyStrikes[] memory keyStrikesList,
+            bytes32[] memory proof,
+            bool[] memory proofFlags
+        )
+    {
+        leaf = leaves[leafIndex];
+        keyStrikesList = new IValidatorStrikes.KeyStrikes[](1);
+        keyStrikesList[0] = leaf.keyStrikes;
+        proof = tree.getProof(leafIndex);
+        proofFlags = new bool[](proof.length);
+    }
+
+    function _mockModule(Leaf memory leaf) internal {
+        vm.mockCall(
+            address(module),
+            abi.encodeWithSelector(
+                ICSModule.getSigningKeys.selector,
+                leaf.keyStrikes.nodeOperatorId,
+                leaf.keyStrikes.keyIndex
+            ),
+            abi.encode(leaf.pubkey)
+        );
+    }
 
     function setUp() public {
         stranger = nextAddress("STRANGER");
@@ -693,24 +732,14 @@ contract ValidatorStrikesProofTest is ValidatorStrikesTestBase {
         public
         withTreeOfLeavesCount(3)
     {
-        Leaf memory leaf = leaves[0];
+        (
+            Leaf memory leaf,
+            IValidatorStrikes.KeyStrikes[] memory keyStrikesList,
+            bytes32[] memory proof,
+            bool[] memory proofFlags
+        ) = _singleLeaf(0);
 
-        IValidatorStrikes.KeyStrikes[]
-            memory keyStrikesList = new IValidatorStrikes.KeyStrikes[](1);
-        keyStrikesList[0] = leaf.keyStrikes;
-
-        bytes32[] memory proof = tree.getProof(0);
-        bool[] memory proofFlags = new bool[](proof.length);
-
-        vm.mockCall(
-            address(module),
-            abi.encodeWithSelector(
-                ICSModule.getSigningKeys.selector,
-                leaf.keyStrikes.nodeOperatorId,
-                leaf.keyStrikes.keyIndex
-            ),
-            abi.encode(leaf.pubkey)
-        );
+        _mockModule(leaf);
         vm.expectCall(
             address(ejector),
             abi.encodeWithSelector(
@@ -726,6 +755,144 @@ contract ValidatorStrikesProofTest is ValidatorStrikesTestBase {
             proof,
             proofFlags,
             address(0)
+        );
+    }
+
+    function test_processBadPerformanceProof_valuePerKeyForwarded()
+        public
+        withTreeOfLeavesCount(2)
+    {
+        uint256[] memory indicies = UintArr(0, 1);
+
+        IValidatorStrikes.KeyStrikes[]
+            memory keyStrikesList = new IValidatorStrikes.KeyStrikes[](
+                indicies.length
+            );
+        (bytes32[] memory proof, bool[] memory proofFlags) = tree.getMultiProof(
+            indicies
+        );
+
+        for (uint256 i; i < indicies.length; i++) {
+            Leaf memory leaf = leaves[indicies[i]];
+            keyStrikesList[i] = leaf.keyStrikes;
+            vm.mockCall(
+                address(module),
+                abi.encodeWithSelector(
+                    ICSModule.getSigningKeys.selector,
+                    leaf.keyStrikes.nodeOperatorId,
+                    leaf.keyStrikes.keyIndex
+                ),
+                abi.encode(leaf.pubkey)
+            );
+            vm.expectCall(
+                address(exitPenalties),
+                abi.encodeWithSelector(
+                    IExitPenalties.processStrikesReport.selector,
+                    leaf.keyStrikes.nodeOperatorId,
+                    leaf.pubkey
+                )
+            );
+        }
+
+        uint256 msgValue = 4 ether;
+        uint256 valuePerKey = msgValue / keyStrikesList.length;
+        for (uint256 i; i < keyStrikesList.length; ++i) {
+            vm.expectCall(
+                address(ejector),
+                valuePerKey,
+                abi.encodeWithSelector(
+                    IEjector.ejectBadPerformer.selector,
+                    keyStrikesList[i].nodeOperatorId,
+                    keyStrikesList[i].keyIndex,
+                    refundRecipient
+                )
+            );
+        }
+
+        this.processBadPerformanceProof{ value: msgValue }(
+            keyStrikesList,
+            proof,
+            proofFlags,
+            refundRecipient
+        );
+    }
+
+    function test_processBadPerformanceProof_strikesAtThreshold()
+        public
+        withTreeOfLeavesCount(1)
+    {
+        (
+            Leaf memory leaf,
+            IValidatorStrikes.KeyStrikes[] memory keyStrikesList,
+            bytes32[] memory proof,
+            bool[] memory proofFlags
+        ) = _singleLeaf(0);
+
+        uint256 threshold;
+        for (uint256 i; i < leaf.keyStrikes.data.length; ++i) {
+            threshold += leaf.keyStrikes.data[i];
+        }
+        module.PARAMETERS_REGISTRY().setStrikesParams(0, 6, threshold);
+
+        _mockModule(leaf);
+        vm.expectCall(
+            address(exitPenalties),
+            abi.encodeWithSelector(
+                IExitPenalties.processStrikesReport.selector,
+                leaf.keyStrikes.nodeOperatorId,
+                leaf.pubkey
+            )
+        );
+        vm.expectCall(
+            address(ejector),
+            abi.encodeWithSelector(
+                IEjector.ejectBadPerformer.selector,
+                leaf.keyStrikes.nodeOperatorId,
+                leaf.keyStrikes.keyIndex,
+                refundRecipient
+            )
+        );
+
+        this.processBadPerformanceProof{ value: 1 }(
+            keyStrikesList,
+            proof,
+            proofFlags,
+            refundRecipient
+        );
+    }
+
+    function test_processBadPerformanceProof_RevertWhen_TreeNotSet() public {
+        Leaf memory leaf;
+        leaf.keyStrikes = IValidatorStrikes.KeyStrikes({
+            nodeOperatorId: 1,
+            keyIndex: 0,
+            data: UintArr(1, 1, 1)
+        });
+        (leaf.pubkey, ) = keysSignatures(1);
+
+        IValidatorStrikes.KeyStrikes[]
+            memory keyStrikesList = new IValidatorStrikes.KeyStrikes[](1);
+        keyStrikesList[0] = leaf.keyStrikes;
+
+        bytes32[] memory proof = new bytes32[](0);
+        bool[] memory proofFlags = new bool[](0);
+
+        vm.mockCall(
+            address(module),
+            abi.encodeWithSelector(
+                ICSModule.getSigningKeys.selector,
+                leaf.keyStrikes.nodeOperatorId,
+                leaf.keyStrikes.keyIndex
+            ),
+            abi.encode(leaf.pubkey)
+        );
+
+        vm.expectRevert(IValidatorStrikes.InvalidProof.selector);
+        this.processBadPerformanceProof{ value: 1 }(
+            keyStrikesList,
+            proof,
+            proofFlags,
+            refundRecipient
         );
     }
 
@@ -802,26 +969,21 @@ contract ValidatorStrikesProofTest is ValidatorStrikesTestBase {
         public
         withTreeOfLeavesCount(3)
     {
-        Leaf memory leaf = leaves[0];
+        (
+            Leaf memory leaf,
+            IValidatorStrikes.KeyStrikes[] memory keyStrikesList,
+            bytes32[] memory proof,
+            bool[] memory proofFlags
+        ) = _singleLeaf(0);
 
-        IValidatorStrikes.KeyStrikes[]
-            memory keyStrikesList = new IValidatorStrikes.KeyStrikes[](1);
-        keyStrikesList[0] = leaf.keyStrikes;
+        uint256 threshold;
+        for (uint256 i; i < leaf.keyStrikes.data.length; ++i) {
+            threshold += leaf.keyStrikes.data[i];
+        }
 
-        bytes32[] memory proof = tree.getProof(0);
-        bool[] memory proofFlags = new bool[](proof.length);
+        module.PARAMETERS_REGISTRY().setStrikesParams(0, 6, threshold + 1);
 
-        module.PARAMETERS_REGISTRY().setStrikesParams(0, 6, 100501);
-
-        vm.mockCall(
-            address(module),
-            abi.encodeWithSelector(
-                ICSModule.getSigningKeys.selector,
-                leaf.keyStrikes.nodeOperatorId,
-                leaf.keyStrikes.keyIndex
-            ),
-            abi.encode(leaf.pubkey)
-        );
+        _mockModule(leaf);
 
         vm.expectRevert(IValidatorStrikes.NotEnoughStrikesToEject.selector);
         this.processBadPerformanceProof{ value: 1 }(


### PR DESCRIPTION
**Description**
- Extend Ejector unit coverage (recoverer role negatives, voluntary eject offset/non-sequential indices, paused/withdrawn ranges) with per-key withdrawal tracking in the mock.
- Expand ValidatorStrikes proof tests using shared helpers for value-per-key forwarding, threshold/invalid-proof cases, and tree-not-set handling.
- Update FeeDistributor tests with new asserts and add invalid proof coverage.

**Checklist**
- [x] Appropriate PR labels applied
- [ ] Test coverage maintained (`just coverage`)
  - [x] Tests are added/updated
- [ ] Documentation maintained

