### PR TITLE
fix: top-up queue limit to uint8

### DIFF
--- a/script/DeployBase.s.sol
+++ b/script/DeployBase.s.sol
@@ -72,7 +72,7 @@ struct DeployParams {
     uint256 stakingModuleId;
     bytes32 moduleType;
     address generalDelayedPenaltyReporter;
-    uint32 topUpQueueLimit;
+    uint8 topUpQueueLimit;
     // ParametersRegistry
     uint256 queueLowestPriority;
     uint256 defaultKeyRemovalCharge;

--- a/src/CSModule.sol
+++ b/src/CSModule.sol
@@ -67,7 +67,7 @@ contract CSModule is ICSModule, BaseModule {
 
     function initialize(
         address admin,
-        uint32 topUpQueueLimit
+        uint8 topUpQueueLimit
     ) external reinitializer(INITIALIZED_VERSION) {
         __BaseModule_init(admin);
 
@@ -274,7 +274,7 @@ contract CSModule is ICSModule, BaseModule {
     function setTopUpQueueLimit(
         uint256 limit
     ) external onlyActiveTopUpQueue onlyRole(MANAGE_TOP_UP_QUEUE_ROLE) {
-        _topUpQueue().limit = limit.toUint32();
+        _topUpQueue().limit = limit.toUint8();
         emit TopUpQueueLimitSet(limit);
         _incrementModuleNonce();
     }
@@ -416,7 +416,7 @@ contract CSModule is ICSModule, BaseModule {
     }
 
     /// @dev Setting `topUpQueueLimit` to 0 effectively disables the top-up queue permanently.
-    function _initTopUpQueue(uint32 topUpQueueLimit) internal {
+    function _initTopUpQueue(uint8 topUpQueueLimit) internal {
         if (topUpQueueLimit > 0) {
             _topUpQueue().active = true;
             _topUpQueue().limit = topUpQueueLimit;

--- a/src/interfaces/ICSModule.sol
+++ b/src/interfaces/ICSModule.sol
@@ -37,7 +37,7 @@ interface ICSModule is
     /// @notice Initializes the contract.
     /// @param admin An address to grant the DEFAULT_ADMIN_ROLE to.
     /// @param topUpQueueLimit The limit of the top-up queue.
-    function initialize(address admin, uint32 topUpQueueLimit) external;
+    function initialize(address admin, uint8 topUpQueueLimit) external;
 
     /// @notice Clean the deposit queue from batches with no depositable keys
     /// @dev Use **eth_call** to check how many items will be removed

--- a/src/lib/TopUpQueueLib.sol
+++ b/src/lib/TopUpQueueLib.sol
@@ -46,8 +46,8 @@ library TopUpQueueLib {
 
     struct Queue {
         TopUpQueueItem[] items;
-        uint32 limit;
         uint32 head;
+        uint8 limit;
         bool active;
     }
 

--- a/test/unit/CSModule.t.sol
+++ b/test/unit/CSModule.t.sol
@@ -29,7 +29,7 @@ contract CSMCommon is ModuleFixtures {
     using Strings for uint128;
 
     CSModule csm;
-    uint32 topUpQueueLimit;
+    uint8 topUpQueueLimit;
 
     function moduleType() internal pure override returns (ModuleType) {
         return ModuleType.Community;
@@ -830,7 +830,7 @@ contract CSMTopUpQueue is CSMCommon {
         csm.getKeysForTopUp(0);
     }
 
-    function testFuzz_setTopUpQueueLimit(uint32 limit) public {
+    function testFuzz_setTopUpQueueLimit(uint8 limit) public {
         vm.expectEmit(true, true, true, true, address(csm));
         emit ICSModule.TopUpQueueLimitSet(limit);
         csm.setTopUpQueueLimit(limit);
@@ -849,12 +849,12 @@ contract CSMTopUpQueue is CSMCommon {
         assertEq(_getTopUpQueueLimit(), 0);
     }
 
-    function test_setTopUpQueueLimit_RevertWhenLimitExceedsUint32() public {
+    function test_setTopUpQueueLimit_RevertWhenLimitExceedsUint8() public {
         uint256 limit = uint256(type(uint32).max) + 1;
         vm.expectRevert(
             abi.encodeWithSelector(
                 SafeCast.SafeCastOverflowedUintDowncast.selector,
-                32,
+                8,
                 limit
             )
         );

--- a/test/unit/lib/TopUpQueueLib.t.sol
+++ b/test/unit/lib/TopUpQueueLib.t.sol
@@ -14,7 +14,7 @@ contract Library {
 
     TopUpQueueLib.Queue internal q;
 
-    function setLimit(uint32 limit) external {
+    function setLimit(uint8 limit) external {
         q.limit = limit;
     }
 


### PR DESCRIPTION
## Description

fix: top-up queue limit to uint8

## Checklist

- [x] Appropriate PR labels applied
- [x] Test coverage maintained (`just coverage`)
  - [ ] No need to add/update tests
  - [x] Tests are added/updated
- [x] Documentation maintained
  - [x] No need to update
  - [ ] Updated
