### PR TITLE
feat: submitWithdrawals to a library

### DIFF
--- a/script/fork-helpers/NodeOperators.s.sol
+++ b/script/fork-helpers/NodeOperators.s.sol
@@ -9,7 +9,7 @@ import { ForkHelpersCommon } from "./Common.sol";
 import { IVEBO } from "../../src/interfaces/IVEBO.sol";
 import { Utilities } from "../../test/helpers/Utilities.sol";
 import { IStakingRouter } from "../../src/interfaces/IStakingRouter.sol";
-import { NodeOperator, ValidatorWithdrawalInfo } from "../../src/interfaces/ICSModule.sol";
+import { NodeOperator, WithdrawnValidatorInfo } from "../../src/interfaces/ICSModule.sol";
 
 contract NodeOperators is
     Script,
@@ -208,15 +208,17 @@ contract NodeOperators is
             .getNodeOperator(noId)
             .totalWithdrawnKeys;
 
-        ValidatorWithdrawalInfo[]
-            memory withdrawalInfo = new ValidatorWithdrawalInfo[](1);
-        withdrawalInfo[0] = ValidatorWithdrawalInfo(
+        WithdrawnValidatorInfo[] memory exitInfo = new WithdrawnValidatorInfo[](
+            1
+        );
+        exitInfo[0] = WithdrawnValidatorInfo(
             noId,
             keyIndex,
             exitBalance,
-            slashingPenalty
+            slashingPenalty,
+            slashingPenalty > 0
         );
-        module.submitWithdrawals(withdrawalInfo);
+        module.reportWithdrawnValidators(exitInfo);
 
         assertTrue(module.isValidatorWithdrawn(noId, keyIndex));
         assertEq(

--- a/script/fork-helpers/NodeOperators.s.sol
+++ b/script/fork-helpers/NodeOperators.s.sol
@@ -208,17 +208,16 @@ contract NodeOperators is
             .getNodeOperator(noId)
             .totalWithdrawnKeys;
 
-        WithdrawnValidatorInfo[] memory exitInfo = new WithdrawnValidatorInfo[](
-            1
-        );
-        exitInfo[0] = WithdrawnValidatorInfo(
+        WithdrawnValidatorInfo[]
+            memory validatorInfos = new WithdrawnValidatorInfo[](1);
+        validatorInfos[0] = WithdrawnValidatorInfo(
             noId,
             keyIndex,
             exitBalance,
             slashingPenalty,
             slashingPenalty > 0
         );
-        module.reportWithdrawnValidators(exitInfo);
+        module.reportWithdrawnValidators(validatorInfos);
 
         assertTrue(module.isValidatorWithdrawn(noId, keyIndex));
         assertEq(

--- a/src/CSModule.sol
+++ b/src/CSModule.sol
@@ -15,8 +15,7 @@ import { IStETH } from "./interfaces/IStETH.sol";
 import { ICSParametersRegistry } from "./interfaces/ICSParametersRegistry.sol";
 import { ICSAccounting } from "./interfaces/ICSAccounting.sol";
 import { ICSExitPenalties } from "./interfaces/ICSExitPenalties.sol";
-import { ICSModule, NodeOperator, NodeOperatorManagementProperties, ValidatorWithdrawalInfo } from "./interfaces/ICSModule.sol";
-import { ExitPenaltyInfo } from "./interfaces/ICSExitPenalties.sol";
+import { ICSModule, NodeOperator, NodeOperatorManagementProperties, WithdrawnValidatorInfo } from "./interfaces/ICSModule.sol";
 import { INodeOperatorOwner } from "./interfaces/INodeOperatorOwner.sol";
 
 import { PausableUntil } from "./lib/utils/PausableUntil.sol";
@@ -26,6 +25,7 @@ import { NOAddresses } from "./lib/NOAddresses.sol";
 import { GeneralPenalty } from "./lib/GeneralPenaltyLib.sol";
 import { TransientUintUintMap, TransientUintUintMapLib } from "./lib/TransientUintUintMapLib.sol";
 import { SigningKeys } from "./lib/SigningKeys.sol";
+import { WithdrawnValidatorLib } from "./lib/WithdrawnValidatorLib.sol";
 
 contract CSModule is
     ICSModule,
@@ -50,10 +50,6 @@ contract CSModule is
     bytes32 public constant RECOVERER_ROLE = keccak256("RECOVERER_ROLE");
     bytes32 public constant CREATE_NODE_OPERATOR_ROLE =
         keccak256("CREATE_NODE_OPERATOR_ROLE");
-
-    uint256 public constant MIN_ACTIVATION_BALANCE = 32 ether;
-    uint256 public constant PENALTY_QUOTIENT = 32 ether;
-    uint256 public constant MAX_PENALTY_MULTIPLIER = 64;
 
     // @dev see IStakingModule.sol
     uint8 private constant FORCED_TARGET_LIMIT_MODE_ID = 2;
@@ -661,160 +657,57 @@ contract CSModule is
         emit ValidatorSlashingReported(nodeOperatorId, keyIndex, pubkey);
     }
 
-    /// TODO: Consider moving to the external library to save bytecode
     /// @inheritdoc ICSModule
-    function submitWithdrawals(
-        ValidatorWithdrawalInfo[] calldata withdrawalsInfo
+    function reportWithdrawnValidators(
+        WithdrawnValidatorInfo[] calldata validatorInfos
     ) external onlyRole(SUBMIT_WITHDRAWALS_ROLE) {
         bool anySubmission = false;
 
-        for (uint256 i; i < withdrawalsInfo.length; ++i) {
-            ValidatorWithdrawalInfo memory withdrawalInfo = withdrawalsInfo[i];
+        for (uint256 i; i < validatorInfos.length; ++i) {
+            WithdrawnValidatorInfo calldata info = validatorInfos[i];
+            _onlyExistingNodeOperator(info.nodeOperatorId);
 
-            // For slashed validator this value should reflect pre-slashing, hence non-zero balance.
-            // For non-slashed validator it will reflect the withdrawal amount, hence it cannot be zero either.
-            if (withdrawalInfo.exitBalance == 0) {
-                revert ZeroExitBalance();
-            }
-
-            _onlyExistingNodeOperator(withdrawalInfo.nodeOperatorId);
-            NodeOperator storage no = _nodeOperators[
-                withdrawalInfo.nodeOperatorId
-            ];
-
-            if (withdrawalInfo.keyIndex >= no.totalDepositedKeys) {
-                revert SigningKeysInvalidOffset();
-            }
-
-            uint256 pointer = _keyPointer(
-                withdrawalInfo.nodeOperatorId,
-                withdrawalInfo.keyIndex
-            );
+            uint256 pointer = _keyPointer(info.nodeOperatorId, info.keyIndex);
             if (_isValidatorWithdrawn[pointer]) {
                 continue;
             }
-
-            if (
-                withdrawalInfo.slashingPenalty > 0 &&
-                !_isValidatorSlashed[pointer]
-            ) {
+            if (info.isSlashed && !_isValidatorSlashed[pointer]) {
                 revert SlashingPenaltyIsNotApplicable();
             }
 
-            anySubmission = true;
+            if (info.slashingPenalty > 0 && !info.isSlashed) {
+                revert InvalidWithdrawnValidatorInfo();
+            }
 
-            _isValidatorWithdrawn[pointer] = true;
+            // For slashed validator this value should reflect pre-slashing, hence non-zero balance.
+            // For non-slashed validator it will reflect the withdrawal amount, hence it cannot be zero either.
+            if (info.exitBalance == 0) {
+                revert ZeroExitBalance();
+            }
+
+            NodeOperator storage no = _nodeOperators[info.nodeOperatorId];
+
+            if (info.keyIndex >= no.totalDepositedKeys) {
+                revert SigningKeysInvalidOffset();
+            }
+
             unchecked {
                 ++no.totalWithdrawnKeys;
             }
 
-            bytes memory pubkey = SigningKeys.loadKeys(
-                withdrawalInfo.nodeOperatorId,
-                withdrawalInfo.keyIndex,
-                1
-            );
-
-            // solhint-disable-next-line func-named-parameters
-            emit WithdrawalSubmitted(
-                withdrawalInfo.nodeOperatorId,
-                withdrawalInfo.keyIndex,
-                withdrawalInfo.exitBalance,
-                withdrawalInfo.slashingPenalty,
-                pubkey
-            );
-
-            // penaltyMultiplier is >= 1
-            uint256 penaltyMultiplier = Math.max(
-                withdrawalInfo.exitBalance,
-                MIN_ACTIVATION_BALANCE
-            ) / PENALTY_QUOTIENT;
-            // It's rather unlikely that the value will exceed 64 because anything above maximum effective balance of a
-            // validator will likely be withdrawn while it waits for a withdrawal. The introduced limit makes it
-            // possible to use unchecked blocks below and acts as an additional limiting factor.
-            penaltyMultiplier = Math.min(
-                MAX_PENALTY_MULTIPLIER,
-                penaltyMultiplier
-            );
-
-            bool chargeWithdrawalRequestFee = false;
-
-            uint256 penaltySum;
-            uint256 feeSum;
-
-            ExitPenaltyInfo memory exitPenaltyInfo = EXIT_PENALTIES
-                .getExitPenaltyInfo(withdrawalInfo.nodeOperatorId, pubkey);
-            if (exitPenaltyInfo.delayFee.isValue) {
-                unchecked {
-                    feeSum = exitPenaltyInfo.delayFee.value * penaltyMultiplier;
-                }
-                chargeWithdrawalRequestFee = true;
-            }
-            if (exitPenaltyInfo.strikesPenalty.isValue) {
-                // It is safe to use unchecked for sum here because base penalties and fees are limited to uint248 in
-                // the MarkedUint248 structures used to store them, and the maximum multiplier is limited to 64, so
-                // `type(uint248).max * 64 < type(uint256).max`.
-                unchecked {
-                    penaltySum =
-                        exitPenaltyInfo.strikesPenalty.value *
-                        penaltyMultiplier;
-                }
-                chargeWithdrawalRequestFee = true;
-            }
-
-            // The withdrawal request fee is taken when either a delay was reported or the validator exited due to
-            // strikes. Otherwise, the fee has already been paid by the node operator upon withdrawal trigger, or it is
-            // a DAO decision to withdraw the validator before the withdrawal request becomes delayed.
-            if (
-                chargeWithdrawalRequestFee &&
-                exitPenaltyInfo.withdrawalRequestFee.value != 0
-            ) {
-                // type(uint248).max * (64 + 1) < type(uint256).max
-                unchecked {
-                    // Withdrawal request fee is not scaled because sending a withdrawal request for a validator does
-                    // not depend on the size of a validator.
-                    feeSum += exitPenaltyInfo.withdrawalRequestFee.value;
-                }
-            }
-
-            if (withdrawalInfo.slashingPenalty > 0) {
-                // Slashing penalty doesn't scale because all the losses are already accounted.
-                penaltySum += withdrawalInfo.slashingPenalty;
-            } else if (withdrawalInfo.exitBalance < MIN_ACTIVATION_BALANCE) {
-                // type(uint248).max * 64 + 32 * 10**18 < type(uint256).max
-                unchecked {
-                    penaltySum +=
-                        MIN_ACTIVATION_BALANCE -
-                        withdrawalInfo.exitBalance;
-                }
-            }
-
-            ICSAccounting accounting = _accounting();
-            bool isFullyCoveredByBond = true;
-
-            if (feeSum > 0) {
-                isFullyCoveredByBond = accounting.chargeFee(
-                    withdrawalInfo.nodeOperatorId,
-                    feeSum
-                );
-            }
-
-            if (penaltySum > 0) {
-                // We still call `penalize` even if there's no bond left, for the lock to be created.
-                isFullyCoveredByBond = accounting.penalize(
-                    withdrawalInfo.nodeOperatorId,
-                    penaltySum
-                );
-            }
-
-            if (!isFullyCoveredByBond) {
-                _onUncompensatedPenalty(withdrawalInfo.nodeOperatorId);
+            bool bondCoversPenalties = WithdrawnValidatorLib.process(info);
+            if (!bondCoversPenalties) {
+                _onUncompensatedPenalty(info.nodeOperatorId);
             }
 
             // Nonce will be updated below even if depositable count was not changed
             _updateDepositableValidatorsCount({
-                nodeOperatorId: withdrawalInfo.nodeOperatorId,
+                nodeOperatorId: info.nodeOperatorId,
                 incrementNonceIfUpdated: false
             });
+
+            _isValidatorWithdrawn[pointer] = true;
+            anySubmission = true;
         }
 
         if (anySubmission) {

--- a/src/CSVerifier.sol
+++ b/src/CSVerifier.sol
@@ -11,7 +11,7 @@ import { GIndex } from "./lib/GIndex.sol";
 import { SSZ } from "./lib/SSZ.sol";
 
 import { ICSVerifier } from "./interfaces/ICSVerifier.sol";
-import { ICSModule, ValidatorWithdrawalInfo } from "./interfaces/ICSModule.sol";
+import { ICSModule, WithdrawnValidatorInfo } from "./interfaces/ICSModule.sol";
 
 /// @notice Convert withdrawal amount to wei
 /// @param withdrawal Withdrawal struct
@@ -96,9 +96,6 @@ contract CSVerifier is ICSVerifier, AccessControlEnumerable, PausableUntil {
 
     /// @dev Staking module contract.
     ICSModule public immutable MODULE;
-
-    /// @dev Placeholder for slashing penalty value in ValidatorWithdrawalInfo.
-    uint256 internal constant NO_SLASHING_PENALTY = 0;
 
     /// @dev The previous and current forks can be essentially the same.
     constructor(
@@ -281,13 +278,14 @@ contract CSVerifier is ICSVerifier, AccessControlEnumerable, PausableUntil {
             data.withdrawalBlock.header
         );
 
-        _submitSingleWithdrawal(
-            ValidatorWithdrawalInfo(
-                data.validator.nodeOperatorId,
-                data.validator.keyIndex,
-                withdrawalAmount,
-                NO_SLASHING_PENALTY
-            )
+        _reportSingleValidator(
+            WithdrawnValidatorInfo({
+                nodeOperatorId: data.validator.nodeOperatorId,
+                keyIndex: data.validator.keyIndex,
+                exitBalance: withdrawalAmount,
+                slashingPenalty: 0,
+                isSlashed: false
+            })
         );
     }
 
@@ -341,13 +339,14 @@ contract CSVerifier is ICSVerifier, AccessControlEnumerable, PausableUntil {
             data.withdrawalBlock.header
         );
 
-        _submitSingleWithdrawal(
-            ValidatorWithdrawalInfo(
-                data.validator.nodeOperatorId,
-                data.validator.keyIndex,
-                withdrawalAmount,
-                NO_SLASHING_PENALTY
-            )
+        _reportSingleValidator(
+            WithdrawnValidatorInfo({
+                nodeOperatorId: data.validator.nodeOperatorId,
+                keyIndex: data.validator.keyIndex,
+                exitBalance: withdrawalAmount,
+                slashingPenalty: 0,
+                isSlashed: false
+            })
         );
     }
 
@@ -443,23 +442,24 @@ contract CSVerifier is ICSVerifier, AccessControlEnumerable, PausableUntil {
             proof: data.balance.proof
         });
 
-        _submitSingleWithdrawal(
-            ValidatorWithdrawalInfo(
-                data.validator.nodeOperatorId,
-                data.validator.keyIndex,
-                gweiToWei(balanceGwei),
-                NO_SLASHING_PENALTY
-            )
+        _reportSingleValidator(
+            WithdrawnValidatorInfo({
+                nodeOperatorId: data.validator.nodeOperatorId,
+                keyIndex: data.validator.keyIndex,
+                exitBalance: gweiToWei(balanceGwei),
+                slashingPenalty: 0,
+                isSlashed: false
+            })
         );
     }
 
-    function _submitSingleWithdrawal(
-        ValidatorWithdrawalInfo memory info
+    function _reportSingleValidator(
+        WithdrawnValidatorInfo memory info
     ) internal {
-        ValidatorWithdrawalInfo[]
-            memory withdrawalsInfo = new ValidatorWithdrawalInfo[](1);
-        withdrawalsInfo[0] = info;
-        MODULE.submitWithdrawals(withdrawalsInfo);
+        WithdrawnValidatorInfo[]
+            memory validatorExits = new WithdrawnValidatorInfo[](1);
+        validatorExits[0] = info;
+        MODULE.reportWithdrawnValidators(validatorExits);
     }
 
     function _getParentBlockRoot(

--- a/src/interfaces/ICSModule.sol
+++ b/src/interfaces/ICSModule.sol
@@ -41,16 +41,17 @@ struct NodeOperatorManagementProperties {
     bool extendedManagerPermissions;
 }
 
-struct ValidatorWithdrawalInfo {
+struct WithdrawnValidatorInfo {
     uint256 nodeOperatorId;
     // Index of the withdrawn key in the Node Operator's keys storage.
     uint256 keyIndex;
     // Balance to be used to calculate penalties. For a regular withdrawal of a validator it's the withdrawal amount.
     // For a slashed validator it's its balance before slashing. The balance will be used to scale incurred penalties.
     uint256 exitBalance;
-    // Amount of ETH/stETH to penalize Node Operator due to slashing. If the value is non-zero, it means the validator
-    // was slashed.
+    // Amount of ETH/stETH to penalize Node Operator due to slashing.
     uint256 slashingPenalty;
+    // Whether the validator has been slashed.
+    bool isSlashed;
 }
 
 /// @title Lido's Community Staking Module interface
@@ -70,6 +71,7 @@ interface ICSModule is
     error ZeroExitBalance();
     error SlashingPenaltyIsNotApplicable();
     error ValidatorSlashingAlreadyReported();
+    error InvalidWithdrawnValidatorInfo();
 
     error InvalidInput();
     error NotEnoughKeys();
@@ -169,10 +171,6 @@ interface ICSModule is
     function RECOVERER_ROLE() external view returns (bytes32);
 
     function CREATE_NODE_OPERATOR_ROLE() external view returns (bytes32);
-
-    function MIN_ACTIVATION_BALANCE() external view returns (uint256);
-
-    function PENALTY_QUOTIENT() external view returns (uint256);
 
     function LIDO_LOCATOR() external view returns (ILidoLocator);
 
@@ -454,12 +452,12 @@ interface ICSModule is
         uint256 keyIndex
     ) external;
 
-    /// @notice Report Node Operator's keys as withdrawn and settle withdrawn amount
+    /// @notice Report Node Operator's keys as withdrawn and charge penalties associated with exit if any.
     /// @notice Called by `CSVerifier` contract.
     ///         See `CSVerifier.processWithdrawalProof` to use this method permissionless
-    /// @param withdrawalsInfo An array for the validator withdrawals info structs
-    function submitWithdrawals(
-        ValidatorWithdrawalInfo[] calldata withdrawalsInfo
+    /// @param validatorInfos An array WithdrawnValidatorInfo structs
+    function reportWithdrawnValidators(
+        WithdrawnValidatorInfo[] calldata validatorInfos
     ) external;
 
     /// @notice Checks if a validator was reported as slashed

--- a/src/interfaces/ICSModule.sol
+++ b/src/interfaces/ICSModule.sol
@@ -453,8 +453,15 @@ interface ICSModule is
     ) external;
 
     /// @notice Report Node Operator's keys as withdrawn and charge penalties associated with exit if any.
+    ///         A validator is considered withdrawn in the following cases:
+    ///         - if it's an exit of a non-slashed validator, when a withdrawal of the validator is included in a beacon
+    ///           block;
+    ///         - if it's an exit of a slashed validator, when the committee reports such a validator as withdrawn; note
+    ///           that it can happen earlier than the actual withdrawal is included on the beacon chain if the committee
+    ///           decides it can account for all penalties in advance;
+    ///         - if it's a consolidated validator, when the corresponding pending consolidation is processed and the
+    ///           balance of the validator has been moved to another validator.
     /// @notice Called by `CSVerifier` contract.
-    ///         See `CSVerifier.processWithdrawalProof` to use this method permissionless
     /// @param validatorInfos An array WithdrawnValidatorInfo structs
     function reportWithdrawnValidators(
         WithdrawnValidatorInfo[] calldata validatorInfos

--- a/src/interfaces/ICSParametersRegistry.sol
+++ b/src/interfaces/ICSParametersRegistry.sol
@@ -258,7 +258,8 @@ interface ICSParametersRegistry {
         uint256 threshold
     ) external;
 
-    /// @notice Set default value for the bad performance penalty. Default value is used if a specific value is not set for the curveId
+    /// @notice Set the default value for the bad performance penalty for a single 32 ether validator
+    /// This value is used if a specific value is not set for the curveId
     /// @param penalty value to be set as default for the bad performance penalty
     function setDefaultBadPerformancePenalty(uint256 penalty) external;
 
@@ -276,7 +277,8 @@ interface ICSParametersRegistry {
     /// @param delay value to be set as default for the allowed exit delay
     function setDefaultAllowedExitDelay(uint256 delay) external;
 
-    /// @notice Sets the default value for exit delay penalty. The default value is used if a specific value is not set for the curveId
+    /// @notice Set the default value for exit delay penalty for a single 32 ether validator
+    /// This value is used if a specific value is not set for the curveId
     /// @param fee The value to be set as default for the exit delay fee
     function setDefaultExitDelayFee(uint256 fee) external;
 
@@ -439,7 +441,7 @@ interface ICSParametersRegistry {
         uint256 curveId
     ) external view returns (uint256 lifetime, uint256 threshold);
 
-    /// @notice Set bad performance penalty for the curveId
+    /// @notice Set the bad performance penalty for the curveId for a single 32 ether validator
     /// @param curveId Curve Id to associate bad performance penalty with
     /// @param penalty Bad performance penalty
     function setBadPerformancePenalty(
@@ -451,7 +453,7 @@ interface ICSParametersRegistry {
     /// @param curveId Curve Id to unset custom bad performance penalty for
     function unsetBadPerformancePenalty(uint256 curveId) external;
 
-    /// @notice Get bad performance penalty by the curveId
+    /// @notice Get bad performance penalty for a single 32 ether validator by the curveId
     /// @dev `defaultBadPerformancePenalty` is returned if the value is not set for the given curveId.
     /// @param curveId Curve Id to get bad performance penalty for
     /// @return penalty Bad performance penalty
@@ -508,7 +510,7 @@ interface ICSParametersRegistry {
         uint256 curveId
     ) external view returns (uint256 delay);
 
-    /// @notice Set exit delay penalty for the curveId
+    /// @notice Set the exit delay penalty for a single 32 ether validator for the given curveId
     /// @dev cannot be zero
     /// @param curveId Curve Id to associate exit delay penalty with
     /// @param fee Exit delay fee
@@ -518,7 +520,7 @@ interface ICSParametersRegistry {
     /// @param curveId The curve ID for unsetting the exit delay fee
     function unsetExitDelayFee(uint256 curveId) external;
 
-    /// @notice Get exit delay penalty by the curveId
+    /// @notice Get exit delay penalty for a single 32 ether validator by the curveId
     /// @dev `defaultExitDelayFee` is returned if the value is not set for the given curveId.
     /// @param curveId Curve ID to get the exit delay fee for
     function getExitDelayFee(

--- a/src/interfaces/ICSVerifier.sol
+++ b/src/interfaces/ICSVerifier.sol
@@ -161,7 +161,7 @@ interface ICSVerifier {
 
     /// @notice Verify withdrawal proof and report withdrawal to the module for valid proofs
     /// @notice The method doesn't accept proofs for slashed validators. A dedicated committee is responsible for
-    /// determining the exact penalty amounts and calling the `ICSModule.submitWithdrawals` method via an EasyTrack
+    /// determining the exact penalty amounts and calling the `ICSModule.reportWithdrawnValidators` method via an EasyTrack
     /// motion.
     /// @param data @see ProcessWithdrawalInput
     function processWithdrawalProof(
@@ -170,7 +170,7 @@ interface ICSVerifier {
 
     /// @notice Verify withdrawal proof against historical summaries data and report withdrawal to the module for valid proofs
     /// @notice The method doesn't accept proofs for slashed validators. A dedicated committee is responsible for
-    /// determining the exact penalty amounts and calling the `ICSModule.submitWithdrawals` method via an EasyTrack
+    /// determining the exact penalty amounts and calling the `ICSModule.reportWithdrawnValidators` method via an EasyTrack
     /// motion.
     /// @param data @see ProcessHistoricalWithdrawalInput
     function processHistoricalWithdrawalProof(

--- a/src/lib/WithdrawnValidatorLib.sol
+++ b/src/lib/WithdrawnValidatorLib.sol
@@ -13,9 +13,13 @@ import { SigningKeys } from "./SigningKeys.sol";
 
 /// @dev A library to extract a part of the code from the the CSModule contract.
 library WithdrawnValidatorLib {
+    uint256 public constant MAX_EFFECTIVE_BALANCE = 2048 ether;
     uint256 public constant MIN_ACTIVATION_BALANCE = 32 ether;
-    uint256 public constant PENALTY_QUOTIENT = 32 ether;
-    uint256 public constant MAX_PENALTY_MULTIPLIER = 64;
+
+    uint256 public constant PENALTY_QUOTIENT = 1 ether;
+    /// @dev Acts as the denominator to calculate the scaled penalty.
+    uint256 public constant PENALTY_SCALE =
+        MIN_ACTIVATION_BALANCE / PENALTY_QUOTIENT;
 
     function process(
         WithdrawnValidatorInfo calldata validatorInfo
@@ -45,10 +49,12 @@ library WithdrawnValidatorLib {
         );
     }
 
+    // NOTE: The function might revert if the penalty recorded in the `penaltyInfo` is large enough. As of now, it
+    // should be greater than 2^245, which is about 5.6 * 10^55 ethers.
     function _fulfilExitObligations(
         WithdrawnValidatorInfo calldata validatorInfo,
         ExitPenaltyInfo memory penaltyInfo
-    ) private returns (bool bondCoversPenalties) {
+    ) internal returns (bool bondCoversPenalties) {
         bool chargeWithdrawalRequestFee = false;
 
         uint256 penaltyMultiplier = _getPenaltyMultiplier(validatorInfo);
@@ -56,21 +62,18 @@ library WithdrawnValidatorLib {
         uint256 feeSum;
 
         if (penaltyInfo.delayFee.isValue) {
-            unchecked {
-                feeSum = penaltyInfo.delayFee.value * penaltyMultiplier;
-            }
+            feeSum = _scalePenaltyByMultiplier(
+                penaltyInfo.delayFee.value,
+                penaltyMultiplier
+            );
             chargeWithdrawalRequestFee = true;
         }
 
         if (penaltyInfo.strikesPenalty.isValue) {
-            // It is safe to use unchecked for sum here because base penalties and fees are limited to uint248 in
-            // the MarkedUint248 structures used to store them, and the maximum multiplier is limited to 64, so
-            // `type(uint248).max * 64 < type(uint256).max`.
-            unchecked {
-                penaltySum =
-                    penaltyInfo.strikesPenalty.value *
-                    penaltyMultiplier;
-            }
+            penaltySum = _scalePenaltyByMultiplier(
+                penaltyInfo.strikesPenalty.value,
+                penaltyMultiplier
+            );
             chargeWithdrawalRequestFee = true;
         }
 
@@ -81,24 +84,16 @@ library WithdrawnValidatorLib {
             chargeWithdrawalRequestFee &&
             penaltyInfo.withdrawalRequestFee.value != 0
         ) {
-            // type(uint248).max * (64 + 1) < type(uint256).max
-            unchecked {
-                // Withdrawal request fee is not scaled because sending a withdrawal request for a validator does
-                // not depend on the size of a validator.
-                feeSum += penaltyInfo.withdrawalRequestFee.value;
-            }
+            // Withdrawal request fee is not scaled because sending a withdrawal request for a validator does
+            // not depend on the size of a validator.
+            feeSum += penaltyInfo.withdrawalRequestFee.value;
         }
 
         if (validatorInfo.isSlashed) {
             // Slashing penalty doesn't scale because all the losses are already accounted.
             penaltySum += validatorInfo.slashingPenalty;
         } else if (validatorInfo.exitBalance < MIN_ACTIVATION_BALANCE) {
-            // type(uint248).max * 64 + 32 * 10**18 < type(uint256).max
-            unchecked {
-                penaltySum +=
-                    MIN_ACTIVATION_BALANCE -
-                    validatorInfo.exitBalance;
-            }
+            penaltySum += MIN_ACTIVATION_BALANCE - validatorInfo.exitBalance;
         }
 
         ICSAccounting accounting = ICSModule(address(this)).ACCOUNTING();
@@ -121,16 +116,20 @@ library WithdrawnValidatorLib {
         }
     }
 
+    /// @dev Acts as the numerator to calculate the scaled penalty.
     function _getPenaltyMultiplier(
         WithdrawnValidatorInfo memory validatorInfo
-    ) private pure returns (uint256 penaltyMultiplier) {
-        // penaltyMultiplier is >= 1
-        penaltyMultiplier =
-            Math.max(validatorInfo.exitBalance, MIN_ACTIVATION_BALANCE) /
-            PENALTY_QUOTIENT;
-        // It's rather unlikely that the value will exceed 64 because anything above maximum effective balance of a
-        // validator will likely be withdrawn while it waits for a withdrawal. The introduced limit makes it
-        // possible to use unchecked blocks above and acts as an additional limiting factor.
-        penaltyMultiplier = Math.min(MAX_PENALTY_MULTIPLIER, penaltyMultiplier);
+    ) internal pure returns (uint256 penaltyMultiplier) {
+        uint256 exitBalance = validatorInfo.exitBalance;
+        exitBalance = Math.max(MIN_ACTIVATION_BALANCE, exitBalance);
+        exitBalance = Math.min(MAX_EFFECTIVE_BALANCE, exitBalance);
+        penaltyMultiplier = exitBalance / PENALTY_QUOTIENT;
+    }
+
+    function _scalePenaltyByMultiplier(
+        uint256 penalty,
+        uint256 multiplier
+    ) internal pure returns (uint256) {
+        return (penalty * multiplier) / PENALTY_SCALE;
     }
 }

--- a/src/lib/WithdrawnValidatorLib.sol
+++ b/src/lib/WithdrawnValidatorLib.sol
@@ -1,0 +1,136 @@
+// SPDX-FileCopyrightText: 2025 Lido <info@lido.fi>
+// SPDX-License-Identifier: GPL-3.0
+
+pragma solidity 0.8.24;
+
+import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";
+
+import { ICSModule, WithdrawnValidatorInfo } from "../interfaces/ICSModule.sol";
+import { ExitPenaltyInfo } from "../interfaces/ICSExitPenalties.sol";
+import { ICSAccounting } from "../interfaces/ICSAccounting.sol";
+
+import { SigningKeys } from "./SigningKeys.sol";
+
+/// @dev A library to extract a part of the code from the the CSModule contract.
+library WithdrawnValidatorLib {
+    uint256 public constant MIN_ACTIVATION_BALANCE = 32 ether;
+    uint256 public constant PENALTY_QUOTIENT = 32 ether;
+    uint256 public constant MAX_PENALTY_MULTIPLIER = 64;
+
+    function process(
+        WithdrawnValidatorInfo calldata validatorInfo
+    ) external returns (bool bondCoversPenalties) {
+        bytes memory pubkey = SigningKeys.loadKeys(
+            validatorInfo.nodeOperatorId,
+            validatorInfo.keyIndex,
+            1
+        );
+
+        ExitPenaltyInfo memory penaltyInfo = ICSModule(address(this))
+            .EXIT_PENALTIES()
+            .getExitPenaltyInfo(validatorInfo.nodeOperatorId, pubkey);
+
+        bondCoversPenalties = _fulfilExitObligations(
+            validatorInfo,
+            penaltyInfo
+        );
+
+        // solhint-disable-next-line func-named-parameters
+        emit ICSModule.WithdrawalSubmitted(
+            validatorInfo.nodeOperatorId,
+            validatorInfo.keyIndex,
+            validatorInfo.exitBalance,
+            validatorInfo.slashingPenalty,
+            pubkey
+        );
+    }
+
+    function _fulfilExitObligations(
+        WithdrawnValidatorInfo calldata validatorInfo,
+        ExitPenaltyInfo memory penaltyInfo
+    ) private returns (bool bondCoversPenalties) {
+        bool chargeWithdrawalRequestFee = false;
+
+        uint256 penaltyMultiplier = _getPenaltyMultiplier(validatorInfo);
+        uint256 penaltySum;
+        uint256 feeSum;
+
+        if (penaltyInfo.delayFee.isValue) {
+            unchecked {
+                feeSum = penaltyInfo.delayFee.value * penaltyMultiplier;
+            }
+            chargeWithdrawalRequestFee = true;
+        }
+
+        if (penaltyInfo.strikesPenalty.isValue) {
+            // It is safe to use unchecked for sum here because base penalties and fees are limited to uint248 in
+            // the MarkedUint248 structures used to store them, and the maximum multiplier is limited to 64, so
+            // `type(uint248).max * 64 < type(uint256).max`.
+            unchecked {
+                penaltySum =
+                    penaltyInfo.strikesPenalty.value *
+                    penaltyMultiplier;
+            }
+            chargeWithdrawalRequestFee = true;
+        }
+
+        // The withdrawal request fee is taken when either a delay was reported or the validator exited due to
+        // strikes. Otherwise, the fee has already been paid by the node operator upon withdrawal trigger, or it is
+        // a DAO decision to withdraw the validator before the withdrawal request becomes delayed.
+        if (
+            chargeWithdrawalRequestFee &&
+            penaltyInfo.withdrawalRequestFee.value != 0
+        ) {
+            // type(uint248).max * (64 + 1) < type(uint256).max
+            unchecked {
+                // Withdrawal request fee is not scaled because sending a withdrawal request for a validator does
+                // not depend on the size of a validator.
+                feeSum += penaltyInfo.withdrawalRequestFee.value;
+            }
+        }
+
+        if (validatorInfo.isSlashed) {
+            // Slashing penalty doesn't scale because all the losses are already accounted.
+            penaltySum += validatorInfo.slashingPenalty;
+        } else if (validatorInfo.exitBalance < MIN_ACTIVATION_BALANCE) {
+            // type(uint248).max * 64 + 32 * 10**18 < type(uint256).max
+            unchecked {
+                penaltySum +=
+                    MIN_ACTIVATION_BALANCE -
+                    validatorInfo.exitBalance;
+            }
+        }
+
+        ICSAccounting accounting = ICSModule(address(this)).ACCOUNTING();
+
+        bondCoversPenalties = true;
+
+        if (feeSum > 0) {
+            bondCoversPenalties = accounting.chargeFee(
+                validatorInfo.nodeOperatorId,
+                feeSum
+            );
+        }
+
+        if (penaltySum > 0) {
+            // We still call `penalize` even if there's no bond left, for the lock to be created.
+            bondCoversPenalties = accounting.penalize(
+                validatorInfo.nodeOperatorId,
+                penaltySum
+            );
+        }
+    }
+
+    function _getPenaltyMultiplier(
+        WithdrawnValidatorInfo memory validatorInfo
+    ) private pure returns (uint256 penaltyMultiplier) {
+        // penaltyMultiplier is >= 1
+        penaltyMultiplier =
+            Math.max(validatorInfo.exitBalance, MIN_ACTIVATION_BALANCE) /
+            PENALTY_QUOTIENT;
+        // It's rather unlikely that the value will exceed 64 because anything above maximum effective balance of a
+        // validator will likely be withdrawn while it waits for a withdrawal. The introduced limit makes it
+        // possible to use unchecked blocks above and acts as an additional limiting factor.
+        penaltyMultiplier = Math.min(MAX_PENALTY_MULTIPLIER, penaltyMultiplier);
+    }
+}

--- a/test/unit/CSModule.t.sol
+++ b/test/unit/CSModule.t.sol
@@ -382,7 +382,10 @@ contract CSMCompensateGeneralDelayedPenalty is
     CSMCommon
 {}
 
-contract CSMSubmitWithdrawals is ModuleSubmitWithdrawals, CSMCommon {}
+contract CSMReportWithdrawnValidators is
+    ModuleReportWithdrawnValidators,
+    CSMCommon
+{}
 
 contract CSMGetStakingModuleSummary is
     ModuleGetStakingModuleSummary,

--- a/test/unit/CSVerifier.t.sol
+++ b/test/unit/CSVerifier.t.sol
@@ -14,7 +14,7 @@ import { Slot } from "src/lib/Types.sol";
 import { GIndex } from "src/lib/GIndex.sol";
 
 import { ICSVerifier } from "src/interfaces/ICSVerifier.sol";
-import { ICSModule, ValidatorWithdrawalInfo } from "src/interfaces/ICSModule.sol";
+import { ICSModule, WithdrawnValidatorInfo } from "src/interfaces/ICSModule.sol";
 
 import { GIndices } from "script/constants/GIndices.sol";
 
@@ -420,19 +420,20 @@ contract CSVerifierWithdrawalTest is CSVerifierTestBase {
     }
 
     function test_processWithdrawalProof_HappyPath() public {
-        ValidatorWithdrawalInfo[]
-            memory withdrawals = new ValidatorWithdrawalInfo[](1);
-        withdrawals[0] = ValidatorWithdrawalInfo({
+        WithdrawnValidatorInfo[]
+            memory withdrawals = new WithdrawnValidatorInfo[](1);
+        withdrawals[0] = WithdrawnValidatorInfo({
             nodeOperatorId: 0,
             keyIndex: 0,
             exitBalance: uint256(fixture.data.withdrawal.object.amount) * 1e9,
-            slashingPenalty: 0
+            slashingPenalty: 0,
+            isSlashed: false
         });
 
         vm.expectCall(
             address(module),
             abi.encodeWithSelector(
-                ICSModule.submitWithdrawals.selector,
+                ICSModule.reportWithdrawnValidators.selector,
                 withdrawals
             )
         );
@@ -650,7 +651,9 @@ contract CSVerifierWithdrawalTest is CSVerifierTestBase {
 
         vm.mockCall(
             address(module),
-            abi.encodeWithSelector(ICSModule.submitWithdrawals.selector),
+            abi.encodeWithSelector(
+                ICSModule.reportWithdrawnValidators.selector
+            ),
             ""
         );
     }
@@ -904,19 +907,20 @@ contract CSVerifierConsolidationTest is CSVerifierTestBase {
     }
 
     function test_processConsolidationProof_HappyPath() public {
-        ValidatorWithdrawalInfo[]
-            memory withdrawals = new ValidatorWithdrawalInfo[](1);
-        withdrawals[0] = ValidatorWithdrawalInfo({
+        WithdrawnValidatorInfo[]
+            memory withdrawals = new WithdrawnValidatorInfo[](1);
+        withdrawals[0] = WithdrawnValidatorInfo({
             nodeOperatorId: fixture.data.validator.nodeOperatorId,
             keyIndex: fixture.data.validator.keyIndex,
             exitBalance: fixture.balanceWei,
-            slashingPenalty: 0
+            slashingPenalty: 0,
+            isSlashed: false
         });
 
         vm.expectCall(
             address(module),
             abi.encodeWithSelector(
-                ICSModule.submitWithdrawals.selector,
+                ICSModule.reportWithdrawnValidators.selector,
                 withdrawals
             )
         );
@@ -1030,7 +1034,9 @@ contract CSVerifierConsolidationTest is CSVerifierTestBase {
 
         vm.mockCall(
             address(module),
-            abi.encodeWithSelector(ICSModule.submitWithdrawals.selector),
+            abi.encodeWithSelector(
+                ICSModule.reportWithdrawnValidators.selector
+            ),
             ""
         );
     }

--- a/test/unit/CSVerifierHistorical.t.sol
+++ b/test/unit/CSVerifierHistorical.t.sol
@@ -5,7 +5,7 @@ pragma solidity 0.8.24;
 import { Test } from "forge-std/Test.sol";
 
 import { ICSVerifier } from "src/interfaces/ICSVerifier.sol";
-import { ICSModule, ValidatorWithdrawalInfo } from "src/interfaces/ICSModule.sol";
+import { ICSModule, WithdrawnValidatorInfo } from "src/interfaces/ICSModule.sol";
 import { GIndex } from "src/lib/GIndex.sol";
 
 import { CSVerifier } from "src/CSVerifier.sol";
@@ -72,7 +72,9 @@ contract CSVerifierHistoricalBase is Test, Utilities {
 
         vm.mockCall(
             address(module),
-            abi.encodeWithSelector(ICSModule.submitWithdrawals.selector),
+            abi.encodeWithSelector(
+                ICSModule.reportWithdrawnValidators.selector
+            ),
             ""
         );
     }
@@ -126,19 +128,20 @@ contract CSVerifierHistoricalTest is CSVerifierHistoricalBase {
     }
 
     function test_processHistoricalWithdrawalProof_HappyPath() public {
-        ValidatorWithdrawalInfo[]
-            memory withdrawals = new ValidatorWithdrawalInfo[](1);
-        withdrawals[0] = ValidatorWithdrawalInfo({
+        WithdrawnValidatorInfo[]
+            memory withdrawals = new WithdrawnValidatorInfo[](1);
+        withdrawals[0] = WithdrawnValidatorInfo({
             nodeOperatorId: 0,
             keyIndex: 0,
             exitBalance: uint256(fixture.data.withdrawal.object.amount) * 1e9,
-            slashingPenalty: 0
+            slashingPenalty: 0,
+            isSlashed: false
         });
 
         vm.expectCall(
             address(module),
             abi.encodeWithSelector(
-                ICSModule.submitWithdrawals.selector,
+                ICSModule.reportWithdrawnValidators.selector,
                 withdrawals
             )
         );
@@ -315,19 +318,20 @@ contract CSVerifierCrossForkHistoricalTest is CSVerifierHistoricalBase {
     }
 
     function test_processHistoricalWithdrawalProof_HappyPath() public {
-        ValidatorWithdrawalInfo[]
-            memory withdrawals = new ValidatorWithdrawalInfo[](1);
-        withdrawals[0] = ValidatorWithdrawalInfo({
+        WithdrawnValidatorInfo[]
+            memory withdrawals = new WithdrawnValidatorInfo[](1);
+        withdrawals[0] = WithdrawnValidatorInfo({
             nodeOperatorId: 0,
             keyIndex: 0,
             exitBalance: uint256(fixture.data.withdrawal.object.amount) * 1e9,
-            slashingPenalty: 0
+            slashingPenalty: 0,
+            isSlashed: false
         });
 
         vm.expectCall(
             address(module),
             abi.encodeWithSelector(
-                ICSModule.submitWithdrawals.selector,
+                ICSModule.reportWithdrawnValidators.selector,
                 withdrawals
             )
         );
@@ -373,19 +377,20 @@ contract CSVerifierCrossForkHistoricalAtPivotSlotTest is
     }
 
     function test_processHistoricalWithdrawalProof_HappyPath() public {
-        ValidatorWithdrawalInfo[]
-            memory withdrawals = new ValidatorWithdrawalInfo[](1);
-        withdrawals[0] = ValidatorWithdrawalInfo({
+        WithdrawnValidatorInfo[]
+            memory withdrawals = new WithdrawnValidatorInfo[](1);
+        withdrawals[0] = WithdrawnValidatorInfo({
             nodeOperatorId: 0,
             keyIndex: 0,
             exitBalance: uint256(fixture.data.withdrawal.object.amount) * 1e9,
-            slashingPenalty: 0
+            slashingPenalty: 0,
+            isSlashed: false
         });
 
         vm.expectCall(
             address(module),
             abi.encodeWithSelector(
-                ICSModule.submitWithdrawals.selector,
+                ICSModule.reportWithdrawnValidators.selector,
                 withdrawals
             )
         );

--- a/test/unit/ModuleAbstract.t.sol
+++ b/test/unit/ModuleAbstract.t.sol
@@ -2,35 +2,39 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity 0.8.24;
 
-import { Test, Vm } from "forge-std/Test.sol";
 import { Strings } from "@openzeppelin/contracts/utils/Strings.sol";
-import { Utilities } from "../helpers/Utilities.sol";
+
+import { console } from "forge-std/console.sol";
+import { Test, Vm } from "forge-std/Test.sol";
+
+import { Batch } from "src/lib/QueueLib.sol";
+import { CSBondLock } from "src/abstract/CSBondLock.sol";
+import { CSModule } from "src/CSModule.sol";
+import { IAssetRecovererLib } from "src/lib/AssetRecovererLib.sol";
+import { ICSAccounting } from "src/interfaces/ICSAccounting.sol";
+import { ICSExitPenalties, ExitPenaltyInfo, MarkedUint248 } from "src/interfaces/ICSExitPenalties.sol";
+import { ICSModule, NodeOperator, NodeOperatorManagementProperties, WithdrawnValidatorInfo } from "src/interfaces/ICSModule.sol";
+import { IGeneralPenalty } from "src/lib/GeneralPenaltyLib.sol";
+import { ILidoLocator } from "src/interfaces/ILidoLocator.sol";
+import { INOAddresses } from "src/lib/NOAddresses.sol";
+import { INodeOperatorOwner } from "src/interfaces/INodeOperatorOwner.sol";
+import { IStakingModule } from "src/interfaces/IStakingModule.sol";
+import { IWithdrawalQueue } from "src/interfaces/IWithdrawalQueue.sol";
+import { PausableUntil } from "src/lib/utils/PausableUntil.sol";
+import { SigningKeys } from "src/lib/SigningKeys.sol";
+import { WithdrawnValidatorLib } from "src/lib/WithdrawnValidatorLib.sol";
+
+import { CSAccountingMock } from "../helpers/mocks/CSAccountingMock.sol";
+import { CSParametersRegistryMock } from "../helpers/mocks/CSParametersRegistryMock.sol";
+import { ERC20Testable } from "../helpers/ERCTestable.sol";
+import { ExitPenaltiesMock } from "../helpers/mocks/ExitPenaltiesMock.sol";
 import { Fixtures } from "../helpers/Fixtures.sol";
 import { InvariantAsserts } from "../helpers/InvariantAsserts.sol";
-import { console } from "forge-std/console.sol";
-import { ICSModule, NodeOperator, NodeOperatorManagementProperties, ValidatorWithdrawalInfo } from "src/interfaces/ICSModule.sol";
-import { CSAccountingMock } from "../helpers/mocks/CSAccountingMock.sol";
-import { ExitPenaltiesMock } from "../helpers/mocks/ExitPenaltiesMock.sol";
-import { CSParametersRegistryMock } from "../helpers/mocks/CSParametersRegistryMock.sol";
 import { LidoLocatorMock } from "../helpers/mocks/LidoLocatorMock.sol";
 import { LidoMock } from "../helpers/mocks/LidoMock.sol";
-import { WstETHMock } from "../helpers/mocks/WstETHMock.sol";
-import { CSModule } from "src/CSModule.sol";
 import { Stub } from "../helpers/mocks/Stub.sol";
-import { Batch } from "src/lib/QueueLib.sol";
-import { ERC20Testable } from "../helpers/ERCTestable.sol";
-import { PausableUntil } from "src/lib/utils/PausableUntil.sol";
-import { ICSAccounting } from "src/interfaces/ICSAccounting.sol";
-import { IStakingModule } from "src/interfaces/IStakingModule.sol";
-import { ILidoLocator } from "src/interfaces/ILidoLocator.sol";
-import { IWithdrawalQueue } from "src/interfaces/IWithdrawalQueue.sol";
-import { SigningKeys } from "src/lib/SigningKeys.sol";
-import { INOAddresses } from "src/lib/NOAddresses.sol";
-import { IGeneralPenalty } from "src/lib/GeneralPenaltyLib.sol";
-import { CSBondLock } from "src/abstract/CSBondLock.sol";
-import { ICSExitPenalties, ExitPenaltyInfo, MarkedUint248 } from "src/interfaces/ICSExitPenalties.sol";
-import { IAssetRecovererLib } from "src/lib/AssetRecovererLib.sol";
-import { INodeOperatorOwner } from "src/interfaces/INodeOperatorOwner.sol";
+import { Utilities } from "../helpers/Utilities.sol";
+import { WstETHMock } from "../helpers/mocks/WstETHMock.sol";
 
 abstract contract ModuleFixtures is
     Test,
@@ -209,15 +213,16 @@ abstract contract ModuleFixtures is
     }
 
     function withdrawKey(uint256 noId, uint256 /* keyIndex */) internal {
-        ValidatorWithdrawalInfo[]
-            memory withdrawalsInfo = new ValidatorWithdrawalInfo[](1);
-        withdrawalsInfo[0] = ValidatorWithdrawalInfo(
-            noId,
-            0,
-            module.MIN_ACTIVATION_BALANCE(),
-            0
-        );
-        module.submitWithdrawals(withdrawalsInfo);
+        WithdrawnValidatorInfo[]
+            memory withdrawalsInfo = new WithdrawnValidatorInfo[](1);
+        withdrawalsInfo[0] = WithdrawnValidatorInfo({
+            nodeOperatorId: noId,
+            keyIndex: 0,
+            exitBalance: WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE,
+            slashingPenalty: 0,
+            isSlashed: false
+        });
+        module.reportWithdrawnValidators(withdrawalsInfo);
     }
 
     // Checks that the queue is in the expected state starting from its head.
@@ -3189,19 +3194,21 @@ abstract contract ModuleQueueOps is ModuleFixtures {
         module.obtainDepositData(2, "");
         module.cleanDepositQueue(1);
 
-        ValidatorWithdrawalInfo[]
-            memory withdrawalInfo = new ValidatorWithdrawalInfo[](1);
-
-        withdrawalInfo[0] = ValidatorWithdrawalInfo(
-            noId,
-            0,
-            module.MIN_ACTIVATION_BALANCE(),
-            0
+        WithdrawnValidatorInfo[] memory exitInfo = new WithdrawnValidatorInfo[](
+            1
         );
+
+        exitInfo[0] = WithdrawnValidatorInfo({
+            nodeOperatorId: noId,
+            keyIndex: 0,
+            exitBalance: WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE,
+            slashingPenalty: 0,
+            isSlashed: false
+        });
 
         vm.expectEmit(address(module));
         emit ICSModule.BatchEnqueued(module.QUEUE_LOWEST_PRIORITY(), noId, 1);
-        module.submitWithdrawals(withdrawalInfo);
+        module.reportWithdrawnValidators(exitInfo);
     }
 }
 
@@ -4213,17 +4220,19 @@ abstract contract ModuleGetNodeOperatorNonWithdrawnKeys is ModuleFixtures {
         uint256 noId = createNodeOperator(3);
         module.obtainDepositData(3, "");
 
-        ValidatorWithdrawalInfo[]
-            memory withdrawalInfo = new ValidatorWithdrawalInfo[](1);
-
-        withdrawalInfo[0] = ValidatorWithdrawalInfo(
-            noId,
-            0,
-            module.MIN_ACTIVATION_BALANCE(),
-            0
+        WithdrawnValidatorInfo[] memory exitInfo = new WithdrawnValidatorInfo[](
+            1
         );
 
-        module.submitWithdrawals(withdrawalInfo);
+        exitInfo[0] = WithdrawnValidatorInfo({
+            nodeOperatorId: noId,
+            keyIndex: 0,
+            exitBalance: WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE,
+            slashingPenalty: 0,
+            isSlashed: false
+        });
+
+        module.reportWithdrawnValidators(exitInfo);
         uint256 keys = module.getNodeOperatorNonWithdrawnKeys(noId);
         assertEq(keys, 2);
     }
@@ -6009,32 +6018,34 @@ abstract contract ModuleCompensateGeneralDelayedPenalty is ModuleFixtures {
 }
 
 abstract contract ModuleSubmitWithdrawals is ModuleFixtures {
-    function test_submitWithdrawals() public assertInvariants {
+    function test_reportWithdrawnValidators() public assertInvariants {
         uint256 keyIndex = 0;
         uint256 noId = createNodeOperator();
         (bytes memory pubkey, ) = module.obtainDepositData(1, "");
 
         uint256 nonce = module.getNonce();
 
-        ValidatorWithdrawalInfo[]
-            memory withdrawalInfo = new ValidatorWithdrawalInfo[](1);
-
-        withdrawalInfo[0] = ValidatorWithdrawalInfo(
-            noId,
-            keyIndex,
-            module.MIN_ACTIVATION_BALANCE(),
-            0
+        WithdrawnValidatorInfo[] memory exitInfo = new WithdrawnValidatorInfo[](
+            1
         );
+
+        exitInfo[0] = WithdrawnValidatorInfo({
+            nodeOperatorId: noId,
+            keyIndex: keyIndex,
+            exitBalance: WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE,
+            slashingPenalty: 0,
+            isSlashed: false
+        });
 
         vm.expectEmit(address(module));
         emit ICSModule.WithdrawalSubmitted(
             noId,
             keyIndex,
-            module.MIN_ACTIVATION_BALANCE(),
+            WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE,
             0,
             pubkey
         );
-        module.submitWithdrawals(withdrawalInfo);
+        module.reportWithdrawnValidators(exitInfo);
 
         NodeOperator memory no = module.getNodeOperator(noId);
         assertEq(no.totalWithdrawnKeys, 1);
@@ -6047,7 +6058,10 @@ abstract contract ModuleSubmitWithdrawals is ModuleFixtures {
         assertEq(module.getNonce(), nonce + 1);
     }
 
-    function test_submitWithdrawals_changeNonce() public assertInvariants {
+    function test_reportWithdrawnValidators_changeNonce()
+        public
+        assertInvariants
+    {
         uint256 keyIndex = 0;
         uint256 noId = createNodeOperator(2);
         (bytes memory pubkey, ) = module.obtainDepositData(1, "");
@@ -6056,25 +6070,28 @@ abstract contract ModuleSubmitWithdrawals is ModuleFixtures {
 
         uint256 balanceShortage = BOND_SIZE - 1 ether;
 
-        ValidatorWithdrawalInfo[]
-            memory withdrawalInfo = new ValidatorWithdrawalInfo[](1);
-
-        withdrawalInfo[0] = ValidatorWithdrawalInfo(
-            noId,
-            keyIndex,
-            module.MIN_ACTIVATION_BALANCE() - balanceShortage,
-            0
+        WithdrawnValidatorInfo[] memory exitInfo = new WithdrawnValidatorInfo[](
+            1
         );
+
+        exitInfo[0] = WithdrawnValidatorInfo({
+            nodeOperatorId: noId,
+            keyIndex: keyIndex,
+            exitBalance: WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE -
+                balanceShortage,
+            slashingPenalty: 0,
+            isSlashed: false
+        });
 
         vm.expectEmit(address(module));
         emit ICSModule.WithdrawalSubmitted(
             noId,
             keyIndex,
-            module.MIN_ACTIVATION_BALANCE() - balanceShortage,
+            WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE - balanceShortage,
             0,
             pubkey
         );
-        module.submitWithdrawals(withdrawalInfo);
+        module.reportWithdrawnValidators(exitInfo);
 
         NodeOperator memory no = module.getNodeOperator(noId);
         assertEq(no.totalWithdrawnKeys, 1);
@@ -6085,22 +6102,28 @@ abstract contract ModuleSubmitWithdrawals is ModuleFixtures {
         assertEq(module.getNonce(), nonce + 1);
     }
 
-    function test_submitWithdrawals_lowExitBalance() public assertInvariants {
+    function test_reportWithdrawnValidators_lowExitBalance()
+        public
+        assertInvariants
+    {
         uint256 keyIndex = 0;
         uint256 noId = createNodeOperator();
         module.obtainDepositData(1, "");
 
         uint256 balanceShortage = BOND_SIZE - 1 ether;
 
-        ValidatorWithdrawalInfo[]
-            memory withdrawalInfo = new ValidatorWithdrawalInfo[](1);
-
-        withdrawalInfo[0] = ValidatorWithdrawalInfo(
-            noId,
-            keyIndex,
-            module.MIN_ACTIVATION_BALANCE() - balanceShortage,
-            0
+        WithdrawnValidatorInfo[] memory exitInfo = new WithdrawnValidatorInfo[](
+            1
         );
+
+        exitInfo[0] = WithdrawnValidatorInfo({
+            nodeOperatorId: noId,
+            keyIndex: keyIndex,
+            exitBalance: WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE -
+                balanceShortage,
+            slashingPenalty: 0,
+            isSlashed: false
+        });
 
         vm.expectCall(
             address(accounting),
@@ -6110,7 +6133,7 @@ abstract contract ModuleSubmitWithdrawals is ModuleFixtures {
                 balanceShortage
             )
         );
-        module.submitWithdrawals(withdrawalInfo);
+        module.reportWithdrawnValidators(exitInfo);
 
         NodeOperator memory no = module.getNodeOperator(noId);
         assertEq(no.totalWithdrawnKeys, 1);
@@ -6119,7 +6142,7 @@ abstract contract ModuleSubmitWithdrawals is ModuleFixtures {
         assertEq(no.targetLimitMode, 0);
     }
 
-    function test_submitWithdrawals_superLowExitBalance()
+    function test_reportWithdrawnValidators_superLowExitBalance()
         public
         assertInvariants
     {
@@ -6129,15 +6152,18 @@ abstract contract ModuleSubmitWithdrawals is ModuleFixtures {
 
         uint256 balanceShortage = BOND_SIZE + 1 ether;
 
-        ValidatorWithdrawalInfo[]
-            memory withdrawalInfo = new ValidatorWithdrawalInfo[](1);
-
-        withdrawalInfo[0] = ValidatorWithdrawalInfo(
-            noId,
-            keyIndex,
-            module.MIN_ACTIVATION_BALANCE() - balanceShortage,
-            0
+        WithdrawnValidatorInfo[] memory exitInfo = new WithdrawnValidatorInfo[](
+            1
         );
+
+        exitInfo[0] = WithdrawnValidatorInfo({
+            nodeOperatorId: noId,
+            keyIndex: keyIndex,
+            exitBalance: WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE -
+                balanceShortage,
+            slashingPenalty: 0,
+            isSlashed: false
+        });
 
         vm.expectCall(
             address(accounting),
@@ -6147,7 +6173,7 @@ abstract contract ModuleSubmitWithdrawals is ModuleFixtures {
                 balanceShortage
             )
         );
-        module.submitWithdrawals(withdrawalInfo);
+        module.reportWithdrawnValidators(exitInfo);
 
         NodeOperator memory no = module.getNodeOperator(noId);
         assertEq(no.totalWithdrawnKeys, 1);
@@ -6156,7 +6182,10 @@ abstract contract ModuleSubmitWithdrawals is ModuleFixtures {
         assertEq(no.targetLimitMode, 2);
     }
 
-    function test_submitWithdrawals_exitDelayFee() public assertInvariants {
+    function test_reportWithdrawnValidators_exitDelayFee()
+        public
+        assertInvariants
+    {
         uint256 keyIndex = 0;
         uint256 noId = createNodeOperator();
         module.obtainDepositData(1, "");
@@ -6171,15 +6200,17 @@ abstract contract ModuleSubmitWithdrawals is ModuleFixtures {
             })
         );
 
-        ValidatorWithdrawalInfo[]
-            memory withdrawalInfo = new ValidatorWithdrawalInfo[](1);
-
-        withdrawalInfo[0] = ValidatorWithdrawalInfo(
-            noId,
-            keyIndex,
-            module.MIN_ACTIVATION_BALANCE(),
-            0
+        WithdrawnValidatorInfo[] memory exitInfo = new WithdrawnValidatorInfo[](
+            1
         );
+
+        exitInfo[0] = WithdrawnValidatorInfo({
+            nodeOperatorId: noId,
+            keyIndex: keyIndex,
+            exitBalance: WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE,
+            slashingPenalty: 0,
+            isSlashed: false
+        });
 
         vm.expectCall(
             address(accounting),
@@ -6189,7 +6220,7 @@ abstract contract ModuleSubmitWithdrawals is ModuleFixtures {
                 exitDelayFeeAmount
             )
         );
-        module.submitWithdrawals(withdrawalInfo);
+        module.reportWithdrawnValidators(exitInfo);
 
         NodeOperator memory no = module.getNodeOperator(noId);
         assertEq(no.totalWithdrawnKeys, 1);
@@ -6198,7 +6229,10 @@ abstract contract ModuleSubmitWithdrawals is ModuleFixtures {
         assertEq(no.targetLimitMode, 0);
     }
 
-    function test_submitWithdrawals_hugeExitDelayFee() public assertInvariants {
+    function test_reportWithdrawnValidators_hugeExitDelayFee()
+        public
+        assertInvariants
+    {
         uint256 keyIndex = 0;
         uint256 noId = createNodeOperator();
         module.obtainDepositData(1, "");
@@ -6213,15 +6247,17 @@ abstract contract ModuleSubmitWithdrawals is ModuleFixtures {
             })
         );
 
-        ValidatorWithdrawalInfo[]
-            memory withdrawalInfo = new ValidatorWithdrawalInfo[](1);
-
-        withdrawalInfo[0] = ValidatorWithdrawalInfo(
-            noId,
-            keyIndex,
-            module.MIN_ACTIVATION_BALANCE(),
-            0
+        WithdrawnValidatorInfo[] memory exitInfo = new WithdrawnValidatorInfo[](
+            1
         );
+
+        exitInfo[0] = WithdrawnValidatorInfo({
+            nodeOperatorId: noId,
+            keyIndex: keyIndex,
+            exitBalance: WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE,
+            slashingPenalty: 0,
+            isSlashed: false
+        });
 
         vm.expectCall(
             address(accounting),
@@ -6231,7 +6267,7 @@ abstract contract ModuleSubmitWithdrawals is ModuleFixtures {
                 exitDelayFeeAmount
             )
         );
-        module.submitWithdrawals(withdrawalInfo);
+        module.reportWithdrawnValidators(exitInfo);
 
         NodeOperator memory no = module.getNodeOperator(noId);
         assertEq(no.totalWithdrawnKeys, 1);
@@ -6240,7 +6276,7 @@ abstract contract ModuleSubmitWithdrawals is ModuleFixtures {
         assertEq(no.targetLimitMode, 2);
     }
 
-    function test_submitWithdrawals_exitDelayFeeWithMultiplier()
+    function test_reportWithdrawnValidators_exitDelayFeeWithMultiplier()
         public
         assertInvariants
     {
@@ -6259,14 +6295,18 @@ abstract contract ModuleSubmitWithdrawals is ModuleFixtures {
             })
         );
 
-        ValidatorWithdrawalInfo[]
-            memory withdrawalInfo = new ValidatorWithdrawalInfo[](1);
-        withdrawalInfo[0] = ValidatorWithdrawalInfo(
-            noId,
-            keyIndex,
-            module.MIN_ACTIVATION_BALANCE() * multiplier + 1 ether,
-            0
+        WithdrawnValidatorInfo[] memory exitInfo = new WithdrawnValidatorInfo[](
+            1
         );
+        exitInfo[0] = WithdrawnValidatorInfo({
+            nodeOperatorId: noId,
+            keyIndex: keyIndex,
+            exitBalance: WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE *
+                multiplier +
+                1 ether,
+            slashingPenalty: 0,
+            isSlashed: false
+        });
 
         vm.expectCall(
             address(accounting),
@@ -6276,10 +6316,10 @@ abstract contract ModuleSubmitWithdrawals is ModuleFixtures {
                 fee * multiplier
             )
         );
-        module.submitWithdrawals(withdrawalInfo);
+        module.reportWithdrawnValidators(exitInfo);
     }
 
-    function test_submitWithdrawals_exitDelayFeeAtMaxWithMultiplier()
+    function test_reportWithdrawnValidators_exitDelayFeeAtMaxWithMultiplier()
         public
         assertInvariants
     {
@@ -6288,7 +6328,7 @@ abstract contract ModuleSubmitWithdrawals is ModuleFixtures {
         module.obtainDepositData(1, "");
 
         uint248 fee = type(uint248).max;
-        uint256 multiplier = module.MAX_PENALTY_MULTIPLIER();
+        uint256 multiplier = WithdrawnValidatorLib.MAX_PENALTY_MULTIPLIER;
 
         exitPenalties.mock_setDelayedExitPenaltyInfo(
             ExitPenaltyInfo({
@@ -6298,14 +6338,18 @@ abstract contract ModuleSubmitWithdrawals is ModuleFixtures {
             })
         );
 
-        ValidatorWithdrawalInfo[]
-            memory withdrawalInfo = new ValidatorWithdrawalInfo[](1);
-        withdrawalInfo[0] = ValidatorWithdrawalInfo(
-            noId,
-            keyIndex,
-            module.MIN_ACTIVATION_BALANCE() * multiplier + 1000 ether,
-            0
+        WithdrawnValidatorInfo[] memory exitInfo = new WithdrawnValidatorInfo[](
+            1
         );
+        exitInfo[0] = WithdrawnValidatorInfo({
+            nodeOperatorId: noId,
+            keyIndex: keyIndex,
+            exitBalance: WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE *
+                multiplier +
+                1000 ether,
+            slashingPenalty: 0,
+            isSlashed: false
+        });
 
         vm.expectCall(
             address(accounting),
@@ -6315,10 +6359,13 @@ abstract contract ModuleSubmitWithdrawals is ModuleFixtures {
                 fee * multiplier
             )
         );
-        module.submitWithdrawals(withdrawalInfo);
+        module.reportWithdrawnValidators(exitInfo);
     }
 
-    function test_submitWithdrawals_strikesPenalty() public assertInvariants {
+    function test_reportWithdrawnValidators_strikesPenalty()
+        public
+        assertInvariants
+    {
         uint256 keyIndex = 0;
         uint256 noId = createNodeOperator();
         module.obtainDepositData(1, "");
@@ -6336,15 +6383,17 @@ abstract contract ModuleSubmitWithdrawals is ModuleFixtures {
             })
         );
 
-        ValidatorWithdrawalInfo[]
-            memory withdrawalInfo = new ValidatorWithdrawalInfo[](1);
-
-        withdrawalInfo[0] = ValidatorWithdrawalInfo(
-            noId,
-            keyIndex,
-            module.MIN_ACTIVATION_BALANCE(),
-            0
+        WithdrawnValidatorInfo[] memory exitInfo = new WithdrawnValidatorInfo[](
+            1
         );
+
+        exitInfo[0] = WithdrawnValidatorInfo({
+            nodeOperatorId: noId,
+            keyIndex: keyIndex,
+            exitBalance: WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE,
+            slashingPenalty: 0,
+            isSlashed: false
+        });
 
         vm.expectCall(
             address(accounting),
@@ -6354,7 +6403,7 @@ abstract contract ModuleSubmitWithdrawals is ModuleFixtures {
                 strikesPenaltyAmount
             )
         );
-        module.submitWithdrawals(withdrawalInfo);
+        module.reportWithdrawnValidators(exitInfo);
 
         NodeOperator memory no = module.getNodeOperator(noId);
         assertEq(no.totalWithdrawnKeys, 1);
@@ -6363,7 +6412,7 @@ abstract contract ModuleSubmitWithdrawals is ModuleFixtures {
         assertEq(no.targetLimitMode, 0);
     }
 
-    function test_submitWithdrawals_hugeStrikesPenalty()
+    function test_reportWithdrawnValidators_hugeStrikesPenalty()
         public
         assertInvariants
     {
@@ -6384,15 +6433,17 @@ abstract contract ModuleSubmitWithdrawals is ModuleFixtures {
             })
         );
 
-        ValidatorWithdrawalInfo[]
-            memory withdrawalInfo = new ValidatorWithdrawalInfo[](1);
-
-        withdrawalInfo[0] = ValidatorWithdrawalInfo(
-            noId,
-            keyIndex,
-            module.MIN_ACTIVATION_BALANCE(),
-            0
+        WithdrawnValidatorInfo[] memory exitInfo = new WithdrawnValidatorInfo[](
+            1
         );
+
+        exitInfo[0] = WithdrawnValidatorInfo({
+            nodeOperatorId: noId,
+            keyIndex: keyIndex,
+            exitBalance: WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE,
+            slashingPenalty: 0,
+            isSlashed: false
+        });
 
         vm.expectCall(
             address(accounting),
@@ -6402,7 +6453,7 @@ abstract contract ModuleSubmitWithdrawals is ModuleFixtures {
                 strikesPenaltyAmount
             )
         );
-        module.submitWithdrawals(withdrawalInfo);
+        module.reportWithdrawnValidators(exitInfo);
 
         NodeOperator memory no = module.getNodeOperator(noId);
         assertEq(no.totalWithdrawnKeys, 1);
@@ -6411,7 +6462,7 @@ abstract contract ModuleSubmitWithdrawals is ModuleFixtures {
         assertEq(no.targetLimitMode, 2);
     }
 
-    function test_submitWithdrawals_strikesPenaltyWithMultiplier()
+    function test_reportWithdrawnValidators_strikesPenaltyWithMultiplier()
         public
         assertInvariants
     {
@@ -6430,14 +6481,18 @@ abstract contract ModuleSubmitWithdrawals is ModuleFixtures {
             })
         );
 
-        ValidatorWithdrawalInfo[]
-            memory withdrawalInfo = new ValidatorWithdrawalInfo[](1);
-        withdrawalInfo[0] = ValidatorWithdrawalInfo(
-            noId,
-            keyIndex,
-            module.MIN_ACTIVATION_BALANCE() * multiplier + 1 ether,
-            0
+        WithdrawnValidatorInfo[] memory exitInfo = new WithdrawnValidatorInfo[](
+            1
         );
+        exitInfo[0] = WithdrawnValidatorInfo({
+            nodeOperatorId: noId,
+            keyIndex: keyIndex,
+            exitBalance: WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE *
+                multiplier +
+                1 ether,
+            slashingPenalty: 0,
+            isSlashed: false
+        });
 
         vm.expectCall(
             address(accounting),
@@ -6447,10 +6502,10 @@ abstract contract ModuleSubmitWithdrawals is ModuleFixtures {
                 penalty * multiplier
             )
         );
-        module.submitWithdrawals(withdrawalInfo);
+        module.reportWithdrawnValidators(exitInfo);
     }
 
-    function test_submitWithdrawals_strikesPenaltyAtMaxWithMultiplier()
+    function test_reportWithdrawnValidators_strikesPenaltyAtMaxWithMultiplier()
         public
         assertInvariants
     {
@@ -6459,7 +6514,7 @@ abstract contract ModuleSubmitWithdrawals is ModuleFixtures {
         module.obtainDepositData(1, "");
 
         uint248 penalty = type(uint248).max;
-        uint256 multiplier = module.MAX_PENALTY_MULTIPLIER();
+        uint256 multiplier = WithdrawnValidatorLib.MAX_PENALTY_MULTIPLIER;
 
         exitPenalties.mock_setDelayedExitPenaltyInfo(
             ExitPenaltyInfo({
@@ -6469,14 +6524,18 @@ abstract contract ModuleSubmitWithdrawals is ModuleFixtures {
             })
         );
 
-        ValidatorWithdrawalInfo[]
-            memory withdrawalInfo = new ValidatorWithdrawalInfo[](1);
-        withdrawalInfo[0] = ValidatorWithdrawalInfo(
-            noId,
-            keyIndex,
-            module.MIN_ACTIVATION_BALANCE() * multiplier + 1000 ether,
-            0
+        WithdrawnValidatorInfo[] memory exitInfo = new WithdrawnValidatorInfo[](
+            1
         );
+        exitInfo[0] = WithdrawnValidatorInfo({
+            nodeOperatorId: noId,
+            keyIndex: keyIndex,
+            exitBalance: WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE *
+                multiplier +
+                1000 ether,
+            slashingPenalty: 0,
+            isSlashed: false
+        });
 
         vm.expectCall(
             address(accounting),
@@ -6486,10 +6545,10 @@ abstract contract ModuleSubmitWithdrawals is ModuleFixtures {
                 penalty * multiplier
             )
         );
-        module.submitWithdrawals(withdrawalInfo);
+        module.reportWithdrawnValidators(exitInfo);
     }
 
-    function test_submitWithdrawals_slashingPenaltyApplied()
+    function test_reportWithdrawnValidators_slashingPenaltyApplied()
         public
         assertInvariants
     {
@@ -6500,14 +6559,16 @@ abstract contract ModuleSubmitWithdrawals is ModuleFixtures {
 
         uint256 slashingPenalty = 5 ether;
 
-        ValidatorWithdrawalInfo[]
-            memory withdrawalInfo = new ValidatorWithdrawalInfo[](1);
-        withdrawalInfo[0] = ValidatorWithdrawalInfo(
-            noId,
-            keyIndex,
-            module.MIN_ACTIVATION_BALANCE(),
-            slashingPenalty
+        WithdrawnValidatorInfo[] memory exitInfo = new WithdrawnValidatorInfo[](
+            1
         );
+        exitInfo[0] = WithdrawnValidatorInfo({
+            nodeOperatorId: noId,
+            keyIndex: keyIndex,
+            exitBalance: WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE,
+            slashingPenalty: slashingPenalty,
+            isSlashed: true
+        });
 
         vm.expectCall(
             address(accounting),
@@ -6517,10 +6578,10 @@ abstract contract ModuleSubmitWithdrawals is ModuleFixtures {
                 slashingPenalty
             )
         );
-        module.submitWithdrawals(withdrawalInfo);
+        module.reportWithdrawnValidators(exitInfo);
     }
 
-    function test_submitWithdrawals_slashingPenaltyOverridesExitBalancePenalty()
+    function test_reportWithdrawnValidators_slashingPenaltyOverridesExitBalancePenalty()
         public
         assertInvariants
     {
@@ -6531,14 +6592,17 @@ abstract contract ModuleSubmitWithdrawals is ModuleFixtures {
 
         uint256 slashingPenalty = 5 ether;
 
-        ValidatorWithdrawalInfo[]
-            memory withdrawalInfo = new ValidatorWithdrawalInfo[](1);
-        withdrawalInfo[0] = ValidatorWithdrawalInfo(
-            noId,
-            keyIndex,
-            module.MIN_ACTIVATION_BALANCE() - 11 ether,
-            slashingPenalty
+        WithdrawnValidatorInfo[] memory exitInfo = new WithdrawnValidatorInfo[](
+            1
         );
+        exitInfo[0] = WithdrawnValidatorInfo({
+            nodeOperatorId: noId,
+            keyIndex: keyIndex,
+            exitBalance: WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE -
+                11 ether,
+            slashingPenalty: slashingPenalty,
+            isSlashed: true
+        });
 
         vm.expectCall(
             address(accounting),
@@ -6548,10 +6612,10 @@ abstract contract ModuleSubmitWithdrawals is ModuleFixtures {
                 slashingPenalty
             )
         );
-        module.submitWithdrawals(withdrawalInfo);
+        module.reportWithdrawnValidators(exitInfo);
     }
 
-    function test_submitWithdrawals_slashingPenaltyNotScaled()
+    function test_reportWithdrawnValidators_slashingPenaltyNotScaled()
         public
         assertInvariants
     {
@@ -6563,14 +6627,17 @@ abstract contract ModuleSubmitWithdrawals is ModuleFixtures {
         uint256 slashingPenalty = 7 ether;
         uint256 multiplier = 5;
 
-        ValidatorWithdrawalInfo[]
-            memory withdrawalInfo = new ValidatorWithdrawalInfo[](1);
-        withdrawalInfo[0] = ValidatorWithdrawalInfo(
-            noId,
-            keyIndex,
-            module.MIN_ACTIVATION_BALANCE() * multiplier,
-            slashingPenalty
+        WithdrawnValidatorInfo[] memory exitInfo = new WithdrawnValidatorInfo[](
+            1
         );
+        exitInfo[0] = WithdrawnValidatorInfo({
+            nodeOperatorId: noId,
+            keyIndex: keyIndex,
+            exitBalance: WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE *
+                multiplier,
+            slashingPenalty: slashingPenalty,
+            isSlashed: true
+        });
 
         vm.expectCall(
             address(accounting),
@@ -6580,10 +6647,10 @@ abstract contract ModuleSubmitWithdrawals is ModuleFixtures {
                 slashingPenalty
             )
         );
-        module.submitWithdrawals(withdrawalInfo);
+        module.reportWithdrawnValidators(exitInfo);
     }
 
-    function test_submitWithdrawals_slashingPenalty_RevertWhenNotReported()
+    function test_reportWithdrawnValidators_slashingPenalty_RevertWhenNotReported()
         public
         assertInvariants
     {
@@ -6593,24 +6660,26 @@ abstract contract ModuleSubmitWithdrawals is ModuleFixtures {
 
         uint256 slashingPenalty = 5 ether;
 
-        ValidatorWithdrawalInfo[]
-            memory withdrawalInfo = new ValidatorWithdrawalInfo[](1);
-        withdrawalInfo[0] = ValidatorWithdrawalInfo(
-            noId,
-            keyIndex,
-            module.MIN_ACTIVATION_BALANCE(),
-            slashingPenalty
+        WithdrawnValidatorInfo[] memory exitInfo = new WithdrawnValidatorInfo[](
+            1
         );
+        exitInfo[0] = WithdrawnValidatorInfo({
+            nodeOperatorId: noId,
+            keyIndex: keyIndex,
+            exitBalance: WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE,
+            slashingPenalty: slashingPenalty,
+            isSlashed: true
+        });
 
         vm.expectRevert(
             ICSModule.SlashingPenaltyIsNotApplicable.selector,
             address(module)
         );
 
-        module.submitWithdrawals(withdrawalInfo);
+        module.reportWithdrawnValidators(exitInfo);
     }
 
-    function test_submitWithdrawals_chargeWithdrawalFee_DelayFee()
+    function test_reportWithdrawnValidators_chargeWithdrawalFee_DelayFee()
         public
         assertInvariants
     {
@@ -6632,15 +6701,17 @@ abstract contract ModuleSubmitWithdrawals is ModuleFixtures {
             })
         );
 
-        ValidatorWithdrawalInfo[]
-            memory withdrawalInfo = new ValidatorWithdrawalInfo[](1);
-
-        withdrawalInfo[0] = ValidatorWithdrawalInfo(
-            noId,
-            keyIndex,
-            module.MIN_ACTIVATION_BALANCE(),
-            0
+        WithdrawnValidatorInfo[] memory exitInfo = new WithdrawnValidatorInfo[](
+            1
         );
+
+        exitInfo[0] = WithdrawnValidatorInfo({
+            nodeOperatorId: noId,
+            keyIndex: keyIndex,
+            exitBalance: WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE,
+            slashingPenalty: 0,
+            isSlashed: false
+        });
 
         vm.expectCall(
             address(accounting),
@@ -6650,7 +6721,7 @@ abstract contract ModuleSubmitWithdrawals is ModuleFixtures {
                 exitDelayFeeAmount + withdrawalRequestFeeAmount
             )
         );
-        module.submitWithdrawals(withdrawalInfo);
+        module.reportWithdrawnValidators(exitInfo);
 
         NodeOperator memory no = module.getNodeOperator(noId);
         assertEq(no.totalWithdrawnKeys, 1);
@@ -6659,7 +6730,7 @@ abstract contract ModuleSubmitWithdrawals is ModuleFixtures {
         assertEq(no.targetLimitMode, 0);
     }
 
-    function test_submitWithdrawals_chargeWithdrawalFee_hugeDelayFee()
+    function test_reportWithdrawnValidators_chargeWithdrawalFee_hugeDelayFee()
         public
         assertInvariants
     {
@@ -6681,15 +6752,17 @@ abstract contract ModuleSubmitWithdrawals is ModuleFixtures {
             })
         );
 
-        ValidatorWithdrawalInfo[]
-            memory withdrawalInfo = new ValidatorWithdrawalInfo[](1);
-
-        withdrawalInfo[0] = ValidatorWithdrawalInfo(
-            noId,
-            keyIndex,
-            module.MIN_ACTIVATION_BALANCE(),
-            0
+        WithdrawnValidatorInfo[] memory exitInfo = new WithdrawnValidatorInfo[](
+            1
         );
+
+        exitInfo[0] = WithdrawnValidatorInfo({
+            nodeOperatorId: noId,
+            keyIndex: keyIndex,
+            exitBalance: WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE,
+            slashingPenalty: 0,
+            isSlashed: false
+        });
 
         vm.expectCall(
             address(accounting),
@@ -6699,7 +6772,7 @@ abstract contract ModuleSubmitWithdrawals is ModuleFixtures {
                 exitDelayFeeAmount + withdrawalRequestFeeAmount
             )
         );
-        module.submitWithdrawals(withdrawalInfo);
+        module.reportWithdrawnValidators(exitInfo);
 
         NodeOperator memory no = module.getNodeOperator(noId);
         assertEq(no.totalWithdrawnKeys, 1);
@@ -6708,7 +6781,7 @@ abstract contract ModuleSubmitWithdrawals is ModuleFixtures {
         assertEq(no.targetLimitMode, 2);
     }
 
-    function test_submitWithdrawals_chargeHugeWithdrawalFee_DelayFee()
+    function test_reportWithdrawnValidators_chargeHugeWithdrawalFee_DelayFee()
         public
         assertInvariants
     {
@@ -6730,15 +6803,17 @@ abstract contract ModuleSubmitWithdrawals is ModuleFixtures {
             })
         );
 
-        ValidatorWithdrawalInfo[]
-            memory withdrawalInfo = new ValidatorWithdrawalInfo[](1);
-
-        withdrawalInfo[0] = ValidatorWithdrawalInfo(
-            noId,
-            keyIndex,
-            module.MIN_ACTIVATION_BALANCE(),
-            0
+        WithdrawnValidatorInfo[] memory exitInfo = new WithdrawnValidatorInfo[](
+            1
         );
+
+        exitInfo[0] = WithdrawnValidatorInfo({
+            nodeOperatorId: noId,
+            keyIndex: keyIndex,
+            exitBalance: WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE,
+            slashingPenalty: 0,
+            isSlashed: false
+        });
 
         vm.expectCall(
             address(accounting),
@@ -6748,7 +6823,7 @@ abstract contract ModuleSubmitWithdrawals is ModuleFixtures {
                 exitDelayFeeAmount + withdrawalRequestFeeAmount
             )
         );
-        module.submitWithdrawals(withdrawalInfo);
+        module.reportWithdrawnValidators(exitInfo);
 
         NodeOperator memory no = module.getNodeOperator(noId);
         assertEq(no.totalWithdrawnKeys, 1);
@@ -6757,7 +6832,7 @@ abstract contract ModuleSubmitWithdrawals is ModuleFixtures {
         assertEq(no.targetLimitMode, 2);
     }
 
-    function test_submitWithdrawals_chargeWithdrawalFee_StrikesPenalty()
+    function test_reportWithdrawnValidators_chargeWithdrawalFee_StrikesPenalty()
         public
         assertInvariants
     {
@@ -6784,15 +6859,17 @@ abstract contract ModuleSubmitWithdrawals is ModuleFixtures {
             })
         );
 
-        ValidatorWithdrawalInfo[]
-            memory withdrawalInfo = new ValidatorWithdrawalInfo[](1);
-
-        withdrawalInfo[0] = ValidatorWithdrawalInfo(
-            noId,
-            keyIndex,
-            module.MIN_ACTIVATION_BALANCE(),
-            0
+        WithdrawnValidatorInfo[] memory exitInfo = new WithdrawnValidatorInfo[](
+            1
         );
+
+        exitInfo[0] = WithdrawnValidatorInfo({
+            nodeOperatorId: noId,
+            keyIndex: keyIndex,
+            exitBalance: WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE,
+            slashingPenalty: 0,
+            isSlashed: false
+        });
 
         vm.expectCall(
             address(accounting),
@@ -6810,7 +6887,7 @@ abstract contract ModuleSubmitWithdrawals is ModuleFixtures {
                 withdrawalRequestFeeAmount
             )
         );
-        module.submitWithdrawals(withdrawalInfo);
+        module.reportWithdrawnValidators(exitInfo);
 
         NodeOperator memory no = module.getNodeOperator(noId);
         assertEq(no.totalWithdrawnKeys, 1);
@@ -6819,7 +6896,7 @@ abstract contract ModuleSubmitWithdrawals is ModuleFixtures {
         assertEq(no.targetLimitMode, 0);
     }
 
-    function test_submitWithdrawals_chargeWithdrawalFee_HugeStrikesPenalty()
+    function test_reportWithdrawnValidators_chargeWithdrawalFee_HugeStrikesPenalty()
         public
         assertInvariants
     {
@@ -6844,15 +6921,17 @@ abstract contract ModuleSubmitWithdrawals is ModuleFixtures {
             })
         );
 
-        ValidatorWithdrawalInfo[]
-            memory withdrawalInfo = new ValidatorWithdrawalInfo[](1);
-
-        withdrawalInfo[0] = ValidatorWithdrawalInfo(
-            noId,
-            keyIndex,
-            module.MIN_ACTIVATION_BALANCE(),
-            0
+        WithdrawnValidatorInfo[] memory exitInfo = new WithdrawnValidatorInfo[](
+            1
         );
+
+        exitInfo[0] = WithdrawnValidatorInfo({
+            nodeOperatorId: noId,
+            keyIndex: keyIndex,
+            exitBalance: WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE,
+            slashingPenalty: 0,
+            isSlashed: false
+        });
 
         vm.expectCall(
             address(accounting),
@@ -6870,7 +6949,7 @@ abstract contract ModuleSubmitWithdrawals is ModuleFixtures {
                 withdrawalRequestFeeAmount
             )
         );
-        module.submitWithdrawals(withdrawalInfo);
+        module.reportWithdrawnValidators(exitInfo);
 
         NodeOperator memory no = module.getNodeOperator(noId);
         assertEq(no.totalWithdrawnKeys, 1);
@@ -6879,7 +6958,7 @@ abstract contract ModuleSubmitWithdrawals is ModuleFixtures {
         assertEq(no.targetLimitMode, 2);
     }
 
-    function test_submitWithdrawals_chargeHugeWithdrawalFee_StrikesPenalty()
+    function test_reportWithdrawnValidators_chargeHugeWithdrawalFee_StrikesPenalty()
         public
         assertInvariants
     {
@@ -6904,15 +6983,17 @@ abstract contract ModuleSubmitWithdrawals is ModuleFixtures {
             })
         );
 
-        ValidatorWithdrawalInfo[]
-            memory withdrawalInfo = new ValidatorWithdrawalInfo[](1);
-
-        withdrawalInfo[0] = ValidatorWithdrawalInfo(
-            noId,
-            keyIndex,
-            module.MIN_ACTIVATION_BALANCE(),
-            0
+        WithdrawnValidatorInfo[] memory exitInfo = new WithdrawnValidatorInfo[](
+            1
         );
+
+        exitInfo[0] = WithdrawnValidatorInfo({
+            nodeOperatorId: noId,
+            keyIndex: keyIndex,
+            exitBalance: WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE,
+            slashingPenalty: 0,
+            isSlashed: false
+        });
 
         vm.expectCall(
             address(accounting),
@@ -6930,7 +7011,7 @@ abstract contract ModuleSubmitWithdrawals is ModuleFixtures {
                 withdrawalRequestFeeAmount
             )
         );
-        module.submitWithdrawals(withdrawalInfo);
+        module.reportWithdrawnValidators(exitInfo);
 
         NodeOperator memory no = module.getNodeOperator(noId);
         assertEq(no.totalWithdrawnKeys, 1);
@@ -6939,7 +7020,7 @@ abstract contract ModuleSubmitWithdrawals is ModuleFixtures {
         assertEq(no.targetLimitMode, 2);
     }
 
-    function test_submitWithdrawals_chargeWithdrawalFee_DelayAndStrikesPenalties()
+    function test_reportWithdrawnValidators_chargeWithdrawalFee_DelayAndStrikesPenalties()
         public
         assertInvariants
     {
@@ -6965,15 +7046,17 @@ abstract contract ModuleSubmitWithdrawals is ModuleFixtures {
             })
         );
 
-        ValidatorWithdrawalInfo[]
-            memory withdrawalInfo = new ValidatorWithdrawalInfo[](1);
-
-        withdrawalInfo[0] = ValidatorWithdrawalInfo(
-            noId,
-            keyIndex,
-            module.MIN_ACTIVATION_BALANCE(),
-            0
+        WithdrawnValidatorInfo[] memory exitInfo = new WithdrawnValidatorInfo[](
+            1
         );
+
+        exitInfo[0] = WithdrawnValidatorInfo({
+            nodeOperatorId: noId,
+            keyIndex: keyIndex,
+            exitBalance: WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE,
+            slashingPenalty: 0,
+            isSlashed: false
+        });
 
         vm.expectCall(
             address(accounting),
@@ -6991,7 +7074,7 @@ abstract contract ModuleSubmitWithdrawals is ModuleFixtures {
                 strikesPenaltyAmount
             )
         );
-        module.submitWithdrawals(withdrawalInfo);
+        module.reportWithdrawnValidators(exitInfo);
 
         NodeOperator memory no = module.getNodeOperator(noId);
         assertEq(no.totalWithdrawnKeys, 1);
@@ -7000,7 +7083,7 @@ abstract contract ModuleSubmitWithdrawals is ModuleFixtures {
         assertEq(no.targetLimitMode, 0);
     }
 
-    function test_submitWithdrawals_chargeWithdrawalFee_DelayAndStrikesPenalties_AllHuge()
+    function test_reportWithdrawnValidators_chargeWithdrawalFee_DelayAndStrikesPenalties_AllHuge()
         public
     {
         uint256 keyIndex = 0;
@@ -7025,15 +7108,17 @@ abstract contract ModuleSubmitWithdrawals is ModuleFixtures {
             })
         );
 
-        ValidatorWithdrawalInfo[]
-            memory withdrawalInfo = new ValidatorWithdrawalInfo[](1);
-
-        withdrawalInfo[0] = ValidatorWithdrawalInfo(
-            noId,
-            keyIndex,
-            module.MIN_ACTIVATION_BALANCE(),
-            0
+        WithdrawnValidatorInfo[] memory exitInfo = new WithdrawnValidatorInfo[](
+            1
         );
+
+        exitInfo[0] = WithdrawnValidatorInfo({
+            nodeOperatorId: noId,
+            keyIndex: keyIndex,
+            exitBalance: WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE,
+            slashingPenalty: 0,
+            isSlashed: false
+        });
 
         vm.expectCall(
             address(accounting),
@@ -7051,7 +7136,7 @@ abstract contract ModuleSubmitWithdrawals is ModuleFixtures {
                 strikesPenaltyAmount
             )
         );
-        module.submitWithdrawals(withdrawalInfo);
+        module.reportWithdrawnValidators(exitInfo);
 
         NodeOperator memory no = module.getNodeOperator(noId);
         assertEq(no.totalWithdrawnKeys, 1);
@@ -7060,7 +7145,7 @@ abstract contract ModuleSubmitWithdrawals is ModuleFixtures {
         assertEq(no.targetLimitMode, 2);
     }
 
-    function test_submitWithdrawals_chargeWithdrawalFee_zeroPenaltyValue()
+    function test_reportWithdrawnValidators_chargeWithdrawalFee_zeroPenaltyValue()
         public
         assertInvariants
     {
@@ -7081,15 +7166,17 @@ abstract contract ModuleSubmitWithdrawals is ModuleFixtures {
             })
         );
 
-        ValidatorWithdrawalInfo[]
-            memory withdrawalInfo = new ValidatorWithdrawalInfo[](1);
-
-        withdrawalInfo[0] = ValidatorWithdrawalInfo(
-            noId,
-            keyIndex,
-            module.MIN_ACTIVATION_BALANCE(),
-            0
+        WithdrawnValidatorInfo[] memory exitInfo = new WithdrawnValidatorInfo[](
+            1
         );
+
+        exitInfo[0] = WithdrawnValidatorInfo({
+            nodeOperatorId: noId,
+            keyIndex: keyIndex,
+            exitBalance: WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE,
+            slashingPenalty: 0,
+            isSlashed: false
+        });
 
         vm.expectCall(
             address(accounting),
@@ -7099,7 +7186,7 @@ abstract contract ModuleSubmitWithdrawals is ModuleFixtures {
                 withdrawalRequestFeeAmount
             )
         );
-        module.submitWithdrawals(withdrawalInfo);
+        module.reportWithdrawnValidators(exitInfo);
 
         NodeOperator memory no = module.getNodeOperator(noId);
         assertEq(no.totalWithdrawnKeys, 1);
@@ -7108,7 +7195,7 @@ abstract contract ModuleSubmitWithdrawals is ModuleFixtures {
         assertEq(no.targetLimitMode, 0);
     }
 
-    function test_submitWithdrawals_chargeHugeWithdrawalFee_zeroPenaltyValue()
+    function test_reportWithdrawnValidators_chargeHugeWithdrawalFee_zeroPenaltyValue()
         public
         assertInvariants
     {
@@ -7129,15 +7216,17 @@ abstract contract ModuleSubmitWithdrawals is ModuleFixtures {
             })
         );
 
-        ValidatorWithdrawalInfo[]
-            memory withdrawalInfo = new ValidatorWithdrawalInfo[](1);
-
-        withdrawalInfo[0] = ValidatorWithdrawalInfo(
-            noId,
-            keyIndex,
-            module.MIN_ACTIVATION_BALANCE(),
-            0
+        WithdrawnValidatorInfo[] memory exitInfo = new WithdrawnValidatorInfo[](
+            1
         );
+
+        exitInfo[0] = WithdrawnValidatorInfo({
+            nodeOperatorId: noId,
+            keyIndex: keyIndex,
+            exitBalance: WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE,
+            slashingPenalty: 0,
+            isSlashed: false
+        });
 
         vm.expectCall(
             address(accounting),
@@ -7147,7 +7236,7 @@ abstract contract ModuleSubmitWithdrawals is ModuleFixtures {
                 withdrawalRequestFeeAmount
             )
         );
-        module.submitWithdrawals(withdrawalInfo);
+        module.reportWithdrawnValidators(exitInfo);
 
         NodeOperator memory no = module.getNodeOperator(noId);
         assertEq(no.totalWithdrawnKeys, 1);
@@ -7156,7 +7245,7 @@ abstract contract ModuleSubmitWithdrawals is ModuleFixtures {
         assertEq(no.targetLimitMode, 2);
     }
 
-    function test_submitWithdrawals_chargeWithdrawalFeeNotScaled()
+    function test_reportWithdrawnValidators_chargeWithdrawalFeeNotScaled()
         public
         assertInvariants
     {
@@ -7175,14 +7264,17 @@ abstract contract ModuleSubmitWithdrawals is ModuleFixtures {
             })
         );
 
-        ValidatorWithdrawalInfo[]
-            memory withdrawalInfo = new ValidatorWithdrawalInfo[](1);
-        withdrawalInfo[0] = ValidatorWithdrawalInfo(
-            noId,
-            keyIndex,
-            module.MIN_ACTIVATION_BALANCE() * multiplier,
-            0
+        WithdrawnValidatorInfo[] memory exitInfo = new WithdrawnValidatorInfo[](
+            1
         );
+        exitInfo[0] = WithdrawnValidatorInfo({
+            nodeOperatorId: noId,
+            keyIndex: keyIndex,
+            exitBalance: WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE *
+                multiplier,
+            slashingPenalty: 0,
+            isSlashed: false
+        });
 
         vm.expectCall(
             address(accounting),
@@ -7192,10 +7284,10 @@ abstract contract ModuleSubmitWithdrawals is ModuleFixtures {
                 withdrawalRequestFee
             )
         );
-        module.submitWithdrawals(withdrawalInfo);
+        module.reportWithdrawnValidators(exitInfo);
     }
 
-    function test_submitWithdrawals_dontChargeWithdrawalFee_noPenalties()
+    function test_reportWithdrawnValidators_dontChargeWithdrawalFee_noPenalties()
         public
         assertInvariants
     {
@@ -7216,15 +7308,17 @@ abstract contract ModuleSubmitWithdrawals is ModuleFixtures {
             })
         );
 
-        ValidatorWithdrawalInfo[]
-            memory withdrawalInfo = new ValidatorWithdrawalInfo[](1);
-
-        withdrawalInfo[0] = ValidatorWithdrawalInfo(
-            noId,
-            keyIndex,
-            module.MIN_ACTIVATION_BALANCE(),
-            0
+        WithdrawnValidatorInfo[] memory exitInfo = new WithdrawnValidatorInfo[](
+            1
         );
+
+        exitInfo[0] = WithdrawnValidatorInfo({
+            nodeOperatorId: noId,
+            keyIndex: keyIndex,
+            exitBalance: WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE,
+            slashingPenalty: 0,
+            isSlashed: false
+        });
 
         expectNoCall(
             address(accounting),
@@ -7234,7 +7328,7 @@ abstract contract ModuleSubmitWithdrawals is ModuleFixtures {
                 withdrawalRequestFeeAmount
             )
         );
-        module.submitWithdrawals(withdrawalInfo);
+        module.reportWithdrawnValidators(exitInfo);
 
         NodeOperator memory no = module.getNodeOperator(noId);
         assertEq(no.totalWithdrawnKeys, 1);
@@ -7243,7 +7337,7 @@ abstract contract ModuleSubmitWithdrawals is ModuleFixtures {
         assertEq(no.targetLimitMode, 0);
     }
 
-    function test_submitWithdrawals_dontChargeWithdrawalFee_exitBalancePenalty()
+    function test_reportWithdrawnValidators_dontChargeWithdrawalFee_exitBalancePenalty()
         public
         assertInvariants
     {
@@ -7265,15 +7359,18 @@ abstract contract ModuleSubmitWithdrawals is ModuleFixtures {
             })
         );
 
-        ValidatorWithdrawalInfo[]
-            memory withdrawalInfo = new ValidatorWithdrawalInfo[](1);
-
-        withdrawalInfo[0] = ValidatorWithdrawalInfo(
-            noId,
-            keyIndex,
-            module.MIN_ACTIVATION_BALANCE() - balanceShortage,
-            0
+        WithdrawnValidatorInfo[] memory exitInfo = new WithdrawnValidatorInfo[](
+            1
         );
+
+        exitInfo[0] = WithdrawnValidatorInfo({
+            nodeOperatorId: noId,
+            keyIndex: keyIndex,
+            exitBalance: WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE -
+                balanceShortage,
+            slashingPenalty: 0,
+            isSlashed: false
+        });
 
         expectNoCall(
             address(accounting),
@@ -7283,7 +7380,7 @@ abstract contract ModuleSubmitWithdrawals is ModuleFixtures {
                 withdrawalRequestFeeAmount
             )
         );
-        module.submitWithdrawals(withdrawalInfo);
+        module.reportWithdrawnValidators(exitInfo);
 
         NodeOperator memory no = module.getNodeOperator(noId);
         assertEq(no.totalWithdrawnKeys, 1);
@@ -7292,21 +7389,31 @@ abstract contract ModuleSubmitWithdrawals is ModuleFixtures {
         assertEq(no.targetLimitMode, 0);
     }
 
-    function test_submitWithdrawals_unbondedKeys() public assertInvariants {
+    function test_reportWithdrawnValidators_unbondedKeys()
+        public
+        assertInvariants
+    {
         uint256 keyIndex = 0;
         uint256 noId = createNodeOperator(2);
         module.obtainDepositData(1, "");
         uint256 nonce = module.getNonce();
 
-        ValidatorWithdrawalInfo[]
-            memory withdrawalInfo = new ValidatorWithdrawalInfo[](1);
-        withdrawalInfo[0] = ValidatorWithdrawalInfo(noId, keyIndex, 1 ether, 0);
+        WithdrawnValidatorInfo[] memory exitInfo = new WithdrawnValidatorInfo[](
+            1
+        );
+        exitInfo[0] = WithdrawnValidatorInfo({
+            nodeOperatorId: noId,
+            keyIndex: keyIndex,
+            exitBalance: 1 ether,
+            slashingPenalty: 0,
+            isSlashed: false
+        });
 
-        module.submitWithdrawals(withdrawalInfo);
+        module.reportWithdrawnValidators(exitInfo);
         assertEq(module.getNonce(), nonce + 1);
     }
 
-    function test_submitWithdrawals_RevertWhen_ZeroExitBalance()
+    function test_reportWithdrawnValidators_RevertWhen_ZeroExitBalance()
         public
         assertInvariants
     {
@@ -7314,57 +7421,83 @@ abstract contract ModuleSubmitWithdrawals is ModuleFixtures {
         uint256 noId = createNodeOperator();
         module.obtainDepositData(1, "");
 
-        ValidatorWithdrawalInfo[]
-            memory withdrawalInfo = new ValidatorWithdrawalInfo[](1);
-        withdrawalInfo[0] = ValidatorWithdrawalInfo(noId, keyIndex, 0, 0);
+        WithdrawnValidatorInfo[] memory exitInfo = new WithdrawnValidatorInfo[](
+            1
+        );
+        exitInfo[0] = WithdrawnValidatorInfo({
+            nodeOperatorId: noId,
+            keyIndex: keyIndex,
+            exitBalance: 0,
+            slashingPenalty: 0,
+            isSlashed: false
+        });
 
         vm.expectRevert(ICSModule.ZeroExitBalance.selector);
-        module.submitWithdrawals(withdrawalInfo);
+        module.reportWithdrawnValidators(exitInfo);
     }
 
-    function test_submitWithdrawals_RevertWhen_NoNodeOperator()
+    function test_reportWithdrawnValidators_RevertWhen_NoNodeOperator()
         public
         assertInvariants
     {
-        ValidatorWithdrawalInfo[]
-            memory withdrawalInfo = new ValidatorWithdrawalInfo[](1);
-        withdrawalInfo[0] = ValidatorWithdrawalInfo(0, 0, 32 ether, 0);
+        WithdrawnValidatorInfo[] memory exitInfo = new WithdrawnValidatorInfo[](
+            1
+        );
+        exitInfo[0] = WithdrawnValidatorInfo({
+            nodeOperatorId: 0,
+            keyIndex: 0,
+            exitBalance: 32 ether,
+            slashingPenalty: 0,
+            isSlashed: false
+        });
 
         vm.expectRevert(ICSModule.NodeOperatorDoesNotExist.selector);
-        module.submitWithdrawals(withdrawalInfo);
+        module.reportWithdrawnValidators(exitInfo);
     }
 
-    function test_submitWithdrawals_RevertWhen_InvalidKeyIndexOffset()
+    function test_reportWithdrawnValidators_RevertWhen_InvalidKeyIndexOffset()
         public
         assertInvariants
     {
         uint256 noId = createNodeOperator();
 
-        ValidatorWithdrawalInfo[]
-            memory withdrawalInfo = new ValidatorWithdrawalInfo[](1);
-        withdrawalInfo[0] = ValidatorWithdrawalInfo(noId, 0, 32 ether, 0);
+        WithdrawnValidatorInfo[] memory exitInfo = new WithdrawnValidatorInfo[](
+            1
+        );
+        exitInfo[0] = WithdrawnValidatorInfo({
+            nodeOperatorId: noId,
+            keyIndex: 0,
+            exitBalance: 32 ether,
+            slashingPenalty: 0,
+            isSlashed: false
+        });
 
         vm.expectRevert(ICSModule.SigningKeysInvalidOffset.selector);
-        module.submitWithdrawals(withdrawalInfo);
+        module.reportWithdrawnValidators(exitInfo);
     }
 
-    function test_submitWithdrawals_alreadyWithdrawn() public assertInvariants {
+    function test_reportWithdrawnValidators_alreadyWithdrawn()
+        public
+        assertInvariants
+    {
         uint256 noId = createNodeOperator();
         module.obtainDepositData(1, "");
 
-        ValidatorWithdrawalInfo[]
-            memory withdrawalInfo = new ValidatorWithdrawalInfo[](1);
-        withdrawalInfo[0] = ValidatorWithdrawalInfo(
-            noId,
-            0,
-            module.MIN_ACTIVATION_BALANCE(),
-            0
+        WithdrawnValidatorInfo[] memory exitInfo = new WithdrawnValidatorInfo[](
+            1
         );
+        exitInfo[0] = WithdrawnValidatorInfo({
+            nodeOperatorId: noId,
+            keyIndex: 0,
+            exitBalance: WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE,
+            slashingPenalty: 0,
+            isSlashed: false
+        });
 
-        module.submitWithdrawals(withdrawalInfo);
+        module.reportWithdrawnValidators(exitInfo);
 
         uint256 nonceBefore = module.getNonce();
-        module.submitWithdrawals(withdrawalInfo);
+        module.reportWithdrawnValidators(exitInfo);
         assertEq(
             module.getNonce(),
             nonceBefore,
@@ -7372,7 +7505,7 @@ abstract contract ModuleSubmitWithdrawals is ModuleFixtures {
         );
     }
 
-    function test_submitWithdrawals_nonceIncrementsOnceForManyWithdrawals()
+    function test_reportWithdrawnValidators_nonceIncrementsOnceForManyWithdrawals()
         public
         assertInvariants
     {
@@ -7380,17 +7513,19 @@ abstract contract ModuleSubmitWithdrawals is ModuleFixtures {
         module.obtainDepositData(3, "");
         uint256 nonceBefore = module.getNonce();
 
-        ValidatorWithdrawalInfo[]
-            memory withdrawalInfo = new ValidatorWithdrawalInfo[](3);
+        WithdrawnValidatorInfo[] memory exitInfo = new WithdrawnValidatorInfo[](
+            3
+        );
         for (uint256 i = 0; i < 3; ++i) {
-            withdrawalInfo[i] = ValidatorWithdrawalInfo(
-                noId,
-                i,
-                module.MIN_ACTIVATION_BALANCE(),
-                0
-            );
+            exitInfo[i] = WithdrawnValidatorInfo({
+                nodeOperatorId: noId,
+                keyIndex: i,
+                exitBalance: WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE,
+                slashingPenalty: 0,
+                isSlashed: false
+            });
         }
-        module.submitWithdrawals(withdrawalInfo);
+        module.reportWithdrawnValidators(exitInfo);
         assertEq(
             module.getNonce(),
             nonceBefore + 1,
@@ -7652,7 +7787,7 @@ abstract contract ModuleAccessControl is ModuleFixtures {
         module.onValidatorSlashed(noId, 0);
     }
 
-    function test_submitWithdrawalsRole() public {
+    function test_reportWithdrawnValidatorsRole() public {
         uint256 noId = createNodeOperator();
         bytes32 role = module.SUBMIT_WITHDRAWALS_ROLE();
 
@@ -7662,25 +7797,39 @@ abstract contract ModuleAccessControl is ModuleFixtures {
         module.obtainDepositData(1, "");
         vm.stopPrank();
 
-        ValidatorWithdrawalInfo[]
-            memory withdrawalInfo = new ValidatorWithdrawalInfo[](1);
-        withdrawalInfo[0] = ValidatorWithdrawalInfo(noId, 0, 1 ether, 0);
+        WithdrawnValidatorInfo[] memory exitInfo = new WithdrawnValidatorInfo[](
+            1
+        );
+        exitInfo[0] = WithdrawnValidatorInfo({
+            nodeOperatorId: noId,
+            keyIndex: 0,
+            exitBalance: 1 ether,
+            slashingPenalty: 0,
+            isSlashed: false
+        });
 
         vm.prank(actor);
-        module.submitWithdrawals(withdrawalInfo);
+        module.reportWithdrawnValidators(exitInfo);
     }
 
-    function test_submitWithdrawalsRole_revert() public {
+    function test_reportWithdrawnValidatorsRole_revert() public {
         uint256 noId = createNodeOperator();
         bytes32 role = module.SUBMIT_WITHDRAWALS_ROLE();
 
-        ValidatorWithdrawalInfo[]
-            memory withdrawalInfo = new ValidatorWithdrawalInfo[](1);
-        withdrawalInfo[0] = ValidatorWithdrawalInfo(noId, 0, 1 ether, 0);
+        WithdrawnValidatorInfo[] memory exitInfo = new WithdrawnValidatorInfo[](
+            1
+        );
+        exitInfo[0] = WithdrawnValidatorInfo({
+            nodeOperatorId: noId,
+            keyIndex: 0,
+            exitBalance: 1 ether,
+            slashingPenalty: 0,
+            isSlashed: false
+        });
 
         vm.prank(stranger);
         expectRoleRevert(stranger, role);
-        module.submitWithdrawals(withdrawalInfo);
+        module.reportWithdrawnValidators(exitInfo);
     }
 
     function test_recovererRole() public {
@@ -7934,29 +8083,34 @@ abstract contract ModuleDepositableValidatorsCount is ModuleFixtures {
 
         penalize(noId, BOND_SIZE * 3);
 
-        ValidatorWithdrawalInfo[]
-            memory withdrawalInfo = new ValidatorWithdrawalInfo[](3);
-        withdrawalInfo[0] = ValidatorWithdrawalInfo(
-            noId,
-            0,
-            module.MIN_ACTIVATION_BALANCE(),
-            0
+        WithdrawnValidatorInfo[] memory exitInfo = new WithdrawnValidatorInfo[](
+            3
         );
-        withdrawalInfo[1] = ValidatorWithdrawalInfo(
-            noId,
-            1,
-            module.MIN_ACTIVATION_BALANCE(),
-            0
-        );
-        withdrawalInfo[2] = ValidatorWithdrawalInfo(
-            noId,
-            2,
-            module.MIN_ACTIVATION_BALANCE() - BOND_SIZE,
-            0
-        ); // Large CL balance drop, that doesn't change the unbonded count.
+        exitInfo[0] = WithdrawnValidatorInfo({
+            nodeOperatorId: noId,
+            keyIndex: 0,
+            exitBalance: WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE,
+            slashingPenalty: 0,
+            isSlashed: false
+        });
+        exitInfo[1] = WithdrawnValidatorInfo({
+            nodeOperatorId: noId,
+            keyIndex: 1,
+            exitBalance: WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE,
+            slashingPenalty: 0,
+            isSlashed: false
+        });
+        exitInfo[2] = WithdrawnValidatorInfo({
+            nodeOperatorId: noId,
+            keyIndex: 2,
+            exitBalance: WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE -
+                BOND_SIZE,
+            slashingPenalty: 0,
+            isSlashed: false
+        }); // Large CL balance drop, that doesn't change the unbonded count.
 
         assertEq(module.getNodeOperator(noId).depositableValidatorsCount, 0);
-        module.submitWithdrawals(withdrawalInfo);
+        module.reportWithdrawnValidators(exitInfo);
         assertEq(module.getNodeOperator(noId).depositableValidatorsCount, 2);
         assertEq(getStakingModuleSummary().depositableValidatorsCount, 2);
     }

--- a/test/unit/ModuleAbstract.t.sol
+++ b/test/unit/ModuleAbstract.t.sol
@@ -3194,11 +3194,10 @@ abstract contract ModuleQueueOps is ModuleFixtures {
         module.obtainDepositData(2, "");
         module.cleanDepositQueue(1);
 
-        WithdrawnValidatorInfo[] memory exitInfo = new WithdrawnValidatorInfo[](
-            1
-        );
+        WithdrawnValidatorInfo[]
+            memory validatorInfos = new WithdrawnValidatorInfo[](1);
 
-        exitInfo[0] = WithdrawnValidatorInfo({
+        validatorInfos[0] = WithdrawnValidatorInfo({
             nodeOperatorId: noId,
             keyIndex: 0,
             exitBalance: WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE,
@@ -3208,7 +3207,7 @@ abstract contract ModuleQueueOps is ModuleFixtures {
 
         vm.expectEmit(address(module));
         emit ICSModule.BatchEnqueued(module.QUEUE_LOWEST_PRIORITY(), noId, 1);
-        module.reportWithdrawnValidators(exitInfo);
+        module.reportWithdrawnValidators(validatorInfos);
     }
 }
 
@@ -4220,11 +4219,10 @@ abstract contract ModuleGetNodeOperatorNonWithdrawnKeys is ModuleFixtures {
         uint256 noId = createNodeOperator(3);
         module.obtainDepositData(3, "");
 
-        WithdrawnValidatorInfo[] memory exitInfo = new WithdrawnValidatorInfo[](
-            1
-        );
+        WithdrawnValidatorInfo[]
+            memory validatorInfos = new WithdrawnValidatorInfo[](1);
 
-        exitInfo[0] = WithdrawnValidatorInfo({
+        validatorInfos[0] = WithdrawnValidatorInfo({
             nodeOperatorId: noId,
             keyIndex: 0,
             exitBalance: WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE,
@@ -4232,7 +4230,7 @@ abstract contract ModuleGetNodeOperatorNonWithdrawnKeys is ModuleFixtures {
             isSlashed: false
         });
 
-        module.reportWithdrawnValidators(exitInfo);
+        module.reportWithdrawnValidators(validatorInfos);
         uint256 keys = module.getNodeOperatorNonWithdrawnKeys(noId);
         assertEq(keys, 2);
     }
@@ -6028,11 +6026,10 @@ abstract contract ModuleReportWithdrawnValidators is ModuleFixtures {
 
         uint256 nonce = module.getNonce();
 
-        WithdrawnValidatorInfo[] memory exitInfo = new WithdrawnValidatorInfo[](
-            1
-        );
+        WithdrawnValidatorInfo[]
+            memory validatorInfos = new WithdrawnValidatorInfo[](1);
 
-        exitInfo[0] = WithdrawnValidatorInfo({
+        validatorInfos[0] = WithdrawnValidatorInfo({
             nodeOperatorId: noId,
             keyIndex: keyIndex,
             exitBalance: WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE,
@@ -6048,7 +6045,7 @@ abstract contract ModuleReportWithdrawnValidators is ModuleFixtures {
             0,
             pubkey
         );
-        module.reportWithdrawnValidators(exitInfo);
+        module.reportWithdrawnValidators(validatorInfos);
 
         NodeOperator memory no = module.getNodeOperator(noId);
         assertEq(no.totalWithdrawnKeys, 1);
@@ -6073,11 +6070,10 @@ abstract contract ModuleReportWithdrawnValidators is ModuleFixtures {
 
         uint256 balanceShortage = BOND_SIZE - 1 ether;
 
-        WithdrawnValidatorInfo[] memory exitInfo = new WithdrawnValidatorInfo[](
-            1
-        );
+        WithdrawnValidatorInfo[]
+            memory validatorInfos = new WithdrawnValidatorInfo[](1);
 
-        exitInfo[0] = WithdrawnValidatorInfo({
+        validatorInfos[0] = WithdrawnValidatorInfo({
             nodeOperatorId: noId,
             keyIndex: keyIndex,
             exitBalance: WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE -
@@ -6094,7 +6090,7 @@ abstract contract ModuleReportWithdrawnValidators is ModuleFixtures {
             0,
             pubkey
         );
-        module.reportWithdrawnValidators(exitInfo);
+        module.reportWithdrawnValidators(validatorInfos);
 
         NodeOperator memory no = module.getNodeOperator(noId);
         assertEq(no.totalWithdrawnKeys, 1);
@@ -6115,11 +6111,10 @@ abstract contract ModuleReportWithdrawnValidators is ModuleFixtures {
 
         uint256 balanceShortage = BOND_SIZE - 1 ether;
 
-        WithdrawnValidatorInfo[] memory exitInfo = new WithdrawnValidatorInfo[](
-            1
-        );
+        WithdrawnValidatorInfo[]
+            memory validatorInfos = new WithdrawnValidatorInfo[](1);
 
-        exitInfo[0] = WithdrawnValidatorInfo({
+        validatorInfos[0] = WithdrawnValidatorInfo({
             nodeOperatorId: noId,
             keyIndex: keyIndex,
             exitBalance: WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE -
@@ -6136,7 +6131,7 @@ abstract contract ModuleReportWithdrawnValidators is ModuleFixtures {
                 balanceShortage
             )
         );
-        module.reportWithdrawnValidators(exitInfo);
+        module.reportWithdrawnValidators(validatorInfos);
 
         NodeOperator memory no = module.getNodeOperator(noId);
         assertEq(no.totalWithdrawnKeys, 1);
@@ -6155,11 +6150,10 @@ abstract contract ModuleReportWithdrawnValidators is ModuleFixtures {
 
         uint256 balanceShortage = BOND_SIZE + 1 ether;
 
-        WithdrawnValidatorInfo[] memory exitInfo = new WithdrawnValidatorInfo[](
-            1
-        );
+        WithdrawnValidatorInfo[]
+            memory validatorInfos = new WithdrawnValidatorInfo[](1);
 
-        exitInfo[0] = WithdrawnValidatorInfo({
+        validatorInfos[0] = WithdrawnValidatorInfo({
             nodeOperatorId: noId,
             keyIndex: keyIndex,
             exitBalance: WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE -
@@ -6176,7 +6170,7 @@ abstract contract ModuleReportWithdrawnValidators is ModuleFixtures {
                 balanceShortage
             )
         );
-        module.reportWithdrawnValidators(exitInfo);
+        module.reportWithdrawnValidators(validatorInfos);
 
         NodeOperator memory no = module.getNodeOperator(noId);
         assertEq(no.totalWithdrawnKeys, 1);
@@ -6203,11 +6197,10 @@ abstract contract ModuleReportWithdrawnValidators is ModuleFixtures {
             })
         );
 
-        WithdrawnValidatorInfo[] memory exitInfo = new WithdrawnValidatorInfo[](
-            1
-        );
+        WithdrawnValidatorInfo[]
+            memory validatorInfos = new WithdrawnValidatorInfo[](1);
 
-        exitInfo[0] = WithdrawnValidatorInfo({
+        validatorInfos[0] = WithdrawnValidatorInfo({
             nodeOperatorId: noId,
             keyIndex: keyIndex,
             exitBalance: WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE,
@@ -6223,7 +6216,7 @@ abstract contract ModuleReportWithdrawnValidators is ModuleFixtures {
                 exitDelayFeeAmount
             )
         );
-        module.reportWithdrawnValidators(exitInfo);
+        module.reportWithdrawnValidators(validatorInfos);
 
         NodeOperator memory no = module.getNodeOperator(noId);
         assertEq(no.totalWithdrawnKeys, 1);
@@ -6250,11 +6243,10 @@ abstract contract ModuleReportWithdrawnValidators is ModuleFixtures {
             })
         );
 
-        WithdrawnValidatorInfo[] memory exitInfo = new WithdrawnValidatorInfo[](
-            1
-        );
+        WithdrawnValidatorInfo[]
+            memory validatorInfos = new WithdrawnValidatorInfo[](1);
 
-        exitInfo[0] = WithdrawnValidatorInfo({
+        validatorInfos[0] = WithdrawnValidatorInfo({
             nodeOperatorId: noId,
             keyIndex: keyIndex,
             exitBalance: WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE,
@@ -6270,7 +6262,7 @@ abstract contract ModuleReportWithdrawnValidators is ModuleFixtures {
                 exitDelayFeeAmount
             )
         );
-        module.reportWithdrawnValidators(exitInfo);
+        module.reportWithdrawnValidators(validatorInfos);
 
         NodeOperator memory no = module.getNodeOperator(noId);
         assertEq(no.totalWithdrawnKeys, 1);
@@ -6298,10 +6290,9 @@ abstract contract ModuleReportWithdrawnValidators is ModuleFixtures {
             })
         );
 
-        WithdrawnValidatorInfo[] memory exitInfo = new WithdrawnValidatorInfo[](
-            1
-        );
-        exitInfo[0] = WithdrawnValidatorInfo({
+        WithdrawnValidatorInfo[]
+            memory validatorInfos = new WithdrawnValidatorInfo[](1);
+        validatorInfos[0] = WithdrawnValidatorInfo({
             nodeOperatorId: noId,
             keyIndex: keyIndex,
             exitBalance: WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE *
@@ -6320,7 +6311,7 @@ abstract contract ModuleReportWithdrawnValidators is ModuleFixtures {
                 fee * multiplier
             )
         );
-        module.reportWithdrawnValidators(exitInfo);
+        module.reportWithdrawnValidators(validatorInfos);
     }
 
     function test_reportWithdrawnValidators_exitDelayFeeAtMaxWithMultiplier()
@@ -6344,10 +6335,9 @@ abstract contract ModuleReportWithdrawnValidators is ModuleFixtures {
             })
         );
 
-        WithdrawnValidatorInfo[] memory exitInfo = new WithdrawnValidatorInfo[](
-            1
-        );
-        exitInfo[0] = WithdrawnValidatorInfo({
+        WithdrawnValidatorInfo[]
+            memory validatorInfos = new WithdrawnValidatorInfo[](1);
+        validatorInfos[0] = WithdrawnValidatorInfo({
             nodeOperatorId: noId,
             keyIndex: keyIndex,
             exitBalance: WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE *
@@ -6365,7 +6355,7 @@ abstract contract ModuleReportWithdrawnValidators is ModuleFixtures {
                 fee * multiplier
             )
         );
-        module.reportWithdrawnValidators(exitInfo);
+        module.reportWithdrawnValidators(validatorInfos);
     }
 
     function test_reportWithdrawnValidators_strikesPenalty()
@@ -6389,11 +6379,10 @@ abstract contract ModuleReportWithdrawnValidators is ModuleFixtures {
             })
         );
 
-        WithdrawnValidatorInfo[] memory exitInfo = new WithdrawnValidatorInfo[](
-            1
-        );
+        WithdrawnValidatorInfo[]
+            memory validatorInfos = new WithdrawnValidatorInfo[](1);
 
-        exitInfo[0] = WithdrawnValidatorInfo({
+        validatorInfos[0] = WithdrawnValidatorInfo({
             nodeOperatorId: noId,
             keyIndex: keyIndex,
             exitBalance: WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE,
@@ -6409,7 +6398,7 @@ abstract contract ModuleReportWithdrawnValidators is ModuleFixtures {
                 strikesPenaltyAmount
             )
         );
-        module.reportWithdrawnValidators(exitInfo);
+        module.reportWithdrawnValidators(validatorInfos);
 
         NodeOperator memory no = module.getNodeOperator(noId);
         assertEq(no.totalWithdrawnKeys, 1);
@@ -6439,11 +6428,10 @@ abstract contract ModuleReportWithdrawnValidators is ModuleFixtures {
             })
         );
 
-        WithdrawnValidatorInfo[] memory exitInfo = new WithdrawnValidatorInfo[](
-            1
-        );
+        WithdrawnValidatorInfo[]
+            memory validatorInfos = new WithdrawnValidatorInfo[](1);
 
-        exitInfo[0] = WithdrawnValidatorInfo({
+        validatorInfos[0] = WithdrawnValidatorInfo({
             nodeOperatorId: noId,
             keyIndex: keyIndex,
             exitBalance: WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE,
@@ -6459,7 +6447,7 @@ abstract contract ModuleReportWithdrawnValidators is ModuleFixtures {
                 strikesPenaltyAmount
             )
         );
-        module.reportWithdrawnValidators(exitInfo);
+        module.reportWithdrawnValidators(validatorInfos);
 
         NodeOperator memory no = module.getNodeOperator(noId);
         assertEq(no.totalWithdrawnKeys, 1);
@@ -6487,10 +6475,9 @@ abstract contract ModuleReportWithdrawnValidators is ModuleFixtures {
             })
         );
 
-        WithdrawnValidatorInfo[] memory exitInfo = new WithdrawnValidatorInfo[](
-            1
-        );
-        exitInfo[0] = WithdrawnValidatorInfo({
+        WithdrawnValidatorInfo[]
+            memory validatorInfos = new WithdrawnValidatorInfo[](1);
+        validatorInfos[0] = WithdrawnValidatorInfo({
             nodeOperatorId: noId,
             keyIndex: keyIndex,
             exitBalance: WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE *
@@ -6509,7 +6496,7 @@ abstract contract ModuleReportWithdrawnValidators is ModuleFixtures {
                 penalty * multiplier
             )
         );
-        module.reportWithdrawnValidators(exitInfo);
+        module.reportWithdrawnValidators(validatorInfos);
     }
 
     function test_reportWithdrawnValidators_strikesPenaltyAtMaxWithMultiplier()
@@ -6533,10 +6520,9 @@ abstract contract ModuleReportWithdrawnValidators is ModuleFixtures {
             })
         );
 
-        WithdrawnValidatorInfo[] memory exitInfo = new WithdrawnValidatorInfo[](
-            1
-        );
-        exitInfo[0] = WithdrawnValidatorInfo({
+        WithdrawnValidatorInfo[]
+            memory validatorInfos = new WithdrawnValidatorInfo[](1);
+        validatorInfos[0] = WithdrawnValidatorInfo({
             nodeOperatorId: noId,
             keyIndex: keyIndex,
             exitBalance: WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE *
@@ -6554,7 +6540,7 @@ abstract contract ModuleReportWithdrawnValidators is ModuleFixtures {
                 penalty * multiplier
             )
         );
-        module.reportWithdrawnValidators(exitInfo);
+        module.reportWithdrawnValidators(validatorInfos);
     }
 
     function test_reportWithdrawnValidators_slashingPenaltyApplied()
@@ -6568,10 +6554,9 @@ abstract contract ModuleReportWithdrawnValidators is ModuleFixtures {
 
         uint256 slashingPenalty = 5 ether;
 
-        WithdrawnValidatorInfo[] memory exitInfo = new WithdrawnValidatorInfo[](
-            1
-        );
-        exitInfo[0] = WithdrawnValidatorInfo({
+        WithdrawnValidatorInfo[]
+            memory validatorInfos = new WithdrawnValidatorInfo[](1);
+        validatorInfos[0] = WithdrawnValidatorInfo({
             nodeOperatorId: noId,
             keyIndex: keyIndex,
             exitBalance: WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE,
@@ -6587,7 +6572,7 @@ abstract contract ModuleReportWithdrawnValidators is ModuleFixtures {
                 slashingPenalty
             )
         );
-        module.reportWithdrawnValidators(exitInfo);
+        module.reportWithdrawnValidators(validatorInfos);
     }
 
     function test_reportWithdrawnValidators_slashingPenaltyOverridesExitBalancePenalty()
@@ -6601,10 +6586,9 @@ abstract contract ModuleReportWithdrawnValidators is ModuleFixtures {
 
         uint256 slashingPenalty = 5 ether;
 
-        WithdrawnValidatorInfo[] memory exitInfo = new WithdrawnValidatorInfo[](
-            1
-        );
-        exitInfo[0] = WithdrawnValidatorInfo({
+        WithdrawnValidatorInfo[]
+            memory validatorInfos = new WithdrawnValidatorInfo[](1);
+        validatorInfos[0] = WithdrawnValidatorInfo({
             nodeOperatorId: noId,
             keyIndex: keyIndex,
             exitBalance: WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE -
@@ -6621,7 +6605,7 @@ abstract contract ModuleReportWithdrawnValidators is ModuleFixtures {
                 slashingPenalty
             )
         );
-        module.reportWithdrawnValidators(exitInfo);
+        module.reportWithdrawnValidators(validatorInfos);
     }
 
     function test_reportWithdrawnValidators_slashingPenaltyNotScaled()
@@ -6636,10 +6620,9 @@ abstract contract ModuleReportWithdrawnValidators is ModuleFixtures {
         uint256 slashingPenalty = 7 ether;
         uint256 multiplier = 5;
 
-        WithdrawnValidatorInfo[] memory exitInfo = new WithdrawnValidatorInfo[](
-            1
-        );
-        exitInfo[0] = WithdrawnValidatorInfo({
+        WithdrawnValidatorInfo[]
+            memory validatorInfos = new WithdrawnValidatorInfo[](1);
+        validatorInfos[0] = WithdrawnValidatorInfo({
             nodeOperatorId: noId,
             keyIndex: keyIndex,
             exitBalance: WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE *
@@ -6656,7 +6639,7 @@ abstract contract ModuleReportWithdrawnValidators is ModuleFixtures {
                 slashingPenalty
             )
         );
-        module.reportWithdrawnValidators(exitInfo);
+        module.reportWithdrawnValidators(validatorInfos);
     }
 
     function test_reportWithdrawnValidators_slashingPenalty_RevertWhenNotReported()
@@ -6669,10 +6652,9 @@ abstract contract ModuleReportWithdrawnValidators is ModuleFixtures {
 
         uint256 slashingPenalty = 5 ether;
 
-        WithdrawnValidatorInfo[] memory exitInfo = new WithdrawnValidatorInfo[](
-            1
-        );
-        exitInfo[0] = WithdrawnValidatorInfo({
+        WithdrawnValidatorInfo[]
+            memory validatorInfos = new WithdrawnValidatorInfo[](1);
+        validatorInfos[0] = WithdrawnValidatorInfo({
             nodeOperatorId: noId,
             keyIndex: keyIndex,
             exitBalance: WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE,
@@ -6685,7 +6667,7 @@ abstract contract ModuleReportWithdrawnValidators is ModuleFixtures {
             address(module)
         );
 
-        module.reportWithdrawnValidators(exitInfo);
+        module.reportWithdrawnValidators(validatorInfos);
     }
 
     function test_reportWithdrawnValidators_chargeWithdrawalFee_DelayFee()
@@ -6710,11 +6692,10 @@ abstract contract ModuleReportWithdrawnValidators is ModuleFixtures {
             })
         );
 
-        WithdrawnValidatorInfo[] memory exitInfo = new WithdrawnValidatorInfo[](
-            1
-        );
+        WithdrawnValidatorInfo[]
+            memory validatorInfos = new WithdrawnValidatorInfo[](1);
 
-        exitInfo[0] = WithdrawnValidatorInfo({
+        validatorInfos[0] = WithdrawnValidatorInfo({
             nodeOperatorId: noId,
             keyIndex: keyIndex,
             exitBalance: WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE,
@@ -6730,7 +6711,7 @@ abstract contract ModuleReportWithdrawnValidators is ModuleFixtures {
                 exitDelayFeeAmount + withdrawalRequestFeeAmount
             )
         );
-        module.reportWithdrawnValidators(exitInfo);
+        module.reportWithdrawnValidators(validatorInfos);
 
         NodeOperator memory no = module.getNodeOperator(noId);
         assertEq(no.totalWithdrawnKeys, 1);
@@ -6761,11 +6742,10 @@ abstract contract ModuleReportWithdrawnValidators is ModuleFixtures {
             })
         );
 
-        WithdrawnValidatorInfo[] memory exitInfo = new WithdrawnValidatorInfo[](
-            1
-        );
+        WithdrawnValidatorInfo[]
+            memory validatorInfos = new WithdrawnValidatorInfo[](1);
 
-        exitInfo[0] = WithdrawnValidatorInfo({
+        validatorInfos[0] = WithdrawnValidatorInfo({
             nodeOperatorId: noId,
             keyIndex: keyIndex,
             exitBalance: WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE,
@@ -6781,7 +6761,7 @@ abstract contract ModuleReportWithdrawnValidators is ModuleFixtures {
                 exitDelayFeeAmount + withdrawalRequestFeeAmount
             )
         );
-        module.reportWithdrawnValidators(exitInfo);
+        module.reportWithdrawnValidators(validatorInfos);
 
         NodeOperator memory no = module.getNodeOperator(noId);
         assertEq(no.totalWithdrawnKeys, 1);
@@ -6812,11 +6792,10 @@ abstract contract ModuleReportWithdrawnValidators is ModuleFixtures {
             })
         );
 
-        WithdrawnValidatorInfo[] memory exitInfo = new WithdrawnValidatorInfo[](
-            1
-        );
+        WithdrawnValidatorInfo[]
+            memory validatorInfos = new WithdrawnValidatorInfo[](1);
 
-        exitInfo[0] = WithdrawnValidatorInfo({
+        validatorInfos[0] = WithdrawnValidatorInfo({
             nodeOperatorId: noId,
             keyIndex: keyIndex,
             exitBalance: WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE,
@@ -6832,7 +6811,7 @@ abstract contract ModuleReportWithdrawnValidators is ModuleFixtures {
                 exitDelayFeeAmount + withdrawalRequestFeeAmount
             )
         );
-        module.reportWithdrawnValidators(exitInfo);
+        module.reportWithdrawnValidators(validatorInfos);
 
         NodeOperator memory no = module.getNodeOperator(noId);
         assertEq(no.totalWithdrawnKeys, 1);
@@ -6868,11 +6847,10 @@ abstract contract ModuleReportWithdrawnValidators is ModuleFixtures {
             })
         );
 
-        WithdrawnValidatorInfo[] memory exitInfo = new WithdrawnValidatorInfo[](
-            1
-        );
+        WithdrawnValidatorInfo[]
+            memory validatorInfos = new WithdrawnValidatorInfo[](1);
 
-        exitInfo[0] = WithdrawnValidatorInfo({
+        validatorInfos[0] = WithdrawnValidatorInfo({
             nodeOperatorId: noId,
             keyIndex: keyIndex,
             exitBalance: WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE,
@@ -6896,7 +6874,7 @@ abstract contract ModuleReportWithdrawnValidators is ModuleFixtures {
                 withdrawalRequestFeeAmount
             )
         );
-        module.reportWithdrawnValidators(exitInfo);
+        module.reportWithdrawnValidators(validatorInfos);
 
         NodeOperator memory no = module.getNodeOperator(noId);
         assertEq(no.totalWithdrawnKeys, 1);
@@ -6930,11 +6908,10 @@ abstract contract ModuleReportWithdrawnValidators is ModuleFixtures {
             })
         );
 
-        WithdrawnValidatorInfo[] memory exitInfo = new WithdrawnValidatorInfo[](
-            1
-        );
+        WithdrawnValidatorInfo[]
+            memory validatorInfos = new WithdrawnValidatorInfo[](1);
 
-        exitInfo[0] = WithdrawnValidatorInfo({
+        validatorInfos[0] = WithdrawnValidatorInfo({
             nodeOperatorId: noId,
             keyIndex: keyIndex,
             exitBalance: WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE,
@@ -6958,7 +6935,7 @@ abstract contract ModuleReportWithdrawnValidators is ModuleFixtures {
                 withdrawalRequestFeeAmount
             )
         );
-        module.reportWithdrawnValidators(exitInfo);
+        module.reportWithdrawnValidators(validatorInfos);
 
         NodeOperator memory no = module.getNodeOperator(noId);
         assertEq(no.totalWithdrawnKeys, 1);
@@ -6992,11 +6969,10 @@ abstract contract ModuleReportWithdrawnValidators is ModuleFixtures {
             })
         );
 
-        WithdrawnValidatorInfo[] memory exitInfo = new WithdrawnValidatorInfo[](
-            1
-        );
+        WithdrawnValidatorInfo[]
+            memory validatorInfos = new WithdrawnValidatorInfo[](1);
 
-        exitInfo[0] = WithdrawnValidatorInfo({
+        validatorInfos[0] = WithdrawnValidatorInfo({
             nodeOperatorId: noId,
             keyIndex: keyIndex,
             exitBalance: WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE,
@@ -7020,7 +6996,7 @@ abstract contract ModuleReportWithdrawnValidators is ModuleFixtures {
                 withdrawalRequestFeeAmount
             )
         );
-        module.reportWithdrawnValidators(exitInfo);
+        module.reportWithdrawnValidators(validatorInfos);
 
         NodeOperator memory no = module.getNodeOperator(noId);
         assertEq(no.totalWithdrawnKeys, 1);
@@ -7055,11 +7031,10 @@ abstract contract ModuleReportWithdrawnValidators is ModuleFixtures {
             })
         );
 
-        WithdrawnValidatorInfo[] memory exitInfo = new WithdrawnValidatorInfo[](
-            1
-        );
+        WithdrawnValidatorInfo[]
+            memory validatorInfos = new WithdrawnValidatorInfo[](1);
 
-        exitInfo[0] = WithdrawnValidatorInfo({
+        validatorInfos[0] = WithdrawnValidatorInfo({
             nodeOperatorId: noId,
             keyIndex: keyIndex,
             exitBalance: WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE,
@@ -7083,7 +7058,7 @@ abstract contract ModuleReportWithdrawnValidators is ModuleFixtures {
                 strikesPenaltyAmount
             )
         );
-        module.reportWithdrawnValidators(exitInfo);
+        module.reportWithdrawnValidators(validatorInfos);
 
         NodeOperator memory no = module.getNodeOperator(noId);
         assertEq(no.totalWithdrawnKeys, 1);
@@ -7117,11 +7092,10 @@ abstract contract ModuleReportWithdrawnValidators is ModuleFixtures {
             })
         );
 
-        WithdrawnValidatorInfo[] memory exitInfo = new WithdrawnValidatorInfo[](
-            1
-        );
+        WithdrawnValidatorInfo[]
+            memory validatorInfos = new WithdrawnValidatorInfo[](1);
 
-        exitInfo[0] = WithdrawnValidatorInfo({
+        validatorInfos[0] = WithdrawnValidatorInfo({
             nodeOperatorId: noId,
             keyIndex: keyIndex,
             exitBalance: WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE,
@@ -7145,7 +7119,7 @@ abstract contract ModuleReportWithdrawnValidators is ModuleFixtures {
                 strikesPenaltyAmount
             )
         );
-        module.reportWithdrawnValidators(exitInfo);
+        module.reportWithdrawnValidators(validatorInfos);
 
         NodeOperator memory no = module.getNodeOperator(noId);
         assertEq(no.totalWithdrawnKeys, 1);
@@ -7175,11 +7149,10 @@ abstract contract ModuleReportWithdrawnValidators is ModuleFixtures {
             })
         );
 
-        WithdrawnValidatorInfo[] memory exitInfo = new WithdrawnValidatorInfo[](
-            1
-        );
+        WithdrawnValidatorInfo[]
+            memory validatorInfos = new WithdrawnValidatorInfo[](1);
 
-        exitInfo[0] = WithdrawnValidatorInfo({
+        validatorInfos[0] = WithdrawnValidatorInfo({
             nodeOperatorId: noId,
             keyIndex: keyIndex,
             exitBalance: WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE,
@@ -7195,7 +7168,7 @@ abstract contract ModuleReportWithdrawnValidators is ModuleFixtures {
                 withdrawalRequestFeeAmount
             )
         );
-        module.reportWithdrawnValidators(exitInfo);
+        module.reportWithdrawnValidators(validatorInfos);
 
         NodeOperator memory no = module.getNodeOperator(noId);
         assertEq(no.totalWithdrawnKeys, 1);
@@ -7225,11 +7198,10 @@ abstract contract ModuleReportWithdrawnValidators is ModuleFixtures {
             })
         );
 
-        WithdrawnValidatorInfo[] memory exitInfo = new WithdrawnValidatorInfo[](
-            1
-        );
+        WithdrawnValidatorInfo[]
+            memory validatorInfos = new WithdrawnValidatorInfo[](1);
 
-        exitInfo[0] = WithdrawnValidatorInfo({
+        validatorInfos[0] = WithdrawnValidatorInfo({
             nodeOperatorId: noId,
             keyIndex: keyIndex,
             exitBalance: WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE,
@@ -7245,7 +7217,7 @@ abstract contract ModuleReportWithdrawnValidators is ModuleFixtures {
                 withdrawalRequestFeeAmount
             )
         );
-        module.reportWithdrawnValidators(exitInfo);
+        module.reportWithdrawnValidators(validatorInfos);
 
         NodeOperator memory no = module.getNodeOperator(noId);
         assertEq(no.totalWithdrawnKeys, 1);
@@ -7273,10 +7245,9 @@ abstract contract ModuleReportWithdrawnValidators is ModuleFixtures {
             })
         );
 
-        WithdrawnValidatorInfo[] memory exitInfo = new WithdrawnValidatorInfo[](
-            1
-        );
-        exitInfo[0] = WithdrawnValidatorInfo({
+        WithdrawnValidatorInfo[]
+            memory validatorInfos = new WithdrawnValidatorInfo[](1);
+        validatorInfos[0] = WithdrawnValidatorInfo({
             nodeOperatorId: noId,
             keyIndex: keyIndex,
             exitBalance: WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE *
@@ -7293,7 +7264,7 @@ abstract contract ModuleReportWithdrawnValidators is ModuleFixtures {
                 withdrawalRequestFee
             )
         );
-        module.reportWithdrawnValidators(exitInfo);
+        module.reportWithdrawnValidators(validatorInfos);
     }
 
     function test_reportWithdrawnValidators_dontChargeWithdrawalFee_noPenalties()
@@ -7317,11 +7288,10 @@ abstract contract ModuleReportWithdrawnValidators is ModuleFixtures {
             })
         );
 
-        WithdrawnValidatorInfo[] memory exitInfo = new WithdrawnValidatorInfo[](
-            1
-        );
+        WithdrawnValidatorInfo[]
+            memory validatorInfos = new WithdrawnValidatorInfo[](1);
 
-        exitInfo[0] = WithdrawnValidatorInfo({
+        validatorInfos[0] = WithdrawnValidatorInfo({
             nodeOperatorId: noId,
             keyIndex: keyIndex,
             exitBalance: WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE,
@@ -7337,7 +7307,7 @@ abstract contract ModuleReportWithdrawnValidators is ModuleFixtures {
                 withdrawalRequestFeeAmount
             )
         );
-        module.reportWithdrawnValidators(exitInfo);
+        module.reportWithdrawnValidators(validatorInfos);
 
         NodeOperator memory no = module.getNodeOperator(noId);
         assertEq(no.totalWithdrawnKeys, 1);
@@ -7368,11 +7338,10 @@ abstract contract ModuleReportWithdrawnValidators is ModuleFixtures {
             })
         );
 
-        WithdrawnValidatorInfo[] memory exitInfo = new WithdrawnValidatorInfo[](
-            1
-        );
+        WithdrawnValidatorInfo[]
+            memory validatorInfos = new WithdrawnValidatorInfo[](1);
 
-        exitInfo[0] = WithdrawnValidatorInfo({
+        validatorInfos[0] = WithdrawnValidatorInfo({
             nodeOperatorId: noId,
             keyIndex: keyIndex,
             exitBalance: WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE -
@@ -7389,7 +7358,7 @@ abstract contract ModuleReportWithdrawnValidators is ModuleFixtures {
                 withdrawalRequestFeeAmount
             )
         );
-        module.reportWithdrawnValidators(exitInfo);
+        module.reportWithdrawnValidators(validatorInfos);
 
         NodeOperator memory no = module.getNodeOperator(noId);
         assertEq(no.totalWithdrawnKeys, 1);
@@ -7407,10 +7376,9 @@ abstract contract ModuleReportWithdrawnValidators is ModuleFixtures {
         module.obtainDepositData(1, "");
         uint256 nonce = module.getNonce();
 
-        WithdrawnValidatorInfo[] memory exitInfo = new WithdrawnValidatorInfo[](
-            1
-        );
-        exitInfo[0] = WithdrawnValidatorInfo({
+        WithdrawnValidatorInfo[]
+            memory validatorInfos = new WithdrawnValidatorInfo[](1);
+        validatorInfos[0] = WithdrawnValidatorInfo({
             nodeOperatorId: noId,
             keyIndex: keyIndex,
             exitBalance: 1 ether,
@@ -7418,7 +7386,7 @@ abstract contract ModuleReportWithdrawnValidators is ModuleFixtures {
             isSlashed: false
         });
 
-        module.reportWithdrawnValidators(exitInfo);
+        module.reportWithdrawnValidators(validatorInfos);
         assertEq(module.getNonce(), nonce + 1);
     }
 
@@ -7430,10 +7398,9 @@ abstract contract ModuleReportWithdrawnValidators is ModuleFixtures {
         uint256 noId = createNodeOperator();
         module.obtainDepositData(1, "");
 
-        WithdrawnValidatorInfo[] memory exitInfo = new WithdrawnValidatorInfo[](
-            1
-        );
-        exitInfo[0] = WithdrawnValidatorInfo({
+        WithdrawnValidatorInfo[]
+            memory validatorInfos = new WithdrawnValidatorInfo[](1);
+        validatorInfos[0] = WithdrawnValidatorInfo({
             nodeOperatorId: noId,
             keyIndex: keyIndex,
             exitBalance: 0,
@@ -7442,17 +7409,16 @@ abstract contract ModuleReportWithdrawnValidators is ModuleFixtures {
         });
 
         vm.expectRevert(ICSModule.ZeroExitBalance.selector);
-        module.reportWithdrawnValidators(exitInfo);
+        module.reportWithdrawnValidators(validatorInfos);
     }
 
     function test_reportWithdrawnValidators_RevertWhen_NoNodeOperator()
         public
         assertInvariants
     {
-        WithdrawnValidatorInfo[] memory exitInfo = new WithdrawnValidatorInfo[](
-            1
-        );
-        exitInfo[0] = WithdrawnValidatorInfo({
+        WithdrawnValidatorInfo[]
+            memory validatorInfos = new WithdrawnValidatorInfo[](1);
+        validatorInfos[0] = WithdrawnValidatorInfo({
             nodeOperatorId: 0,
             keyIndex: 0,
             exitBalance: 32 ether,
@@ -7461,7 +7427,7 @@ abstract contract ModuleReportWithdrawnValidators is ModuleFixtures {
         });
 
         vm.expectRevert(ICSModule.NodeOperatorDoesNotExist.selector);
-        module.reportWithdrawnValidators(exitInfo);
+        module.reportWithdrawnValidators(validatorInfos);
     }
 
     function test_reportWithdrawnValidators_RevertWhen_InvalidKeyIndexOffset()
@@ -7470,10 +7436,9 @@ abstract contract ModuleReportWithdrawnValidators is ModuleFixtures {
     {
         uint256 noId = createNodeOperator();
 
-        WithdrawnValidatorInfo[] memory exitInfo = new WithdrawnValidatorInfo[](
-            1
-        );
-        exitInfo[0] = WithdrawnValidatorInfo({
+        WithdrawnValidatorInfo[]
+            memory validatorInfos = new WithdrawnValidatorInfo[](1);
+        validatorInfos[0] = WithdrawnValidatorInfo({
             nodeOperatorId: noId,
             keyIndex: 0,
             exitBalance: 32 ether,
@@ -7482,7 +7447,7 @@ abstract contract ModuleReportWithdrawnValidators is ModuleFixtures {
         });
 
         vm.expectRevert(ICSModule.SigningKeysInvalidOffset.selector);
-        module.reportWithdrawnValidators(exitInfo);
+        module.reportWithdrawnValidators(validatorInfos);
     }
 
     function test_reportWithdrawnValidators_alreadyWithdrawn()
@@ -7492,10 +7457,9 @@ abstract contract ModuleReportWithdrawnValidators is ModuleFixtures {
         uint256 noId = createNodeOperator();
         module.obtainDepositData(1, "");
 
-        WithdrawnValidatorInfo[] memory exitInfo = new WithdrawnValidatorInfo[](
-            1
-        );
-        exitInfo[0] = WithdrawnValidatorInfo({
+        WithdrawnValidatorInfo[]
+            memory validatorInfos = new WithdrawnValidatorInfo[](1);
+        validatorInfos[0] = WithdrawnValidatorInfo({
             nodeOperatorId: noId,
             keyIndex: 0,
             exitBalance: WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE,
@@ -7503,10 +7467,10 @@ abstract contract ModuleReportWithdrawnValidators is ModuleFixtures {
             isSlashed: false
         });
 
-        module.reportWithdrawnValidators(exitInfo);
+        module.reportWithdrawnValidators(validatorInfos);
 
         uint256 nonceBefore = module.getNonce();
-        module.reportWithdrawnValidators(exitInfo);
+        module.reportWithdrawnValidators(validatorInfos);
         assertEq(
             module.getNonce(),
             nonceBefore,
@@ -7522,11 +7486,10 @@ abstract contract ModuleReportWithdrawnValidators is ModuleFixtures {
         module.obtainDepositData(3, "");
         uint256 nonceBefore = module.getNonce();
 
-        WithdrawnValidatorInfo[] memory exitInfo = new WithdrawnValidatorInfo[](
-            3
-        );
+        WithdrawnValidatorInfo[]
+            memory validatorInfos = new WithdrawnValidatorInfo[](3);
         for (uint256 i = 0; i < 3; ++i) {
-            exitInfo[i] = WithdrawnValidatorInfo({
+            validatorInfos[i] = WithdrawnValidatorInfo({
                 nodeOperatorId: noId,
                 keyIndex: i,
                 exitBalance: WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE,
@@ -7534,7 +7497,7 @@ abstract contract ModuleReportWithdrawnValidators is ModuleFixtures {
                 isSlashed: false
             });
         }
-        module.reportWithdrawnValidators(exitInfo);
+        module.reportWithdrawnValidators(validatorInfos);
         assertEq(
             module.getNonce(),
             nonceBefore + 1,
@@ -7806,10 +7769,9 @@ abstract contract ModuleAccessControl is ModuleFixtures {
         module.obtainDepositData(1, "");
         vm.stopPrank();
 
-        WithdrawnValidatorInfo[] memory exitInfo = new WithdrawnValidatorInfo[](
-            1
-        );
-        exitInfo[0] = WithdrawnValidatorInfo({
+        WithdrawnValidatorInfo[]
+            memory validatorInfos = new WithdrawnValidatorInfo[](1);
+        validatorInfos[0] = WithdrawnValidatorInfo({
             nodeOperatorId: noId,
             keyIndex: 0,
             exitBalance: 1 ether,
@@ -7818,17 +7780,16 @@ abstract contract ModuleAccessControl is ModuleFixtures {
         });
 
         vm.prank(actor);
-        module.reportWithdrawnValidators(exitInfo);
+        module.reportWithdrawnValidators(validatorInfos);
     }
 
     function test_reportWithdrawnValidatorsRole_revert() public {
         uint256 noId = createNodeOperator();
         bytes32 role = module.SUBMIT_WITHDRAWALS_ROLE();
 
-        WithdrawnValidatorInfo[] memory exitInfo = new WithdrawnValidatorInfo[](
-            1
-        );
-        exitInfo[0] = WithdrawnValidatorInfo({
+        WithdrawnValidatorInfo[]
+            memory validatorInfos = new WithdrawnValidatorInfo[](1);
+        validatorInfos[0] = WithdrawnValidatorInfo({
             nodeOperatorId: noId,
             keyIndex: 0,
             exitBalance: 1 ether,
@@ -7838,7 +7799,7 @@ abstract contract ModuleAccessControl is ModuleFixtures {
 
         vm.prank(stranger);
         expectRoleRevert(stranger, role);
-        module.reportWithdrawnValidators(exitInfo);
+        module.reportWithdrawnValidators(validatorInfos);
     }
 
     function test_recovererRole() public {
@@ -8092,24 +8053,23 @@ abstract contract ModuleDepositableValidatorsCount is ModuleFixtures {
 
         penalize(noId, BOND_SIZE * 3);
 
-        WithdrawnValidatorInfo[] memory exitInfo = new WithdrawnValidatorInfo[](
-            3
-        );
-        exitInfo[0] = WithdrawnValidatorInfo({
+        WithdrawnValidatorInfo[]
+            memory validatorInfos = new WithdrawnValidatorInfo[](3);
+        validatorInfos[0] = WithdrawnValidatorInfo({
             nodeOperatorId: noId,
             keyIndex: 0,
             exitBalance: WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE,
             slashingPenalty: 0,
             isSlashed: false
         });
-        exitInfo[1] = WithdrawnValidatorInfo({
+        validatorInfos[1] = WithdrawnValidatorInfo({
             nodeOperatorId: noId,
             keyIndex: 1,
             exitBalance: WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE,
             slashingPenalty: 0,
             isSlashed: false
         });
-        exitInfo[2] = WithdrawnValidatorInfo({
+        validatorInfos[2] = WithdrawnValidatorInfo({
             nodeOperatorId: noId,
             keyIndex: 2,
             exitBalance: WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE -
@@ -8119,7 +8079,7 @@ abstract contract ModuleDepositableValidatorsCount is ModuleFixtures {
         }); // Large CL balance drop, that doesn't change the unbonded count.
 
         assertEq(module.getNodeOperator(noId).depositableValidatorsCount, 0);
-        module.reportWithdrawnValidators(exitInfo);
+        module.reportWithdrawnValidators(validatorInfos);
         assertEq(module.getNodeOperator(noId).depositableValidatorsCount, 2);
         assertEq(getStakingModuleSummary().depositableValidatorsCount, 2);
     }

--- a/test/unit/ModuleAbstract.t.sol
+++ b/test/unit/ModuleAbstract.t.sol
@@ -6017,8 +6017,11 @@ abstract contract ModuleCompensateGeneralDelayedPenalty is ModuleFixtures {
     }
 }
 
-abstract contract ModuleSubmitWithdrawals is ModuleFixtures {
-    function test_reportWithdrawnValidators() public assertInvariants {
+abstract contract ModuleReportWithdrawnValidators is ModuleFixtures {
+    function test_reportWithdrawnValidators_NoPenalties()
+        public
+        assertInvariants
+    {
         uint256 keyIndex = 0;
         uint256 noId = createNodeOperator();
         (bytes memory pubkey, ) = module.obtainDepositData(1, "");
@@ -6303,7 +6306,8 @@ abstract contract ModuleSubmitWithdrawals is ModuleFixtures {
             keyIndex: keyIndex,
             exitBalance: WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE *
                 multiplier +
-                1 ether,
+                1 ether -
+                1 wei,
             slashingPenalty: 0,
             isSlashed: false
         });
@@ -6327,8 +6331,10 @@ abstract contract ModuleSubmitWithdrawals is ModuleFixtures {
         uint256 noId = createNodeOperator();
         module.obtainDepositData(1, "");
 
-        uint248 fee = type(uint248).max;
-        uint256 multiplier = WithdrawnValidatorLib.MAX_PENALTY_MULTIPLIER;
+        // (1 << (256 - log2(2048))) - 1
+        uint248 fee = (1 << 245) - 1;
+        uint256 multiplier = WithdrawnValidatorLib.MAX_EFFECTIVE_BALANCE /
+            WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE;
 
         exitPenalties.mock_setDelayedExitPenaltyInfo(
             ExitPenaltyInfo({
@@ -6489,7 +6495,8 @@ abstract contract ModuleSubmitWithdrawals is ModuleFixtures {
             keyIndex: keyIndex,
             exitBalance: WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE *
                 multiplier +
-                1 ether,
+                1 ether -
+                1 wei,
             slashingPenalty: 0,
             isSlashed: false
         });
@@ -6513,8 +6520,10 @@ abstract contract ModuleSubmitWithdrawals is ModuleFixtures {
         uint256 noId = createNodeOperator();
         module.obtainDepositData(1, "");
 
-        uint248 penalty = type(uint248).max;
-        uint256 multiplier = WithdrawnValidatorLib.MAX_PENALTY_MULTIPLIER;
+        // (1 << (256 - log2(2048))) - 1
+        uint248 penalty = (1 << 245) - 1;
+        uint256 multiplier = WithdrawnValidatorLib.MAX_EFFECTIVE_BALANCE /
+            WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE;
 
         exitPenalties.mock_setDelayedExitPenaltyInfo(
             ExitPenaltyInfo({

--- a/test/unit/lib/WithdrawnValidatorLib.t.sol
+++ b/test/unit/lib/WithdrawnValidatorLib.t.sol
@@ -1,0 +1,114 @@
+// SPDX-FileCopyrightText: 2025 Lido <info@lido.fi>
+// SPDX-License-Identifier: GPL-3.0
+
+pragma solidity 0.8.24;
+
+import { Test } from "forge-std/Test.sol";
+
+import { WithdrawnValidatorInfo } from "src/interfaces/ICSModule.sol";
+import { WithdrawnValidatorLib } from "src/lib/WithdrawnValidatorLib.sol";
+
+contract Library {
+    function scalePenaltyByMultiplier(
+        uint256 penalty,
+        uint256 multiplier
+    ) external pure returns (uint256) {
+        return
+            WithdrawnValidatorLib._scalePenaltyByMultiplier(
+                penalty,
+                multiplier
+            );
+    }
+
+    function getPenaltyMultiplier(
+        WithdrawnValidatorInfo memory validatorInfo
+    ) external pure returns (uint256 penaltyMultiplier) {
+        return WithdrawnValidatorLib._getPenaltyMultiplier(validatorInfo);
+    }
+}
+
+contract TestWithdrawnValidatorLib is Test {
+    Library internal lib;
+
+    function setUp() public {
+        lib = new Library();
+    }
+
+    function test_scalePenaltyByMultiplier() public {
+        uint256 s;
+
+        s = lib.scalePenaltyByMultiplier(33, 33);
+        assertEq(s, 34);
+
+        s = lib.scalePenaltyByMultiplier(3300000, 33);
+        assertEq(s, 3403125);
+
+        s = lib.scalePenaltyByMultiplier(0.1 ether, 33);
+        assertEq(s, 0.103125 ether);
+
+        s = lib.scalePenaltyByMultiplier(0.1 ether, 1041);
+        assertEq(s, 3.253125 ether);
+
+        s = lib.scalePenaltyByMultiplier(0.1 ether, 2048);
+        assertEq(s, 6.4 ether);
+
+        s = lib.scalePenaltyByMultiplier(32 ether, 1);
+        assertEq(s, 1 ether);
+
+        s = lib.scalePenaltyByMultiplier(32 ether, 2048);
+        assertEq(s, 2048 ether);
+    }
+
+    function test_getPenaltyMultiplier_Step() public {
+        WithdrawnValidatorInfo memory info;
+        uint256 m;
+
+        info.exitBalance = 0;
+        m = lib.getPenaltyMultiplier(info);
+        assertEq(m, 32);
+
+        info.exitBalance = 1 ether;
+        m = lib.getPenaltyMultiplier(info);
+        assertEq(m, 32);
+
+        info.exitBalance = 32 ether - 1 wei;
+        m = lib.getPenaltyMultiplier(info);
+        assertEq(m, 32);
+
+        info.exitBalance = 32 ether;
+        m = lib.getPenaltyMultiplier(info);
+        assertEq(m, 32);
+
+        info.exitBalance = 32 ether + 1 wei;
+        m = lib.getPenaltyMultiplier(info);
+        assertEq(m, 32);
+
+        info.exitBalance = 33 ether - 1 wei;
+        m = lib.getPenaltyMultiplier(info);
+        assertEq(m, 32);
+
+        info.exitBalance = 33 ether;
+        m = lib.getPenaltyMultiplier(info);
+        assertEq(m, 33);
+
+        info.exitBalance = 33 ether + 1 wei;
+        m = lib.getPenaltyMultiplier(info);
+        assertEq(m, 33);
+
+        info.exitBalance = 2048 ether - 1;
+        m = lib.getPenaltyMultiplier(info);
+        assertEq(m, 2047);
+
+        info.exitBalance = 2048 ether;
+        m = lib.getPenaltyMultiplier(info);
+        assertEq(m, 2048);
+
+        info.exitBalance = 2048 ether + 1 wei;
+        m = lib.getPenaltyMultiplier(info);
+        assertEq(m, 2048);
+
+        info.exitBalance = 2049 ether;
+        m = lib.getPenaltyMultiplier(info);
+        assertEq(m, 2048);
+    }
+}


### PR DESCRIPTION
## Description

Extract `submitWithdrawals` method body (most of it, at least) to a separate library.

## Checklist

- [x] Appropriate PR labels applied
- [x] Test coverage maintained (`just coverage`)
  - [ ] No need to add/update tests
  - [x] Tests are added/updated
- [x] Documentation maintained
  - [x] No need to update
  - [ ] Updated
