### PR TITLE
ci: add regression composite action

### DIFF
--- a/.github/actions/regression-tests/action.yml
+++ b/.github/actions/regression-tests/action.yml
@@ -1,0 +1,82 @@
+name: "Regression tests"
+description: "Checkout and run regression tests for community-staking-module"
+
+inputs:
+  rpc_url:
+    description: "RPC URL injected as RPC_URL env for fork tests."
+    required: true
+  repository:
+    description: "Repository to checkout (owner/repo)."
+    required: false
+    default: "lidofinance/community-staking-module"
+  ref:
+    description: "Git ref of the repository to test."
+    required: false
+    default: "main"
+  path:
+    description: "Path to checkout the repository."
+    required: false
+    default: "community-staking-module"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Checkout community-staking-module
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ inputs.repository }}
+        ref: ${{ inputs.ref }}
+        path: ${{ inputs.path }}
+
+    - name: Set env vars
+      shell: bash
+      working-directory: ${{ inputs.path }}
+      run: |
+        echo "FOUNDRY_VERSION=$(head .foundryref)" >> "$GITHUB_ENV"
+        echo "JUST_TAG=1.24.0" >> "$GITHUB_ENV"
+
+    - name: Cache just
+      id: just-cache
+      uses: actions/cache@v4
+      with:
+        path: ~/.cargo/bin/
+        key: cargobin-${{ runner.os }}-just-${{ env.JUST_TAG }}
+
+    - name: Install just
+      shell: bash
+      run: |
+        if ! command -v just >/dev/null 2>&1; then
+          cargo install "just@${JUST_TAG}"
+        fi
+
+    - name: Install Foundry
+      uses: foundry-rs/foundry-toolchain@v1
+      with:
+        version: ${{ env.FOUNDRY_VERSION }}
+
+    - name: Install node
+      uses: actions/setup-node@v4
+      with:
+        node-version-file: "${{ inputs.path }}/.nvmrc"
+        cache: yarn
+        cache-dependency-path: "${{ inputs.path }}/**/yarn.lock"
+
+    - name: Install dependencies
+      shell: bash
+      working-directory: ${{ inputs.path }}
+      run: just deps
+
+    - name: Build
+      shell: bash
+      working-directory: ${{ inputs.path }}
+      run: just build
+
+    - name: Run regression tests
+      shell: bash
+      working-directory: ${{ inputs.path }}
+      run: just test-integration
+      env:
+        RPC_URL: ${{ inputs.rpc_url }}
+        CHAIN: mainnet
+        DEPLOY_CONFIG: ./artifacts/mainnet/upgrade-v2-mainnet.json
+        FOUNDRY_PROFILE: ci

--- a/.github/workflows/regular-mainnet.yml
+++ b/.github/workflows/regular-mainnet.yml
@@ -46,8 +46,8 @@ jobs:
         run: cargo install "just@$JUST_TAG"
         if: steps.get-cache.outputs.cache-hit != 'true'
 
-  test:
-    name: Integration & Invariant tests
+  regression-tests:
+    name: Regression tests
     runs-on: ubuntu-latest
     needs: bootstrap
     steps:
@@ -55,13 +55,13 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Set FOUNDRY_VERSION
-        run: echo "FOUNDRY_VERSION=$(head .foundryref)" >> "$GITHUB_ENV"
-
       - uses: actions/cache@v4
         with:
           path: ${{ needs.bootstrap.outputs.cache-path }}
           key: ${{ needs.bootstrap.outputs.cache-key }}
+
+      - name: Set FOUNDRY_VERSION
+        run: echo "FOUNDRY_VERSION=$(head .foundryref)" >> "$GITHUB_ENV"
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
@@ -78,17 +78,22 @@ jobs:
       - name: Install dependencies
         run: just deps
 
-      # TODO: Remove `continue-on-error` after making the contracts fit.
-      - name: Build
-        run: just build --sizes
-        continue-on-error: true
-
-      - name: Run post-vote tests
-        run: just test-post-voting
+      - name: Start mainnet fork
         env:
-          CHAIN: mainnet
-          DEPLOY_CONFIG: ./artifacts/mainnet/deploy-mainnet.json
           RPC_URL: ${{ secrets.RPC_URL_MAINNET }}
+        run: just make-fork &
+
+      - name: Run regression tests
+        uses: ./.github/actions/regression-tests
+        with:
+          repository: ${{ github.repository }}
+          ref: v2.0 # Run the stable v2.0 release tests
+          path: community-staking-module-v2
+          rpc_url: http://127.0.0.1:8545
+
+      - name: Kill fork
+        if: always()
+        run: just kill-fork
 
       - name: Echo embeds to the env variable
         if: ${{ failure() && (github.event_name == 'schedule' || inputs.notify) }}


### PR DESCRIPTION
## Description

- add composite GitHub Action `.github/actions/regression-tests` so external workflows can build and run repo tests while controlling fork setup on their side

an example: https://github.com/lidofinance/scripts/pull/544

## Checklist

- [x] Appropriate PR labels applied
- [ ] Test coverage maintained (`just coverage`)
  - [x] No need to add/update tests
  - [ ] Tests are added/updated
- [ ] Documentation maintained
  - [x] No need to update
  - [ ] Updated
