### PR TITLE
fix: staking router wiring and devnet test updates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,9 @@
 - Linting: `yarn lint:check` (prettier + solhint), `yarn lint:fix`, `yarn lint:solhint`.
 - Diff: `git diff --no-ext-diff`
 
+- For fast local checks after small edits, prefer targeted compile of changed Solidity files: `forge build <changed-file-1> <changed-file-2> ...`.
+- Keep `forge build` as the full-project compile when touching shared interfaces/libraries or before final handoff.
+
 ## Coding Style & Naming Conventions
 
 - Formatting: Prettier + `prettier-plugin-solidity` (Solidity `printWidth=80`, `tabWidth=4`, spaces only).
@@ -45,6 +48,9 @@
 - Run: `just test-unit` for fast cycles; `CHAIN`/`RPC_URL` required for fork tests. Example: `export CHAIN=hoodi && export RPC_URL=<https-url>`.
 - Coverage: `just coverage-lcov` produces LCOV output (commit if relevant).
 - After making changes to the source code make sure you've either ran build command or unit tests.
+- `vm.prank(addr)` applies to the next external call only. Avoid patterns where the next call is accidentally consumed by a getter inside arguments or call-chaining.
+  Bad: `vm.prank(admin); target.grantRole(target.ROLE(), user)` or `vm.prank(admin); module.PARAMETERS_REGISTRY().setX(...)`.
+  Good: precompute external values before prank (`bytes32 role = target.ROLE();`) or use `vm.startPrank`/`vm.stopPrank` for multi-call sequences.
 - Do not assert unchanged state after a reverting call.
 - Deployment test name suffixes are part of the test selection contract used by `just` recipes and encode two axes: phase and flow.
 - Phase semantics:

--- a/script/csm/DeployBase.s.sol
+++ b/script/csm/DeployBase.s.sol
@@ -559,6 +559,9 @@ abstract contract DeployBase is Script {
             deployJson.set("GateSeal", gateSeal);
             deployJson.set("DeployParams", abi.encode(config));
             deployJson.set("git-ref", gitRef);
+            if (!vm.exists(artifactDir)) {
+                vm.createDir(artifactDir, true);
+            }
             vm.writeJson(deployJson.str, _deployJsonFilename());
         }
 

--- a/script/csm/DeployCSMImplementationsBase.s.sol
+++ b/script/csm/DeployCSMImplementationsBase.s.sol
@@ -172,7 +172,20 @@ abstract contract DeployCSMImplementationsBase is DeployBase {
             deployJson.set("GateSealV3", gateSealV3);
             deployJson.set("DeployParams", abi.encode(config));
             deployJson.set("git-ref", gitRef);
-            vm.writeJson(deployJson.str, string(abi.encodePacked(artifactDir, "upgrade-", chainName, ".json")));
+            if (!vm.exists(artifactDir)) {
+                vm.createDir(artifactDir, true);
+            }
+            vm.writeJson(
+                deployJson.str,
+                string(
+                    abi.encodePacked(
+                        artifactDir,
+                        "upgrade-",
+                        chainName,
+                        ".json"
+                    )
+                )
+            );
         }
 
         vm.stopBroadcast();

--- a/script/csm/DeployCSMImplementationsBase.s.sol
+++ b/script/csm/DeployCSMImplementationsBase.s.sol
@@ -175,17 +175,7 @@ abstract contract DeployCSMImplementationsBase is DeployBase {
             if (!vm.exists(artifactDir)) {
                 vm.createDir(artifactDir, true);
             }
-            vm.writeJson(
-                deployJson.str,
-                string(
-                    abi.encodePacked(
-                        artifactDir,
-                        "upgrade-",
-                        chainName,
-                        ".json"
-                    )
-                )
-            );
+            vm.writeJson(deployJson.str, string(abi.encodePacked(artifactDir, "upgrade-", chainName, ".json")));
         }
 
         vm.stopBroadcast();

--- a/script/curated/DeployBase.s.sol
+++ b/script/curated/DeployBase.s.sol
@@ -304,20 +304,23 @@ abstract contract DeployBase is Script {
 
             {
                 OssifiableProxy moduleProxy = OssifiableProxy(payable(address(curatedModule)));
-                moduleProxy.proxy__upgradeTo(address(curatedModuleImpl));
+                moduleProxy.proxy__upgradeToAndCall(
+                    address(curatedModuleImpl),
+                    abi.encodeCall(CuratedModule.initialize, (deployer))
+                );
                 moduleProxy.proxy__changeAdmin(config.proxyAdmin);
             }
-
-            curatedModule.initialize({ admin: deployer });
 
             MetaRegistry metaRegistryImpl = new MetaRegistry(address(curatedModule));
 
             {
                 OssifiableProxy metaRegistryProxy = OssifiableProxy(payable(address(metaRegistry)));
-                metaRegistryProxy.proxy__upgradeTo(address(metaRegistryImpl));
+                metaRegistryProxy.proxy__upgradeToAndCall(
+                    address(metaRegistryImpl),
+                    abi.encodeCall(MetaRegistry.initialize, (deployer))
+                );
                 metaRegistryProxy.proxy__changeAdmin(config.proxyAdmin);
             }
-            metaRegistry.initialize({ admin: deployer });
 
             accounting.grantRole(accounting.MANAGE_BOND_CURVES_ROLE(), address(deployer));
             metaRegistry.grantRole(metaRegistry.SET_BOND_CURVE_WEIGHT_ROLE(), deployer);

--- a/script/curated/DeployBase.s.sol
+++ b/script/curated/DeployBase.s.sol
@@ -21,6 +21,7 @@ import { CuratedGate } from "../../src/CuratedGate.sol";
 import { MerkleGateFactory } from "../../src/MerkleGateFactory.sol";
 
 import { ILidoLocator } from "../../src/interfaces/ILidoLocator.sol";
+import { IStakingRouter } from "../../src/interfaces/IStakingRouter.sol";
 import { IGateSealFactory } from "../../src/interfaces/IGateSealFactory.sol";
 import { BaseOracle } from "../../src/lib/base-oracle/BaseOracle.sol";
 import { IVerifier } from "../../src/interfaces/IVerifier.sol";
@@ -91,6 +92,7 @@ struct CuratedDeployParams {
     uint256 bondLockPeriod;
     address chargePenaltyRecipient;
     // Module
+    uint256 stakingModuleId;
     bytes32 moduleType;
     address generalDelayedPenaltyReporter;
     // ParametersRegistry
@@ -654,5 +656,9 @@ abstract contract DeployBase is Script {
         ejector.grantRole(ejector.DEFAULT_ADMIN_ROLE(), config.secondAdminAddress);
         verifier.grantRole(verifier.DEFAULT_ADMIN_ROLE(), config.secondAdminAddress);
         strikes.grantRole(strikes.DEFAULT_ADMIN_ROLE(), config.secondAdminAddress);
+    }
+
+    function _nextStakingModuleId(address locatorAddress) internal view returns (uint256) {
+        return IStakingRouter(ILidoLocator(locatorAddress).stakingRouter()).getStakingModulesCount() + 1;
     }
 }

--- a/script/curated/DeployBase.s.sol
+++ b/script/curated/DeployBase.s.sol
@@ -21,7 +21,6 @@ import { CuratedGate } from "../../src/CuratedGate.sol";
 import { MerkleGateFactory } from "../../src/MerkleGateFactory.sol";
 
 import { ILidoLocator } from "../../src/interfaces/ILidoLocator.sol";
-import { IStakingRouter } from "../../src/interfaces/IStakingRouter.sol";
 import { IGateSealFactory } from "../../src/interfaces/IGateSealFactory.sol";
 import { BaseOracle } from "../../src/lib/base-oracle/BaseOracle.sol";
 import { IVerifier } from "../../src/interfaces/IVerifier.sol";
@@ -92,7 +91,6 @@ struct CuratedDeployParams {
     uint256 bondLockPeriod;
     address chargePenaltyRecipient;
     // Module
-    uint256 stakingModuleId;
     bytes32 moduleType;
     address generalDelayedPenaltyReporter;
     // ParametersRegistry
@@ -656,9 +654,5 @@ abstract contract DeployBase is Script {
         ejector.grantRole(ejector.DEFAULT_ADMIN_ROLE(), config.secondAdminAddress);
         verifier.grantRole(verifier.DEFAULT_ADMIN_ROLE(), config.secondAdminAddress);
         strikes.grantRole(strikes.DEFAULT_ADMIN_ROLE(), config.secondAdminAddress);
-    }
-
-    function _nextStakingModuleId(address locatorAddress) internal view returns (uint256) {
-        return IStakingRouter(ILidoLocator(locatorAddress).stakingRouter()).getStakingModulesCount() + 1;
     }
 }

--- a/script/curated/DeployBase.s.sol
+++ b/script/curated/DeployBase.s.sol
@@ -47,6 +47,7 @@ struct GateCurveParams {
     uint256 attestationsWeight;
     uint256 blocksWeight;
     uint256 syncWeight;
+    uint256 metaRegistryBondCurveWeight;
     uint256 allowedExitDelay;
     uint256 exitDelayFee;
     uint256 maxElWithdrawalRequestFee;
@@ -290,7 +291,36 @@ abstract contract DeployBase is Script {
                 accountingProxy.proxy__changeAdmin(config.proxyAdmin);
             }
 
+            exitPenalties = ExitPenalties(_deployProxy(deployer, address(dummyImpl)));
+
+            CuratedModule curatedModuleImpl = new CuratedModule({
+                moduleType: config.moduleType,
+                lidoLocator: config.lidoLocatorAddress,
+                parametersRegistry: address(parametersRegistry),
+                accounting: address(accounting),
+                exitPenalties: address(exitPenalties),
+                metaRegistry: address(metaRegistry)
+            });
+
+            {
+                OssifiableProxy moduleProxy = OssifiableProxy(payable(address(curatedModule)));
+                moduleProxy.proxy__upgradeTo(address(curatedModuleImpl));
+                moduleProxy.proxy__changeAdmin(config.proxyAdmin);
+            }
+
+            curatedModule.initialize({ admin: deployer });
+
+            MetaRegistry metaRegistryImpl = new MetaRegistry(address(curatedModule));
+
+            {
+                OssifiableProxy metaRegistryProxy = OssifiableProxy(payable(address(metaRegistry)));
+                metaRegistryProxy.proxy__upgradeTo(address(metaRegistryImpl));
+                metaRegistryProxy.proxy__changeAdmin(config.proxyAdmin);
+            }
+            metaRegistry.initialize({ admin: deployer });
+
             accounting.grantRole(accounting.MANAGE_BOND_CURVES_ROLE(), address(deployer));
+            metaRegistry.grantRole(metaRegistry.SET_BOND_CURVE_WEIGHT_ROLE(), deployer);
 
             for (uint256 i = 0; i < gatesCount; i++) {
                 CuratedGateConfig storage gateConfig = config.curatedGates[i];
@@ -335,42 +365,13 @@ abstract contract DeployBase is Script {
                     params.blocksWeight,
                     params.syncWeight
                 );
+                metaRegistry.setBondCurveWeight(curveId, params.metaRegistryBondCurveWeight);
                 parametersRegistry.setAllowedExitDelay(curveId, params.allowedExitDelay);
                 parametersRegistry.setExitDelayFee(curveId, params.exitDelayFee);
                 parametersRegistry.setMaxElWithdrawalRequestFee(curveId, params.maxElWithdrawalRequestFee);
             }
             accounting.revokeRole(accounting.MANAGE_BOND_CURVES_ROLE(), address(deployer));
-
-            exitPenalties = ExitPenalties(_deployProxy(deployer, address(dummyImpl)));
-
-            CuratedModule curatedModuleImpl = new CuratedModule({
-                moduleType: config.moduleType,
-                lidoLocator: config.lidoLocatorAddress,
-                parametersRegistry: address(parametersRegistry),
-                accounting: address(accounting),
-                exitPenalties: address(exitPenalties),
-                metaRegistry: address(metaRegistry)
-            });
-
-            {
-                OssifiableProxy moduleProxy = OssifiableProxy(payable(address(curatedModule)));
-                moduleProxy.proxy__upgradeToAndCall(
-                    address(curatedModuleImpl),
-                    abi.encodeCall(CuratedModule.initialize, (deployer))
-                );
-                moduleProxy.proxy__changeAdmin(config.proxyAdmin);
-            }
-
-            MetaRegistry metaRegistryImpl = new MetaRegistry(address(curatedModule));
-
-            {
-                OssifiableProxy metaRegistryProxy = OssifiableProxy(payable(address(metaRegistry)));
-                metaRegistryProxy.proxy__upgradeToAndCall(
-                    address(metaRegistryImpl),
-                    abi.encodeCall(MetaRegistry.initialize, (deployer))
-                );
-                metaRegistryProxy.proxy__changeAdmin(config.proxyAdmin);
-            }
+            metaRegistry.revokeRole(metaRegistry.SET_BOND_CURVE_WEIGHT_ROLE(), deployer);
 
             ValidatorStrikes strikesImpl = new ValidatorStrikes({
                 module: address(curatedModule),

--- a/script/curated/DeployBase.s.sol
+++ b/script/curated/DeployBase.s.sol
@@ -558,6 +558,9 @@ abstract contract DeployBase is Script {
             deployJson.set("DeployParams", abi.encode(config));
             deployJson.set("CuratedDeployParams", abi.encode(config));
             deployJson.set("git-ref", gitRef);
+            if (!vm.exists(artifactDir)) {
+                vm.createDir(artifactDir, true);
+            }
             vm.writeJson(deployJson.str, _deployJsonFilename());
         }
 

--- a/script/curated/DeployHoodi.s.sol
+++ b/script/curated/DeployHoodi.s.sol
@@ -56,7 +56,6 @@ contract DeployHoodi is DeployBase {
         config.bondLockPeriod = 8 weeks;
         config.chargePenaltyRecipient = 0x0534aA41907c9631fae990960bCC72d75fA7cfeD; // locator.treasury()
         // Module
-        config.stakingModuleId = _nextStakingModuleId(config.lidoLocatorAddress);
         config.moduleType = "curated-onchain-v2"; // Just a unique type name to be used by the off-chain tooling
         config.generalDelayedPenaltyReporter = 0x4AF43Ee34a6fcD1fEcA1e1F832124C763561dA53; // Dev team EOA
 

--- a/script/curated/DeployHoodi.s.sol
+++ b/script/curated/DeployHoodi.s.sol
@@ -102,6 +102,7 @@ contract DeployHoodi is DeployBase {
             primaryGate.params.attestationsWeight = 52; // TODO
             primaryGate.params.blocksWeight = 6; // TODO
             primaryGate.params.syncWeight = 2; // TODO
+            primaryGate.params.metaRegistryBondCurveWeight = 1; // TODO reconsider
             primaryGate.params.allowedExitDelay = 3 days; // TODO
             primaryGate.params.exitDelayFee = 0.02 ether; // TODO
             primaryGate.params.maxElWithdrawalRequestFee = 0.05 ether; // TODO

--- a/script/curated/DeployHoodi.s.sol
+++ b/script/curated/DeployHoodi.s.sol
@@ -56,7 +56,8 @@ contract DeployHoodi is DeployBase {
         config.bondLockPeriod = 8 weeks;
         config.chargePenaltyRecipient = 0x0534aA41907c9631fae990960bCC72d75fA7cfeD; // locator.treasury()
         // Module
-        config.moduleType = "curated-onchain-v1"; // Just a unique type name to be used by the off-chain tooling
+        config.stakingModuleId = _nextStakingModuleId(config.lidoLocatorAddress);
+        config.moduleType = "curated-onchain-v2"; // Just a unique type name to be used by the off-chain tooling
         config.generalDelayedPenaltyReporter = 0x4AF43Ee34a6fcD1fEcA1e1F832124C763561dA53; // Dev team EOA
 
         // ParametersRegistry

--- a/script/curated/DeployLocalDevNet.s.sol
+++ b/script/curated/DeployLocalDevNet.s.sol
@@ -45,7 +45,6 @@ contract DeployLocalDevNet is DeployBase {
         config.bondLockPeriod = 1 days;
         config.chargePenaltyRecipient = vm.envAddress("CSM_FIRST_ADMIN_ADDRESS"); // Dev team EOA
         // Module
-        config.stakingModuleId = vm.envUint("CSM_STAKING_MODULE_ID");
         config.moduleType = "curated-onchain-v2"; // Just a unique type name to be used by the off-chain tooling
         config.generalDelayedPenaltyReporter = vm.envAddress("CSM_FIRST_ADMIN_ADDRESS"); // Dev team EOA
 

--- a/script/curated/DeployLocalDevNet.s.sol
+++ b/script/curated/DeployLocalDevNet.s.sol
@@ -84,10 +84,7 @@ contract DeployLocalDevNet is DeployBase {
                 "CURATED_GATE_GENERAL_DELAYED_PENALTY_FINE",
                 uint256(0.05 ether)
             );
-            primaryGate.params.keysLimit = vm.envOr(
-                "CURATED_GATE_KEYS_LIMIT",
-                uint256(type(uint248).max)
-            );
+            primaryGate.params.keysLimit = vm.envOr("CURATED_GATE_KEYS_LIMIT", uint256(type(uint248).max));
             primaryGate.params.avgPerfLeewayData.push([1, 10000]); // TODO
             primaryGate.params.rewardShareData.push([1, 10000]); // TODO
             primaryGate.params.rewardShareData.push([17, 5834]); // TODO
@@ -99,6 +96,7 @@ contract DeployLocalDevNet is DeployBase {
             primaryGate.params.attestationsWeight = 60; // TODO
             primaryGate.params.blocksWeight = 4; // TODO
             primaryGate.params.syncWeight = 0; // TODO
+            primaryGate.params.metaRegistryBondCurveWeight = 1; // TODO reconsider
             primaryGate.params.allowedExitDelay = 8 days; // TODO
             primaryGate.params.exitDelayFee = 0.05 ether; // TODO
             primaryGate.params.maxElWithdrawalRequestFee = 0.05 ether; // TODO

--- a/script/curated/DeployLocalDevNet.s.sol
+++ b/script/curated/DeployLocalDevNet.s.sol
@@ -45,7 +45,8 @@ contract DeployLocalDevNet is DeployBase {
         config.bondLockPeriod = 1 days;
         config.chargePenaltyRecipient = vm.envAddress("CSM_FIRST_ADMIN_ADDRESS"); // Dev team EOA
         // Module
-        config.moduleType = "curated-onchain-v1"; // Just a unique type name to be used by the off-chain tooling
+        config.stakingModuleId = vm.envUint("CSM_STAKING_MODULE_ID");
+        config.moduleType = "curated-onchain-v2"; // Just a unique type name to be used by the off-chain tooling
         config.generalDelayedPenaltyReporter = vm.envAddress("CSM_FIRST_ADMIN_ADDRESS"); // Dev team EOA
 
         // ParametersRegistry

--- a/script/curated/DeployLocalDevNet.s.sol
+++ b/script/curated/DeployLocalDevNet.s.sol
@@ -53,7 +53,7 @@ contract DeployLocalDevNet is DeployBase {
         config.defaultKeyRemovalCharge = 0;
         config.defaultGeneralDelayedPenaltyAdditionalFine = 0.1 ether;
         config.defaultKeysLimit = type(uint256).max;
-        config.defaultAvgPerfLeewayBP = 450;
+        config.defaultAvgPerfLeewayBP = 10000;
         config.defaultRewardShareBP = 10000;
         config.defaultStrikesLifetimeFrames = 6;
         config.defaultStrikesThreshold = 3;
@@ -84,8 +84,11 @@ contract DeployLocalDevNet is DeployBase {
                 "CURATED_GATE_GENERAL_DELAYED_PENALTY_FINE",
                 uint256(0.05 ether)
             );
-            primaryGate.params.keysLimit = vm.envOr("CURATED_GATE_KEYS_LIMIT", uint256(type(uint248).max));
-            primaryGate.params.avgPerfLeewayData.push([1, 500]); // TODO
+            primaryGate.params.keysLimit = vm.envOr(
+                "CURATED_GATE_KEYS_LIMIT",
+                uint256(type(uint248).max)
+            );
+            primaryGate.params.avgPerfLeewayData.push([1, 10000]); // TODO
             primaryGate.params.rewardShareData.push([1, 10000]); // TODO
             primaryGate.params.rewardShareData.push([17, 5834]); // TODO
             primaryGate.params.strikesLifetimeFrames = 6; // TODO

--- a/script/curated/DeployMainnet.s.sol
+++ b/script/curated/DeployMainnet.s.sol
@@ -55,7 +55,8 @@ contract DeployMainnet is DeployBase {
         config.chargePenaltyRecipient = 0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c; // locator.treasury()
 
         // Module
-        config.moduleType = "curated-onchain-v1"; // TODO reconsider
+        config.stakingModuleId = _nextStakingModuleId(config.lidoLocatorAddress);
+        config.moduleType = "curated-onchain-v2"; // TODO reconsider
         config.generalDelayedPenaltyReporter = 0xC52fC3081123073078698F1EAc2f1Dc7Bd71880f; // TODO reconsider once we have CMC address
 
         // ParametersRegistry TODO reconsider

--- a/script/curated/DeployMainnet.s.sol
+++ b/script/curated/DeployMainnet.s.sol
@@ -104,6 +104,7 @@ contract DeployMainnet is DeployBase {
             primaryGate.params.attestationsWeight = 54; // TODO
             primaryGate.params.blocksWeight = 4; // TODO
             primaryGate.params.syncWeight = 2; // TODO
+            primaryGate.params.metaRegistryBondCurveWeight = 1; // TODO reconsider
             primaryGate.params.allowedExitDelay = 5 days; // TODO
             primaryGate.params.exitDelayFee = 0.05 ether; // TODO
             primaryGate.params.maxElWithdrawalRequestFee = 0.1 ether; // TODO

--- a/script/curated/DeployMainnet.s.sol
+++ b/script/curated/DeployMainnet.s.sol
@@ -55,7 +55,6 @@ contract DeployMainnet is DeployBase {
         config.chargePenaltyRecipient = 0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c; // locator.treasury()
 
         // Module
-        config.stakingModuleId = _nextStakingModuleId(config.lidoLocatorAddress);
         config.moduleType = "curated-onchain-v2"; // TODO reconsider
         config.generalDelayedPenaltyReporter = 0xC52fC3081123073078698F1EAc2f1Dc7Bd71880f; // TODO reconsider once we have CMC address
 

--- a/script/fork-helpers/SimulateVote.s.sol
+++ b/script/fork-helpers/SimulateVote.s.sol
@@ -118,7 +118,7 @@ contract SimulateVote is Script, ForkHelpersCommon {
         vm.startBroadcast(agent);
 
         stakingRouter.addStakingModule({
-            _name: "curated-onchain-v1",
+            _name: "curated-onchain-v2",
             _stakingModuleAddress: address(curatedModule),
             _stakeShareLimit: 2000, // 20%
             _priorityExitShareThreshold: 2500, // 25%

--- a/src/interfaces/ILido.sol
+++ b/src/interfaces/ILido.sol
@@ -13,7 +13,7 @@ interface ILido is IStETH {
 
     function submit(address _referral) external payable returns (uint256);
 
-    function deposit(uint256 _maxDepositsCount, uint256 _stakingModuleId, bytes calldata _depositCalldata) external;
+    function getDepositableEther() external view returns (uint256);
 
     function removeStakingLimit() external;
 

--- a/src/interfaces/ILidoLocator.sol
+++ b/src/interfaces/ILidoLocator.sol
@@ -35,6 +35,8 @@ interface ILidoLocator {
 
     function treasury() external view returns (address);
 
+    function topUpGateway() external view returns (address);
+
     function validatorsExitBusOracle() external view returns (address);
 
     function withdrawalQueue() external view returns (address);

--- a/src/interfaces/IStakingRouter.sol
+++ b/src/interfaces/IStakingRouter.sol
@@ -4,6 +4,12 @@
 pragma solidity 0.8.33;
 
 interface IStakingRouter {
+    enum StakingModuleStatus {
+        Active,
+        DepositsPaused,
+        Stopped
+    }
+
     event ContractVersionSet(uint256 version);
     event ExitedAndStuckValidatorsCountsUpdateFailed(uint256 indexed stakingModuleId, bytes lowLevelRevertData);
     event RewardsMintedReportFailed(uint256 indexed stakingModuleId, bytes lowLevelRevertData);
@@ -170,7 +176,17 @@ interface IStakingRouter {
         bytes memory _vettedSigningKeysCounts
     ) external;
 
-    function deposit(uint256 _depositsCount, uint256 _stakingModuleId, bytes memory _depositCalldata) external payable;
+    function canDeposit(uint256 _stakingModuleId) external view returns (bool);
+
+    function deposit(uint256 _stakingModuleId, bytes memory _depositCalldata) external payable;
+
+    function topUp(
+        uint256 _stakingModuleId,
+        uint256[] memory _keyIndices,
+        uint256[] memory _operatorIds,
+        bytes[] memory _pubkeys,
+        uint256[] memory _topUpLimits
+    ) external;
 
     function finalizeUpgrade_v2(uint256[] memory _priorityExitShareThresholds) external;
 
@@ -182,6 +198,10 @@ interface IStakingRouter {
 
     function getDepositsAllocation(
         uint256 _depositsCount
+    ) external view returns (uint256 allocated, uint256[] memory allocations);
+
+    function getTopUpAllocation(
+        uint256 _depositAmount
     ) external view returns (uint256 allocated, uint256[] memory allocations);
 
     function getLido() external view returns (address);
@@ -300,6 +320,12 @@ interface IStakingRouter {
         uint256 _stakingModuleId,
         bytes memory _nodeOperatorIds,
         bytes memory _exitedValidatorsCounts
+    ) external;
+
+    function reportStakingModuleOperatorBalances(
+        uint256 _stakingModuleId,
+        bytes memory _nodeOperatorIds,
+        bytes memory _totalBalancesGwei
     ) external;
 
     function reportStakingModuleStuckValidatorsCountByNodeOperator(

--- a/test/fork/deployment/PostDeploymentCSM.t.sol
+++ b/test/fork/deployment/PostDeploymentCSM.t.sol
@@ -28,7 +28,7 @@ contract DeploymentBaseTest is Test, Utilities, DeploymentFixtures {
         Env memory env = envVars();
         vm.createSelectFork(env.RPC_URL);
         initializeFromDeployment();
-        if (moduleType != ModuleType.Community) vm.skip(true);
+        if (moduleType != ModuleType.Community) vm.skip(true, "Current deployment is not Community module type");
         deployParams = parseDeployParams(env.DEPLOY_CONFIG);
         adminsCount = block.chainid == 1 ? 1 : 2;
     }

--- a/test/fork/deployment/PostDeploymentCSM0x02.t.sol
+++ b/test/fork/deployment/PostDeploymentCSM0x02.t.sol
@@ -18,7 +18,8 @@ contract DeploymentBaseTest is Test, Utilities, DeploymentFixtures {
         Env memory env = envVars();
         vm.createSelectFork(env.RPC_URL);
         initializeFromDeployment();
-        if (moduleType != ModuleType.Community0x02) vm.skip(true);
+        if (moduleType != ModuleType.Community0x02)
+            vm.skip(true, "Current deployment is not Community0x02 module type");
         deployParams = parseDeployParams0x02(env.DEPLOY_CONFIG);
         adminsCount = block.chainid == 1 ? 1 : 2;
     }

--- a/test/fork/deployment/PostDeploymentCommon.t.sol
+++ b/test/fork/deployment/PostDeploymentCommon.t.sol
@@ -27,6 +27,7 @@ import { Versioned } from "../../../src/lib/utils/Versioned.sol";
 contract DeploymentBaseTest is Test, Utilities, DeploymentFixtures {
     CommonDeployParams internal deployParams;
     uint256 adminsCount;
+    uint256 expectedModuleScratchNonce;
 
     function setUp() public {
         Env memory env = envVars();
@@ -35,6 +36,12 @@ contract DeploymentBaseTest is Test, Utilities, DeploymentFixtures {
         string memory config = vm.readFile(env.DEPLOY_CONFIG);
         deployParams = parseCommonDeployParams(config);
         adminsCount = block.chainid == 1 ? 1 : 2;
+
+        if (moduleType == ModuleType.Curated) {
+            // Curated deployment sets bond-curve weights once per gate. Each set triggers
+            // requestFullDepositInfoUpdate(), which increments module nonce.
+            expectedModuleScratchNonce = vm.parseJsonAddressArray(config, ".CuratedGates").length;
+        }
     }
 }
 
@@ -42,7 +49,7 @@ contract ModuleDeploymentTest is DeploymentBaseTest {
     function test_state_scratch_onlyFull() public view {
         assertTrue(module.isPaused());
         assertEq(module.getNodeOperatorsCount(), 0);
-        assertEq(module.getNonce(), 0);
+        assertEq(module.getNonce(), expectedModuleScratchNonce);
     }
 
     function test_state_afterVote() public view {

--- a/test/fork/deployment/PostDeploymentCurated.t.sol
+++ b/test/fork/deployment/PostDeploymentCurated.t.sol
@@ -26,7 +26,7 @@ contract DeploymentBaseTest is Test, Utilities, DeploymentFixtures {
         Env memory env = envVars();
         vm.createSelectFork(env.RPC_URL);
         initializeFromDeployment();
-        if (moduleType != ModuleType.Curated) vm.skip(true);
+        if (moduleType != ModuleType.Curated) vm.skip(true, "Current deployment is not Curated module type");
         string memory config = vm.readFile(env.DEPLOY_CONFIG);
         // mutates storage variable
         updateCuratedDeployParams(deployParams, env.DEPLOY_CONFIG);

--- a/test/fork/deployment/PostDeploymentCurated.t.sol
+++ b/test/fork/deployment/PostDeploymentCurated.t.sol
@@ -222,8 +222,7 @@ contract CuratedGatesDeploymentTest is DeploymentBaseTest {
             assertEq(parametersRegistry.getExitDelayFee(curveId), params.exitDelayFee);
             assertEq(parametersRegistry.getMaxElWithdrawalRequestFee(curveId), params.maxElWithdrawalRequestFee);
 
-            // FIXME: add MetaRegistry-level assertions here to replace
-            // the removed deposit-allocation-weight checks.
+            assertEq(metaRegistry.getBondCurveWeight(curveId), params.metaRegistryBondCurveWeight);
         }
     }
 

--- a/test/fork/integration/common/AccountingExtras.t.sol
+++ b/test/fork/integration/common/AccountingExtras.t.sol
@@ -1,0 +1,196 @@
+// SPDX-FileCopyrightText: 2025 Lido <info@lido.fi>
+// SPDX-License-Identifier: GPL-3.0
+
+pragma solidity 0.8.33;
+
+import { IAccounting } from "src/interfaces/IAccounting.sol";
+import { IBondCore } from "src/interfaces/IBondCore.sol";
+
+import { MerkleTree } from "../../../helpers/MerkleTree.sol";
+import { PermitHelper } from "../../../helpers/Permit.sol";
+import { ModuleTypeBase, CSMIntegrationBase, CSM0x02IntegrationBase, CuratedIntegrationBase } from "./ModuleTypeBase.sol";
+
+abstract contract AccountingExtrasTestBase is ModuleTypeBase, PermitHelper {
+    address internal user;
+    address internal stranger;
+    address internal nodeOperator;
+    uint256 internal defaultNoId;
+    uint256 internal accountingSharesSurplus;
+
+    modifier assertInvariants() {
+        _;
+        vm.pauseGasMetering();
+        uint256 noCount = module.getNodeOperatorsCount();
+        assertModuleKeys(module);
+        _assertModuleEnqueuedCount();
+        assertModuleUnusedStorageSlots(module);
+        assertAccountingTotalBondShares(noCount, lido, accounting);
+        assertAccountingBurnerApproval(lido, address(accounting), locator.burner());
+        assertAccountingUnusedStorageSlots(accounting);
+        assertFeeDistributorClaimableShares(lido, feeDistributor);
+        assertFeeDistributorTree(feeDistributor);
+        assertFeeOracleUnusedStorageSlots(oracle);
+        vm.resumeGasMetering();
+    }
+
+    function setUp() public {
+        _setUpModule();
+        accountingSharesSurplus = lido.sharesOf(address(accounting)) - accounting.totalBondShares();
+
+        vm.startPrank(module.getRoleMember(module.DEFAULT_ADMIN_ROLE(), 0));
+        module.grantRole(module.DEFAULT_ADMIN_ROLE(), address(this));
+        module.grantRole(module.REPORT_GENERAL_DELAYED_PENALTY_ROLE(), address(this));
+        module.grantRole(module.SETTLE_GENERAL_DELAYED_PENALTY_ROLE(), address(this));
+        vm.stopPrank();
+
+        vm.startPrank(accounting.getRoleMember(accounting.DEFAULT_ADMIN_ROLE(), 0));
+        accounting.grantRole(accounting.DEFAULT_ADMIN_ROLE(), address(this));
+        vm.stopPrank();
+
+        handleStakingLimit();
+        handleBunkerMode();
+
+        user = nextAddress("User");
+        stranger = nextAddress("stranger");
+        nodeOperator = nextAddress("NodeOperator");
+
+        uint256 keysCount = 5;
+        defaultNoId = integrationHelpers.addNodeOperator(nodeOperator, keysCount);
+    }
+
+    function _simulateRewards(uint256 amount) internal returns (uint256 shares, bytes32[] memory proof) {
+        vm.startPrank(user);
+        vm.deal(user, amount);
+        shares = lido.submit{ value: amount }(address(0));
+        lido.transferShares(address(feeDistributor), shares);
+        vm.stopPrank();
+
+        MerkleTree tree = new MerkleTree();
+        tree.pushLeaf(abi.encode(defaultNoId, shares));
+        tree.pushLeaf(abi.encode(type(uint64).max, 0));
+        proof = tree.getProof(0);
+        bytes32 root = tree.root();
+        uint256 refSlot = 154;
+
+        vm.prank(feeDistributor.ORACLE());
+        feeDistributor.processOracleReport(root, someCIDv0(), someCIDv0(), shares, 0, refSlot);
+    }
+
+    function test_customClaimerCanClaimRewards() public assertInvariants {
+        address claimer = nextAddress("Claimer");
+
+        vm.prank(nodeOperator);
+        accounting.setCustomRewardsClaimer(defaultNoId, claimer);
+
+        // Deposit excess bond
+        uint256 amount = 1 ether;
+        vm.deal(user, amount);
+        vm.prank(user);
+        accounting.depositETH{ value: amount }(defaultNoId);
+
+        uint256 noSharesBefore = lido.sharesOf(nodeOperator);
+
+        // Claimer triggers claim; rewards go to NO reward address
+        vm.prank(claimer);
+        uint256 claimedShares = accounting.claimRewardsStETH(defaultNoId, type(uint256).max, 0, new bytes32[](0));
+
+        assertTrue(claimedShares > 0, "Should claim excess bond shares");
+        assertTrue(lido.sharesOf(nodeOperator) > noSharesBefore, "Rewards should go to NO reward address");
+    }
+
+    function test_bondDebt_createdOnUncompensatedPenalty() public assertInvariants {
+        (uint256 bondBefore, ) = accounting.getBondSummaryShares(defaultNoId);
+        uint256 bondEthBefore = accounting.getBond(defaultNoId);
+
+        // Penalty larger than current bond to create debt
+        uint256 penaltyAmount = bondEthBefore + 1 ether;
+        uint256 additionalFine = module.PARAMETERS_REGISTRY().getGeneralDelayedPenaltyAdditionalFine(
+            accounting.getBondCurveId(defaultNoId)
+        );
+
+        module.reportGeneralDelayedPenalty(
+            defaultNoId,
+            bytes32(abi.encode(1)),
+            penaltyAmount - additionalFine,
+            "Large penalty"
+        );
+
+        module.settleGeneralDelayedPenalty(UintArr(defaultNoId), UintArr(type(uint256).max));
+
+        uint256 debt = accounting.getBondDebt(defaultNoId);
+        assertTrue(debt > 0, "Bond debt should be created");
+
+        (uint256 bondAfter, ) = accounting.getBondSummaryShares(defaultNoId);
+        assertEq(bondAfter, 0, "Bond shares should be fully consumed");
+    }
+
+    function test_bondDebt_coveredByNewDeposit() public assertInvariants {
+        uint256 bondEthBefore = accounting.getBond(defaultNoId);
+
+        // Create debt via large penalty
+        uint256 penaltyAmount = bondEthBefore + 1 ether;
+        uint256 additionalFine = module.PARAMETERS_REGISTRY().getGeneralDelayedPenaltyAdditionalFine(
+            accounting.getBondCurveId(defaultNoId)
+        );
+
+        module.reportGeneralDelayedPenalty(
+            defaultNoId,
+            bytes32(abi.encode(1)),
+            penaltyAmount - additionalFine,
+            "Large penalty"
+        );
+
+        module.settleGeneralDelayedPenalty(UintArr(defaultNoId), UintArr(type(uint256).max));
+
+        uint256 debtBefore = accounting.getBondDebt(defaultNoId);
+        assertTrue(debtBefore > 0, "Debt should exist before deposit");
+
+        // New deposit should cover debt
+        uint256 depositAmount = debtBefore + 1 ether;
+        vm.deal(user, depositAmount);
+        vm.prank(user);
+        accounting.depositETH{ value: depositAmount }(defaultNoId);
+
+        uint256 debtAfter = accounting.getBondDebt(defaultNoId);
+        assertEq(debtAfter, 0, "Debt should be fully covered by deposit");
+    }
+
+    function test_bondDebt_coveredByRewardsDistribution() public assertInvariants {
+        uint256 bondEthBefore = accounting.getBond(defaultNoId);
+
+        // Create debt via large penalty
+        uint256 penaltyAmount = bondEthBefore + 0.5 ether;
+        uint256 additionalFine = module.PARAMETERS_REGISTRY().getGeneralDelayedPenaltyAdditionalFine(
+            accounting.getBondCurveId(defaultNoId)
+        );
+
+        module.reportGeneralDelayedPenalty(
+            defaultNoId,
+            bytes32(abi.encode(1)),
+            penaltyAmount - additionalFine,
+            "Large penalty"
+        );
+
+        module.settleGeneralDelayedPenalty(UintArr(defaultNoId), UintArr(type(uint256).max));
+
+        uint256 debtBefore = accounting.getBondDebt(defaultNoId);
+        assertTrue(debtBefore > 0, "Debt should exist before rewards");
+
+        // Simulate rewards larger than debt
+        uint256 rewardAmount = debtBefore + 1 ether;
+        (uint256 shares, bytes32[] memory proof) = _simulateRewards(rewardAmount);
+
+        // Claim triggers reward pull which credits bond shares, covering debt
+        vm.prank(nodeOperator);
+        accounting.claimRewardsStETH(defaultNoId, 0, shares, proof);
+
+        uint256 debtAfter = accounting.getBondDebt(defaultNoId);
+        assertEq(debtAfter, 0, "Debt should be covered by distributed rewards");
+    }
+}
+
+contract AccountingExtrasTestCSM is AccountingExtrasTestBase, CSMIntegrationBase {}
+
+contract AccountingExtrasTestCSM0x02 is AccountingExtrasTestBase, CSM0x02IntegrationBase {}
+
+contract AccountingExtrasTestCurated is AccountingExtrasTestBase, CuratedIntegrationBase {}

--- a/test/fork/integration/common/FeeDistributorExtras.t.sol
+++ b/test/fork/integration/common/FeeDistributorExtras.t.sol
@@ -1,0 +1,89 @@
+// SPDX-FileCopyrightText: 2025 Lido <info@lido.fi>
+// SPDX-License-Identifier: GPL-3.0
+
+pragma solidity 0.8.33;
+
+import { IFeeDistributor } from "src/interfaces/IFeeDistributor.sol";
+
+import { MerkleTree } from "../../../helpers/MerkleTree.sol";
+import { ModuleTypeBase, CSMIntegrationBase, CSM0x02IntegrationBase, CuratedIntegrationBase } from "./ModuleTypeBase.sol";
+
+abstract contract FeeDistributorExtrasTestBase is ModuleTypeBase {
+    address internal user;
+    address internal nodeOperator;
+    uint256 internal defaultNoId;
+
+    modifier assertInvariants() {
+        _;
+        vm.pauseGasMetering();
+        uint256 noCount = module.getNodeOperatorsCount();
+        assertModuleKeys(module);
+        _assertModuleEnqueuedCount();
+        assertModuleUnusedStorageSlots(module);
+        assertAccountingTotalBondShares(noCount, lido, accounting);
+        assertAccountingBurnerApproval(lido, address(accounting), locator.burner());
+        assertAccountingUnusedStorageSlots(accounting);
+        assertFeeDistributorClaimableShares(lido, feeDistributor);
+        assertFeeDistributorTree(feeDistributor);
+        assertFeeOracleUnusedStorageSlots(oracle);
+        vm.resumeGasMetering();
+    }
+
+    function setUp() public {
+        _setUpModule();
+
+        vm.startPrank(module.getRoleMember(module.DEFAULT_ADMIN_ROLE(), 0));
+        module.grantRole(module.DEFAULT_ADMIN_ROLE(), address(this));
+        vm.stopPrank();
+
+        handleStakingLimit();
+        handleBunkerMode();
+
+        user = nextAddress("User");
+        nodeOperator = nextAddress("NodeOperator");
+
+        uint256 keysCount = 5;
+        defaultNoId = integrationHelpers.addNodeOperator(nodeOperator, keysCount);
+    }
+
+    /// @dev Funds feeDistributor with stETH shares and returns the amount of shares deposited
+    function _fundFeeDistributor(uint256 ethAmount) internal returns (uint256 shares) {
+        vm.startPrank(user);
+        vm.deal(user, ethAmount);
+        shares = lido.submit{ value: ethAmount }(address(0));
+        lido.transferShares(address(feeDistributor), shares);
+        vm.stopPrank();
+    }
+
+    function test_rebateMechanism() public assertInvariants {
+        uint256 totalFunding = 2 ether;
+        uint256 shares = _fundFeeDistributor(totalFunding);
+
+        // Split shares between distributed and rebate
+        uint256 distributed = (shares * 80) / 100;
+        uint256 rebate = shares - distributed;
+
+        address rebateAddr = feeDistributor.rebateRecipient();
+        uint256 rebateSharesBefore = lido.sharesOf(rebateAddr);
+
+        MerkleTree tree = new MerkleTree();
+        tree.pushLeaf(abi.encode(defaultNoId, distributed));
+        tree.pushLeaf(abi.encode(type(uint64).max, 0));
+
+        vm.expectEmit(address(feeDistributor));
+        emit IFeeDistributor.RebateTransferred(rebate);
+
+        vm.startPrank(feeDistributor.ORACLE());
+        feeDistributor.processOracleReport(tree.root(), someCIDv0(), someCIDv0(), distributed, rebate, 154);
+        vm.stopPrank();
+
+        uint256 rebateSharesAfter = lido.sharesOf(rebateAddr);
+        assertEq(rebateSharesAfter - rebateSharesBefore, rebate, "Rebate recipient should receive rebate shares");
+    }
+}
+
+contract FeeDistributorExtrasTestCSM is FeeDistributorExtrasTestBase, CSMIntegrationBase {}
+
+contract FeeDistributorExtrasTestCSM0x02 is FeeDistributorExtrasTestBase, CSM0x02IntegrationBase {}
+
+contract FeeDistributorExtrasTestCurated is FeeDistributorExtrasTestBase, CuratedIntegrationBase {}

--- a/test/fork/integration/common/FeeSplits.t.sol
+++ b/test/fork/integration/common/FeeSplits.t.sol
@@ -1,0 +1,319 @@
+// SPDX-FileCopyrightText: 2025 Lido <info@lido.fi>
+// SPDX-License-Identifier: GPL-3.0
+
+pragma solidity 0.8.33;
+
+import { IFeeSplits } from "src/interfaces/IFeeSplits.sol";
+
+import { MerkleTree } from "../../../helpers/MerkleTree.sol";
+import { ModuleTypeBase, CSMIntegrationBase, CSM0x02IntegrationBase, CuratedIntegrationBase } from "./ModuleTypeBase.sol";
+
+abstract contract FeeSplitsTestBase is ModuleTypeBase {
+    address internal user;
+    address internal stranger;
+    address internal nodeOperator;
+    uint256 internal defaultNoId;
+    uint256 internal accountingSharesSurplus;
+
+    modifier assertInvariants() {
+        _;
+        vm.pauseGasMetering();
+        uint256 noCount = module.getNodeOperatorsCount();
+        assertModuleKeys(module);
+        _assertModuleEnqueuedCount();
+        assertModuleUnusedStorageSlots(module);
+        assertAccountingTotalBondShares(noCount, lido, accounting);
+        assertAccountingBurnerApproval(lido, address(accounting), locator.burner());
+        assertAccountingUnusedStorageSlots(accounting);
+        assertFeeDistributorClaimableShares(lido, feeDistributor);
+        assertFeeDistributorTree(feeDistributor);
+        assertFeeOracleUnusedStorageSlots(oracle);
+        vm.resumeGasMetering();
+    }
+
+    function setUp() public {
+        _setUpModule();
+        accountingSharesSurplus = lido.sharesOf(address(accounting)) - accounting.totalBondShares();
+
+        vm.startPrank(module.getRoleMember(module.DEFAULT_ADMIN_ROLE(), 0));
+        module.grantRole(module.DEFAULT_ADMIN_ROLE(), address(this));
+        vm.stopPrank();
+
+        handleStakingLimit();
+        handleBunkerMode();
+
+        user = nextAddress("User");
+        stranger = nextAddress("stranger");
+        nodeOperator = nextAddress("NodeOperator");
+
+        uint256 keysCount = 5;
+        defaultNoId = integrationHelpers.addNodeOperator(nodeOperator, keysCount);
+    }
+
+    function _simulateRewards(uint256 amount) internal returns (uint256 shares, bytes32[] memory proof) {
+        vm.startPrank(user);
+        vm.deal(user, amount);
+        shares = lido.submit{ value: amount }(address(0));
+        lido.transferShares(address(feeDistributor), shares);
+        vm.stopPrank();
+
+        uint256 previousDistributedShares = feeDistributor.distributedShares(defaultNoId);
+        uint256 distributedInReport = shares;
+        uint256 cumulativeFeeShares = previousDistributedShares + distributedInReport;
+        MerkleTree tree = new MerkleTree();
+        tree.pushLeaf(abi.encode(defaultNoId, cumulativeFeeShares));
+        tree.pushLeaf(abi.encode(type(uint64).max, 0));
+        bytes32 root = tree.root();
+        if (root == feeDistributor.treeRoot()) {
+            if (cumulativeFeeShares == previousDistributedShares) {
+                revert("Zero report shares");
+            }
+            unchecked {
+                --cumulativeFeeShares;
+                --distributedInReport;
+            }
+            tree = new MerkleTree();
+            tree.pushLeaf(abi.encode(defaultNoId, cumulativeFeeShares));
+            tree.pushLeaf(abi.encode(type(uint64).max, 0));
+            root = tree.root();
+        }
+        proof = tree.getProof(0);
+        shares = cumulativeFeeShares;
+        uint256 refSlot = 154;
+
+        vm.prank(feeDistributor.ORACLE());
+        feeDistributor.processOracleReport(root, someCIDv0(), someCIDv0(), distributedInReport, 0, refSlot);
+    }
+
+    function _setFeeSplits(IFeeSplits.FeeSplit[] memory splits) internal {
+        IFeeSplits.FeeSplit[] memory callSplits = splits;
+        vm.prank(nodeOperator);
+        accounting.updateFeeSplits(defaultNoId, callSplits, 0, new bytes32[](0));
+    }
+
+    function test_pullAndSplitFeeRewards() public assertInvariants {
+        address recipient = nextAddress("SplitRecipient");
+        uint256 splitShare = 5000; // 50%
+
+        IFeeSplits.FeeSplit[] memory splits = new IFeeSplits.FeeSplit[](1);
+        splits[0] = IFeeSplits.FeeSplit({ recipient: recipient, share: splitShare });
+        _setFeeSplits(splits);
+
+        uint256 amount = 1 ether;
+        (uint256 shares, bytes32[] memory proof) = _simulateRewards(amount);
+
+        uint256 recipientSharesBefore = lido.sharesOf(recipient);
+        uint256 accountingBondBefore = accounting.getBondShares(defaultNoId);
+
+        accounting.pullAndSplitFeeRewards(defaultNoId, shares, proof);
+
+        uint256 recipientSharesAfter = lido.sharesOf(recipient);
+        uint256 pendingAfter = accounting.getPendingSharesToSplit(defaultNoId);
+
+        uint256 expectedRecipientShares = (shares * splitShare) / 10_000;
+        assertEq(
+            recipientSharesAfter - recipientSharesBefore,
+            expectedRecipientShares,
+            "Recipient should receive correct share"
+        );
+        assertEq(pendingAfter, 0, "Pending shares should be 0 after distribution");
+
+        uint256 accountingBondAfter = accounting.getBondShares(defaultNoId);
+        // Bond increased by distributed shares minus the transferred split shares
+        uint256 transferredShares = recipientSharesAfter - recipientSharesBefore;
+        assertEq(
+            accountingBondAfter,
+            accountingBondBefore + shares - transferredShares,
+            "Bond should increase by rewards minus split transfers"
+        );
+    }
+
+    function test_claimRewardsStETH_withSplits() public assertInvariants {
+        address recipient = nextAddress("SplitRecipient");
+        uint256 splitShare = 5000; // 50%
+
+        IFeeSplits.FeeSplit[] memory splits = new IFeeSplits.FeeSplit[](1);
+        splits[0] = IFeeSplits.FeeSplit({ recipient: recipient, share: splitShare });
+        _setFeeSplits(splits);
+
+        uint256 amount = 1 ether;
+        (uint256 shares, bytes32[] memory proof) = _simulateRewards(amount);
+
+        uint256 recipientSharesBefore = lido.sharesOf(recipient);
+        uint256 noSharesBefore = lido.sharesOf(nodeOperator);
+
+        vm.prank(nodeOperator);
+        accounting.claimRewardsStETH(defaultNoId, type(uint256).max, shares, proof);
+
+        uint256 recipientSharesAfter = lido.sharesOf(recipient);
+        uint256 noSharesAfter = lido.sharesOf(nodeOperator);
+
+        uint256 expectedRecipientShares = (shares * splitShare) / 10_000;
+        assertEq(
+            recipientSharesAfter - recipientSharesBefore,
+            expectedRecipientShares,
+            "Recipient should receive correct split via claim path"
+        );
+        assertTrue(noSharesAfter > noSharesBefore, "NO should receive remaining excess via claim");
+        assertEq(accounting.getPendingSharesToSplit(defaultNoId), 0, "Pending shares should be 0 after claim");
+    }
+
+    function test_updateFeeSplits_blockedWhilePending_unblockAndUpdate() public assertInvariants {
+        address recipient = nextAddress("SplitRecipient");
+        uint256 splitShare = 5000;
+
+        IFeeSplits.FeeSplit[] memory splits = new IFeeSplits.FeeSplit[](1);
+        splits[0] = IFeeSplits.FeeSplit({ recipient: recipient, share: splitShare });
+        _setFeeSplits(splits);
+
+        uint256 amount = 1 ether;
+        (uint256 shares, bytes32[] memory proof) = _simulateRewards(amount);
+
+        // Pause accounting so pullAndSplitFeeRewards pulls rewards to bond
+        // but skips split transfers, leaving pendingSharesToSplit > 0.
+        vm.startPrank(accounting.getRoleMember(accounting.DEFAULT_ADMIN_ROLE(), 0));
+        accounting.grantRole(accounting.PAUSE_ROLE(), address(this));
+        accounting.grantRole(accounting.RESUME_ROLE(), address(this));
+        vm.stopPrank();
+        accounting.pauseFor(1 days);
+        assertTrue(accounting.isPaused(), "Accounting should be paused");
+        accounting.pullAndSplitFeeRewards(defaultNoId, shares, proof);
+        uint256 pending = accounting.getPendingSharesToSplit(defaultNoId);
+        assertTrue(pending > 0, "Pending shares should exist");
+
+        // Undistributed rewards are already pulled, so update must be blocked by pending shares.
+        address newRecipient = nextAddress("NewRecipient");
+        IFeeSplits.FeeSplit[] memory newSplits = new IFeeSplits.FeeSplit[](1);
+        newSplits[0] = IFeeSplits.FeeSplit({ recipient: newRecipient, share: 3000 });
+
+        vm.prank(nodeOperator);
+        vm.expectRevert(IFeeSplits.PendingSharesExist.selector);
+        accounting.updateFeeSplits(defaultNoId, newSplits, shares, proof);
+
+        // Resume and split pending rewards.
+        accounting.resume();
+        assertFalse(accounting.isPaused(), "Accounting should be resumed");
+        accounting.pullAndSplitFeeRewards(defaultNoId, shares, proof);
+        assertEq(accounting.getPendingSharesToSplit(defaultNoId), 0, "Pending shares should be zero after split");
+
+        // Now update should succeed
+        vm.prank(nodeOperator);
+        accounting.updateFeeSplits(defaultNoId, newSplits, shares, proof);
+
+        IFeeSplits.FeeSplit[] memory stored = accounting.getFeeSplits(defaultNoId);
+        assertEq(stored.length, 1, "Should have 1 split");
+        assertEq(stored[0].recipient, newRecipient, "Recipient should be updated");
+        assertEq(stored[0].share, 3000, "Share should be updated");
+    }
+
+    function test_splitUsesAllocationDate_andSurvivesPenaltyUntilLaterClaim() public assertInvariants {
+        address recipient = nextAddress("SplitRecipient");
+        IFeeSplits.FeeSplit[] memory splits = new IFeeSplits.FeeSplit[](1);
+        splits[0] = IFeeSplits.FeeSplit({ recipient: recipient, share: 5000 });
+        _setFeeSplits(splits);
+
+        vm.startPrank(accounting.getRoleMember(accounting.DEFAULT_ADMIN_ROLE(), 0));
+        accounting.grantRole(accounting.PAUSE_ROLE(), address(this));
+        accounting.grantRole(accounting.RESUME_ROLE(), address(this));
+        vm.stopPrank();
+        module.grantRole(module.REPORT_GENERAL_DELAYED_PENALTY_ROLE(), address(this));
+
+        accounting.pauseFor(1 days);
+
+        (uint256 shares1, bytes32[] memory proof1) = _simulateRewards(5 ether);
+
+        uint256 recipientBefore = lido.sharesOf(recipient);
+        accounting.pullAndSplitFeeRewards(defaultNoId, shares1, proof1);
+        uint256 pending1 = accounting.getPendingSharesToSplit(defaultNoId);
+        assertTrue(pending1 > 0, "Pending shares should be created at allocation");
+        assertEq(lido.sharesOf(recipient), recipientBefore, "No split transfers while accounting is paused");
+
+        uint256 claimableBeforePenalty = accounting.getClaimableBondShares(defaultNoId);
+        uint256 penaltyAmount = lido.getPooledEthByShares(claimableBeforePenalty) + 1 ether;
+        module.reportGeneralDelayedPenalty(defaultNoId, bytes32(abi.encode(1)), penaltyAmount, "test penalty");
+        assertEq(accounting.getClaimableBondShares(defaultNoId), 0, "Penalty should consume current claimable shares");
+        assertEq(
+            accounting.getPendingSharesToSplit(defaultNoId),
+            pending1,
+            "Penalty must not reduce pending split amount"
+        );
+
+        accounting.resume();
+        accounting.pullAndSplitFeeRewards(defaultNoId, shares1, proof1);
+        assertEq(
+            accounting.getPendingSharesToSplit(defaultNoId),
+            pending1,
+            "Pending should stay unchanged when no claimable shares exist"
+        );
+        assertEq(
+            lido.sharesOf(recipient),
+            recipientBefore,
+            "Recipient should not receive shares while claimable is zero"
+        );
+
+        uint256 topUp = penaltyAmount + lido.getPooledEthByShares(pending1) + 2 ether;
+        vm.deal(nodeOperator, topUp);
+        vm.prank(nodeOperator);
+        accounting.depositETH{ value: topUp }(defaultNoId);
+
+        uint256 pendingBeforeClaim = accounting.getPendingSharesToSplit(defaultNoId);
+        vm.prank(nodeOperator);
+        accounting.claimRewardsStETH(defaultNoId, type(uint256).max, shares1, proof1);
+
+        assertTrue(
+            lido.sharesOf(recipient) > recipientBefore,
+            "Pending rewards should be split later during claim operations"
+        );
+        assertLt(
+            accounting.getPendingSharesToSplit(defaultNoId),
+            pendingBeforeClaim,
+            "Pending shares should decrease after later split"
+        );
+    }
+
+    function test_removeFeeSplits() public assertInvariants {
+        address recipient = nextAddress("SplitRecipient");
+        IFeeSplits.FeeSplit[] memory splits = new IFeeSplits.FeeSplit[](1);
+        splits[0] = IFeeSplits.FeeSplit({ recipient: recipient, share: 5000 });
+        _setFeeSplits(splits);
+
+        assertTrue(accounting.hasSplits(defaultNoId), "Should have splits");
+
+        // With active splits, updateFeeSplits requires a valid proof path.
+        // Pull rewards first so cumulative shares can be reused to prove zero undistributed delta.
+        (uint256 initialShares, bytes32[] memory initialProof) = _simulateRewards(1 ether);
+        accounting.pullAndSplitFeeRewards(defaultNoId, initialShares, initialProof);
+
+        // Remove splits by setting empty array
+        IFeeSplits.FeeSplit[] memory emptySplits = new IFeeSplits.FeeSplit[](0);
+        vm.prank(nodeOperator);
+        accounting.updateFeeSplits(defaultNoId, emptySplits, initialShares, initialProof);
+
+        IFeeSplits.FeeSplit[] memory stored = accounting.getFeeSplits(defaultNoId);
+        assertEq(stored.length, 0, "Splits should be removed");
+        assertFalse(accounting.hasSplits(defaultNoId), "hasSplits should be false");
+
+        // Simulate new rewards and claim — all goes to NO
+        uint256 amount = 1 ether;
+        (uint256 shares, bytes32[] memory proof) = _simulateRewards(amount);
+
+        uint256 recipientSharesBefore = lido.sharesOf(recipient);
+        uint256 noSharesBefore = lido.sharesOf(nodeOperator);
+
+        vm.prank(nodeOperator);
+        accounting.claimRewardsStETH(defaultNoId, type(uint256).max, shares, proof);
+
+        assertEq(
+            lido.sharesOf(recipient),
+            recipientSharesBefore,
+            "Recipient should not receive any shares after splits removed"
+        );
+        assertTrue(lido.sharesOf(nodeOperator) > noSharesBefore, "NO should receive all rewards");
+    }
+}
+
+contract FeeSplitsTestCSM is FeeSplitsTestBase, CSMIntegrationBase {}
+
+contract FeeSplitsTestCSM0x02 is FeeSplitsTestBase, CSM0x02IntegrationBase {}
+
+contract FeeSplitsTestCurated is FeeSplitsTestBase, CuratedIntegrationBase {}

--- a/test/fork/integration/common/ModuleTypeBase.sol
+++ b/test/fork/integration/common/ModuleTypeBase.sol
@@ -24,7 +24,7 @@ abstract contract ModuleTypeBase is DeploymentFixtures, Utilities, InvariantAsse
 abstract contract CSMIntegrationBase is ModuleTypeBase {
     function _setUpModule() internal override {
         _forkAndInitialize();
-        if (moduleType != ModuleType.Community) vm.skip(true);
+        if (moduleType != ModuleType.Community) vm.skip(true, "Integration suite requires Community module type");
         integrationHelpers = new CSMIntegrationHelpers(module, accounting, stakingRouter, permissionlessGate);
     }
 
@@ -37,7 +37,7 @@ abstract contract CSM0x02IntegrationBase is ModuleTypeBase {
     function _setUpModule() internal override {
         _forkAndInitialize();
         if (moduleType != ModuleType.Community0x02) {
-            vm.skip(true);
+            vm.skip(true, "Integration suite requires Community0x02 module type");
         }
         integrationHelpers = new CSMIntegrationHelpers(module, accounting, stakingRouter, permissionlessGate);
     }
@@ -50,7 +50,7 @@ abstract contract CSM0x02IntegrationBase is ModuleTypeBase {
 abstract contract CuratedIntegrationBase is ModuleTypeBase {
     function _setUpModule() internal override {
         _forkAndInitialize();
-        if (moduleType != ModuleType.Curated) vm.skip(true);
+        if (moduleType != ModuleType.Curated) vm.skip(true, "Integration suite requires Curated module type");
         integrationHelpers = new CuratedIntegrationHelpers(module, accounting, stakingRouter, curatedGates);
     }
 

--- a/test/fork/integration/common/Oracle.t.sol
+++ b/test/fork/integration/common/Oracle.t.sol
@@ -49,11 +49,11 @@ abstract contract OracleTestBase is ModuleTypeBase {
         hugeDeposit();
 
         refundRecipient = nextAddress("refundRecipient");
-        uint256 keysCount;
         uint256 moduleId = findModule();
-        (nodeOperatorId, keysCount) = integrationHelpers.getDepositableNodeOperator(nextAddress());
+        (nodeOperatorId, ) = integrationHelpers.getDepositableNodeOperator(nextAddress());
+        _ensureStakingRouterCanDeposit(moduleId);
         vm.prank(locator.depositSecurityModule());
-        lido.deposit(keysCount, moduleId, "");
+        stakingRouter.deposit(moduleId, "");
     }
 
     function reachConsensus(uint256 refSlot, bytes32 hash) public {
@@ -167,7 +167,6 @@ abstract contract OracleTestBase is ModuleTypeBase {
 
         uint256 initialBalance = 1 ether;
         vm.deal(refundRecipient, initialBalance);
-        vm.prank(refundRecipient);
         uint256 expectedWithdrawalFee = IWithdrawalVault(locator.withdrawalVault()).getWithdrawalRequestFee();
 
         IValidatorStrikes.KeyStrikes[] memory keyStrikesList = new IValidatorStrikes.KeyStrikes[](1);

--- a/test/fork/integration/common/Oracle.t.sol
+++ b/test/fork/integration/common/Oracle.t.sol
@@ -49,11 +49,24 @@ abstract contract OracleTestBase is ModuleTypeBase {
         hugeDeposit();
 
         refundRecipient = nextAddress("refundRecipient");
+        uint256 keysCount;
         uint256 moduleId = findModule();
-        (nodeOperatorId, ) = integrationHelpers.getDepositableNodeOperator(nextAddress());
-        _ensureStakingRouterCanDeposit(moduleId);
-        vm.prank(locator.depositSecurityModule());
-        stakingRouter.deposit(moduleId, "");
+        (nodeOperatorId, keysCount) = integrationHelpers.getDepositableNodeOperator(nextAddress());
+
+        bool isStakingRouterUpgraded = _isStakingRouterUpgraded();
+        if (isStakingRouterUpgraded) {
+            _ensureStakingRouterCanDeposit(moduleId);
+            vm.prank(locator.depositSecurityModule());
+            stakingRouter.deposit(moduleId, "");
+        } else {
+            vm.prank(locator.depositSecurityModule());
+            _legacyLidoDeposit(keysCount, moduleId, "");
+        }
+
+        if (module.getNodeOperator(nodeOperatorId).totalDepositedKeys == 0) {
+            // Skip: this scenario requires at least one deposited key for the selected node operator.
+            vm.skip(true, "Scenario requires at least one deposited key for selected node operator");
+        }
     }
 
     function reachConsensus(uint256 refSlot, bytes32 hash) public {

--- a/test/fork/integration/common/ParametersRegistry.t.sol
+++ b/test/fork/integration/common/ParametersRegistry.t.sol
@@ -1,0 +1,300 @@
+// SPDX-FileCopyrightText: 2025 Lido <info@lido.fi>
+// SPDX-License-Identifier: GPL-3.0
+
+pragma solidity 0.8.33;
+
+import { IBaseModule } from "src/interfaces/IBaseModule.sol";
+import { IExitPenalties, ExitPenaltyInfo } from "src/interfaces/IExitPenalties.sol";
+import { IParametersRegistry } from "src/interfaces/IParametersRegistry.sol";
+import { IValidatorStrikes } from "src/interfaces/IValidatorStrikes.sol";
+
+import { ModuleTypeBase, CuratedIntegrationBase } from "./ModuleTypeBase.sol";
+
+abstract contract ParametersRegistryTestBase is ModuleTypeBase {
+    address internal nodeOperator;
+    uint256 internal defaultNoId;
+    uint256 internal bondCurveId;
+    uint256 internal initialKeysCount = 3;
+
+    modifier assertInvariants() {
+        _;
+        vm.pauseGasMetering();
+        uint256 noCount = module.getNodeOperatorsCount();
+        assertModuleKeys(module);
+        _assertModuleEnqueuedCount();
+        assertModuleUnusedStorageSlots(module);
+        assertAccountingTotalBondShares(noCount, lido, accounting);
+        assertAccountingBurnerApproval(lido, address(accounting), locator.burner());
+        assertAccountingUnusedStorageSlots(accounting);
+        assertFeeDistributorClaimableShares(lido, feeDistributor);
+        assertFeeDistributorTree(feeDistributor);
+        assertFeeOracleUnusedStorageSlots(oracle);
+        vm.resumeGasMetering();
+    }
+
+    function setUp() public {
+        _setUpModule();
+
+        vm.startPrank(module.getRoleMember(module.DEFAULT_ADMIN_ROLE(), 0));
+        module.grantRole(module.DEFAULT_ADMIN_ROLE(), address(this));
+        vm.stopPrank();
+
+        vm.startPrank(parametersRegistry.getRoleMember(parametersRegistry.DEFAULT_ADMIN_ROLE(), 0));
+        parametersRegistry.grantRole(parametersRegistry.DEFAULT_ADMIN_ROLE(), address(this));
+        vm.stopPrank();
+
+        handleStakingLimit();
+        handleBunkerMode();
+
+        nodeOperator = nextAddress("NodeOperator");
+        defaultNoId = integrationHelpers.addNodeOperator(nodeOperator, initialKeysCount);
+        bondCurveId = accounting.getBondCurveId(defaultNoId);
+    }
+
+    function _assertChangeKeyRemovalCharge() internal {
+        uint256 newCharge = 0.05 ether;
+        parametersRegistry.setKeyRemovalCharge(bondCurveId, newCharge);
+
+        assertEq(
+            parametersRegistry.getKeyRemovalCharge(bondCurveId),
+            newCharge,
+            "Key removal charge should be updated"
+        );
+
+        address chargeRecipient = accounting.chargePenaltyRecipient();
+        uint256 recipientSharesBefore = lido.sharesOf(chargeRecipient);
+
+        vm.prank(nodeOperator);
+        module.removeKeys(defaultNoId, initialKeysCount - 1, 1);
+
+        uint256 recipientSharesAfter = lido.sharesOf(chargeRecipient);
+        uint256 chargedShares = recipientSharesAfter - recipientSharesBefore;
+        uint256 chargedAmount = lido.getPooledEthByShares(chargedShares);
+
+        assertApproxEqAbs(chargedAmount, newCharge, 2 wei, "Charge recipient should receive key removal charge");
+    }
+
+    function _grantStakingRouterRole() internal {
+        module.grantRole(module.STAKING_ROUTER_ROLE(), address(this));
+    }
+
+    function _getExitPenaltyInfo(bytes memory pubkey) internal view returns (ExitPenaltyInfo memory) {
+        return exitPenalties.getExitPenaltyInfo(defaultNoId, pubkey);
+    }
+
+    function test_changeGeneralDelayedPenaltyAdditionalFine() public assertInvariants {
+        uint256 newFine = 0.1 ether;
+        parametersRegistry.setGeneralDelayedPenaltyAdditionalFine(bondCurveId, newFine);
+
+        assertEq(
+            parametersRegistry.getGeneralDelayedPenaltyAdditionalFine(bondCurveId),
+            newFine,
+            "Additional fine should be updated"
+        );
+
+        // Verify fine is applied on penalty report
+        module.grantRole(module.REPORT_GENERAL_DELAYED_PENALTY_ROLE(), address(this));
+
+        uint256 lockedBefore = accounting.getLockedBond(defaultNoId);
+        uint256 penaltyAmount = 0.5 ether;
+
+        module.reportGeneralDelayedPenalty(defaultNoId, bytes32(abi.encode(1)), penaltyAmount, "Test penalty");
+
+        uint256 lockedAfter = accounting.getLockedBond(defaultNoId);
+
+        assertEq(
+            lockedAfter - lockedBefore,
+            penaltyAmount + newFine,
+            "Locked bond should increase by penalty + additional fine"
+        );
+    }
+
+    function test_setKeysLimit() public assertInvariants {
+        uint256 limit = initialKeysCount;
+        parametersRegistry.setKeysLimit(bondCurveId, limit);
+
+        assertEq(parametersRegistry.getKeysLimit(bondCurveId), limit, "Keys limit should be updated");
+
+        // NO already has initialKeysCount keys — attempt to add more should revert
+        (bytes memory keys, bytes memory signatures) = keysSignatures(1);
+        uint256 amount = accounting.getRequiredBondForNextKeys(defaultNoId, 1);
+        vm.deal(nodeOperator, amount);
+
+        vm.prank(nodeOperator);
+        vm.expectRevert(IBaseModule.KeysLimitExceeded.selector);
+        module.addValidatorKeysETH{ value: amount }(nodeOperator, defaultNoId, 1, keys, signatures);
+    }
+
+    function test_setMaxElWithdrawalRequestFee() public assertInvariants {
+        uint256 newFee = 0.01 ether;
+        parametersRegistry.setMaxElWithdrawalRequestFee(bondCurveId, newFee);
+
+        assertEq(
+            parametersRegistry.getMaxElWithdrawalRequestFee(bondCurveId),
+            newFee,
+            "Max EL withdrawal request fee should be updated"
+        );
+
+        _grantStakingRouterRole();
+        bytes memory pubkey = module.getSigningKeys(defaultNoId, 0, 1);
+        module.onValidatorExitTriggered(defaultNoId, pubkey, newFee + 0.01 ether, exitPenalties.STRIKES_EXIT_TYPE_ID());
+
+        ExitPenaltyInfo memory penaltyInfo = _getExitPenaltyInfo(pubkey);
+        assertTrue(penaltyInfo.elWithdrawalRequestFee.isValue, "EL withdrawal fee should be recorded");
+        assertEq(penaltyInfo.elWithdrawalRequestFee.value, newFee, "EL withdrawal fee should be capped by max value");
+    }
+
+    function _assertSetQueueConfig() internal {
+        uint256 queueLowestPriority = parametersRegistry.QUEUE_LOWEST_PRIORITY();
+        if (queueLowestPriority == 0) {
+            vm.skip(true, "No dedicated priority queue on this deployment");
+        }
+
+        uint256 priority = queueLowestPriority - 1;
+        uint256 maxDeposits = 1;
+        parametersRegistry.setQueueConfig(bondCurveId, priority, maxDeposits);
+
+        (uint32 p, uint32 md) = parametersRegistry.getQueueConfig(bondCurveId);
+        assertEq(p, priority, "Queue priority should be updated");
+        assertEq(md, maxDeposits, "Max deposits should be updated");
+
+        (, uint128 tailPriorityBefore) = module.depositQueuePointers(priority);
+        (, uint128 tailLowestBefore) = module.depositQueuePointers(queueLowestPriority);
+        integrationHelpers.addNodeOperator(nextAddress("PriorityQueueNO"), 1);
+        (, uint128 tailPriorityAfter) = module.depositQueuePointers(priority);
+        (, uint128 tailLowestAfter) = module.depositQueuePointers(queueLowestPriority);
+
+        assertGt(tailPriorityAfter, tailPriorityBefore, "Batch should be enqueued to the configured priority queue");
+        assertEq(tailLowestAfter, tailLowestBefore, "Batch should not be enqueued to the lowest-priority queue");
+    }
+
+    function test_setRewardShareData() public assertInvariants {
+        IParametersRegistry.KeyNumberValueInterval[] memory data = new IParametersRegistry.KeyNumberValueInterval[](2);
+        data[0] = IParametersRegistry.KeyNumberValueInterval({ minKeyNumber: 1, value: 8000 });
+        data[1] = IParametersRegistry.KeyNumberValueInterval({ minKeyNumber: 10, value: 9000 });
+
+        parametersRegistry.setRewardShareData(bondCurveId, data);
+
+        IParametersRegistry.KeyNumberValueInterval[] memory stored = parametersRegistry.getRewardShareData(bondCurveId);
+        assertEq(stored.length, 2, "Should have 2 intervals");
+        assertEq(stored[0].minKeyNumber, 1, "First minKeyNumber");
+        assertEq(stored[0].value, 8000, "First value");
+        assertEq(stored[1].minKeyNumber, 10, "Second minKeyNumber");
+        assertEq(stored[1].value, 9000, "Second value");
+    }
+
+    function test_setPerformanceLeewayData() public assertInvariants {
+        IParametersRegistry.KeyNumberValueInterval[] memory data = new IParametersRegistry.KeyNumberValueInterval[](1);
+        data[0] = IParametersRegistry.KeyNumberValueInterval({ minKeyNumber: 1, value: 500 });
+
+        parametersRegistry.setPerformanceLeewayData(bondCurveId, data);
+
+        IParametersRegistry.KeyNumberValueInterval[] memory stored = parametersRegistry.getPerformanceLeewayData(
+            bondCurveId
+        );
+        assertEq(stored.length, 1, "Should have 1 interval");
+        assertEq(stored[0].value, 500, "Leeway value mismatch");
+    }
+
+    function test_setPerformanceCoefficients() public assertInvariants {
+        uint256 attW = 7000;
+        uint256 blkW = 2000;
+        uint256 syncW = 1000;
+        parametersRegistry.setPerformanceCoefficients(bondCurveId, attW, blkW, syncW);
+
+        (uint256 a, uint256 b, uint256 s) = parametersRegistry.getPerformanceCoefficients(bondCurveId);
+        assertEq(a, attW, "Attestations weight mismatch");
+        assertEq(b, blkW, "Blocks weight mismatch");
+        assertEq(s, syncW, "Sync weight mismatch");
+    }
+
+    function test_setStrikesParams() public assertInvariants {
+        uint256 lifetime = 10;
+        uint256 threshold = 3;
+        parametersRegistry.setStrikesParams(bondCurveId, lifetime, threshold);
+
+        (uint256 lt, uint256 th) = parametersRegistry.getStrikesParams(bondCurveId);
+        assertEq(lt, lifetime, "Strikes lifetime mismatch");
+        assertEq(th, threshold, "Strikes threshold mismatch");
+
+        uint256[] memory strikesData = new uint256[](1);
+        strikesData[0] = threshold - 1;
+        bytes memory pubkey = module.getSigningKeys(defaultNoId, 0, 1);
+        IValidatorStrikes.KeyStrikes[] memory keyStrikesList = new IValidatorStrikes.KeyStrikes[](1);
+        keyStrikesList[0] = IValidatorStrikes.KeyStrikes({
+            nodeOperatorId: defaultNoId,
+            keyIndex: 0,
+            data: strikesData
+        });
+
+        bytes32 treeRoot = strikes.hashLeaf(keyStrikesList[0], pubkey);
+        vm.prank(address(oracle));
+        strikes.processOracleReport(treeRoot, someCIDv0());
+
+        bytes32[] memory proof = new bytes32[](0);
+        bool[] memory proofFlags = new bool[](0);
+        vm.expectRevert(IValidatorStrikes.NotEnoughStrikesToEject.selector);
+        strikes.processBadPerformanceProof{ value: 1 wei }(keyStrikesList, proof, proofFlags, address(this));
+    }
+
+    function test_setAllowedExitDelay() public assertInvariants {
+        uint256 delay = 7200;
+        parametersRegistry.setAllowedExitDelay(bondCurveId, delay);
+
+        assertEq(parametersRegistry.getAllowedExitDelay(bondCurveId), delay, "Allowed exit delay should be updated");
+
+        _grantStakingRouterRole();
+        bytes memory pubkey = module.getSigningKeys(defaultNoId, 0, 1);
+
+        vm.expectRevert(IExitPenalties.ValidatorExitDelayNotApplicable.selector);
+        module.reportValidatorExitDelay(defaultNoId, 12345, pubkey, delay);
+
+        module.reportValidatorExitDelay(defaultNoId, 12345, pubkey, delay + 1);
+
+        ExitPenaltyInfo memory penaltyInfo = _getExitPenaltyInfo(pubkey);
+        assertTrue(penaltyInfo.delayFee.isValue, "Delay fee should be recorded");
+        assertEq(
+            penaltyInfo.delayFee.value,
+            parametersRegistry.getExitDelayFee(bondCurveId),
+            "Delay fee should match current curve setting"
+        );
+    }
+
+    function test_setExitDelayFee() public assertInvariants {
+        uint256 fee = 0.02 ether;
+        parametersRegistry.setExitDelayFee(bondCurveId, fee);
+
+        assertEq(parametersRegistry.getExitDelayFee(bondCurveId), fee, "Exit delay fee should be updated");
+
+        parametersRegistry.setAllowedExitDelay(bondCurveId, 1);
+        _grantStakingRouterRole();
+        bytes memory pubkey = module.getSigningKeys(defaultNoId, 0, 1);
+
+        module.reportValidatorExitDelay(defaultNoId, 12345, pubkey, 2);
+
+        ExitPenaltyInfo memory penaltyInfo = _getExitPenaltyInfo(pubkey);
+        assertTrue(penaltyInfo.delayFee.isValue, "Delay fee should be recorded");
+        assertEq(penaltyInfo.delayFee.value, fee, "Delay fee should match updated value");
+    }
+
+    function test_setBadPerformancePenalty() public assertInvariants {
+        uint256 penalty = 0.05 ether;
+        parametersRegistry.setBadPerformancePenalty(bondCurveId, penalty);
+
+        assertEq(
+            parametersRegistry.getBadPerformancePenalty(bondCurveId),
+            penalty,
+            "Bad performance penalty should be updated"
+        );
+
+        bytes memory pubkey = module.getSigningKeys(defaultNoId, 0, 1);
+        vm.prank(address(strikes));
+        exitPenalties.processStrikesReport(defaultNoId, pubkey);
+
+        ExitPenaltyInfo memory penaltyInfo = _getExitPenaltyInfo(pubkey);
+        assertTrue(penaltyInfo.strikesPenalty.isValue, "Strikes penalty should be recorded");
+        assertEq(penaltyInfo.strikesPenalty.value, penalty, "Strikes penalty should match updated value");
+    }
+}
+
+contract ParametersRegistryTestCurated is ParametersRegistryTestBase, CuratedIntegrationBase {}

--- a/test/fork/integration/common/StakingRouter.t.sol
+++ b/test/fork/integration/common/StakingRouter.t.sol
@@ -8,7 +8,7 @@ import { IStakingRouter } from "src/interfaces/IStakingRouter.sol";
 import { IWithdrawalVault } from "src/interfaces/IWithdrawalVault.sol";
 
 import { ExitPenaltyInfo } from "../../../../src/interfaces/IExitPenalties.sol";
-import { ModuleTypeBase, CSMIntegrationBase, CSM0x02IntegrationBase, CuratedIntegrationBase } from "./ModuleTypeBase.sol";
+import { ModuleTypeBase } from "./ModuleTypeBase.sol";
 
 abstract contract StakingRouterIntegrationTestBase is ModuleTypeBase {
     address internal agent;
@@ -30,7 +30,7 @@ abstract contract StakingRouterIntegrationTestBase is ModuleTypeBase {
         vm.resumeGasMetering();
     }
 
-    function setUp() public {
+    function setUp() public virtual {
         _setUpModule();
 
         vm.startPrank(module.getRoleMember(module.DEFAULT_ADMIN_ROLE(), 0));
@@ -48,10 +48,11 @@ abstract contract StakingRouterIntegrationTestBase is ModuleTypeBase {
         moduleId = findModule();
     }
 
-    function lidoDepositWithNoGasMetering(uint256 keysCount) internal {
+    function routerDepositWithNoGasMetering() internal {
+        _ensureStakingRouterCanDeposit(moduleId);
         vm.startPrank(locator.depositSecurityModule());
         vm.pauseGasMetering();
-        lido.deposit(keysCount, moduleId, "");
+        stakingRouter.deposit(moduleId, "");
         vm.resumeGasMetering();
         vm.stopPrank();
     }
@@ -92,7 +93,7 @@ abstract contract StakingRouterIntegrationTestBase is ModuleTypeBase {
 
         hugeDeposit();
 
-        lidoDepositWithNoGasMetering(keysCount);
+        routerDepositWithNoGasMetering();
         NodeOperator memory no = module.getNodeOperator(noId);
         assertEq(no.totalDepositedKeys, depositedKeysBefore + keysCount);
     }
@@ -105,9 +106,10 @@ abstract contract StakingRouterIntegrationTestBase is ModuleTypeBase {
             integrationHelpers.addNodeOperator(nextAddress(), keysCount - depositableValidatorsCount);
         }
 
+        _ensureStakingRouterCanDeposit(moduleId);
         vm.prank(locator.depositSecurityModule());
         vm.startSnapshotGas("CSM.lidoDepositCSM_30keys");
-        lido.deposit(keysCount, moduleId, "");
+        stakingRouter.deposit(moduleId, "");
         vm.stopSnapshotGas();
     }
 
@@ -173,7 +175,7 @@ abstract contract StakingRouterIntegrationTestBase is ModuleTypeBase {
 
         hugeDeposit();
 
-        lidoDepositWithNoGasMetering(keysCount);
+        routerDepositWithNoGasMetering();
 
         uint256 newExited = exitedKeysBefore + 1;
         vm.prank(agent);
@@ -194,7 +196,7 @@ abstract contract StakingRouterIntegrationTestBase is ModuleTypeBase {
 
         hugeDeposit();
 
-        lidoDepositWithNoGasMetering(keysCount);
+        routerDepositWithNoGasMetering();
 
         uint256 exitedKeysBefore = module.getNodeOperator(noId).totalExitedKeys;
         uint256 newExited = exitedKeysBefore + 1;
@@ -221,7 +223,7 @@ abstract contract StakingRouterIntegrationTestBase is ModuleTypeBase {
         uint256 exited = no.totalExitedKeys;
 
         hugeDeposit();
-        lidoDepositWithNoGasMetering(keysCount);
+        routerDepositWithNoGasMetering();
 
         vm.prank(agent);
         stakingRouter.reportStakingModuleExitedValidatorsCountByNodeOperator(
@@ -249,7 +251,7 @@ abstract contract StakingRouterIntegrationTestBase is ModuleTypeBase {
 
         for (;;) {
             (noId, keysCount) = integrationHelpers.getDepositableNodeOperator(nextAddress());
-            lidoDepositWithNoGasMetering(keysCount);
+            routerDepositWithNoGasMetering();
             NodeOperator memory no = module.getNodeOperator(noId);
             /// we need to be sure there are more than 1 keys for further checks
             if (no.totalDepositedKeys > 1) {
@@ -301,10 +303,14 @@ abstract contract StakingRouterIntegrationTestBase is ModuleTypeBase {
         assertTrue(exitPenaltyInfo.delayFee.isValue);
         assertEq(exitPenaltyInfo.delayFee.value, expectedPenalty);
     }
+
+    function _getExpectedRouterDepositRequestCount() internal view returns (uint256 expected) {
+        uint256 byAmount = stakingRouter.getStakingModuleMaxDepositsCount(moduleId, lido.getDepositableEther());
+        uint256 maxPerBlock = stakingRouter.getStakingModuleMaxDepositsPerBlock(moduleId);
+        (, , uint256 depositableValidatorsCount) = module.getStakingModuleSummary();
+
+        expected = byAmount;
+        if (maxPerBlock < expected) expected = maxPerBlock;
+        if (depositableValidatorsCount < expected) expected = depositableValidatorsCount;
+    }
 }
-
-contract StakingRouterIntegrationTestCSM is StakingRouterIntegrationTestBase, CSMIntegrationBase {}
-
-contract StakingRouterIntegrationTestCSM0x02 is StakingRouterIntegrationTestBase, CSM0x02IntegrationBase {}
-
-contract StakingRouterIntegrationTestCurated is StakingRouterIntegrationTestBase, CuratedIntegrationBase {}

--- a/test/fork/integration/common/StakingRouter.t.sol
+++ b/test/fork/integration/common/StakingRouter.t.sol
@@ -13,6 +13,7 @@ import { ModuleTypeBase } from "./ModuleTypeBase.sol";
 abstract contract StakingRouterIntegrationTestBase is ModuleTypeBase {
     address internal agent;
     uint256 internal moduleId;
+    bool internal isStakingRouterUpgraded;
 
     modifier assertInvariants() {
         _;
@@ -46,15 +47,24 @@ abstract contract StakingRouterIntegrationTestBase is ModuleTypeBase {
         vm.stopPrank();
 
         moduleId = findModule();
+        isStakingRouterUpgraded = _isStakingRouterUpgraded();
     }
 
-    function routerDepositWithNoGasMetering() internal {
-        _ensureStakingRouterCanDeposit(moduleId);
+    function moduleDepositWithNoGasMetering(uint256 keysCount) internal returns (uint256 deposited) {
+        (, uint256 depositedBefore, ) = module.getStakingModuleSummary();
         vm.startPrank(locator.depositSecurityModule());
         vm.pauseGasMetering();
-        stakingRouter.deposit(moduleId, "");
+        if (isStakingRouterUpgraded) {
+            _ensureStakingRouterCanDeposit(moduleId);
+            stakingRouter.deposit(moduleId, "");
+        } else {
+            _legacyLidoDeposit(keysCount, moduleId, "");
+        }
         vm.resumeGasMetering();
         vm.stopPrank();
+
+        (, uint256 depositedAfter, ) = module.getStakingModuleSummary();
+        deposited = depositedAfter - depositedBefore;
     }
 
     function test_connectCSMToRouter() public view {
@@ -93,9 +103,11 @@ abstract contract StakingRouterIntegrationTestBase is ModuleTypeBase {
 
         hugeDeposit();
 
-        routerDepositWithNoGasMetering();
+        moduleDepositWithNoGasMetering(keysCount);
         NodeOperator memory no = module.getNodeOperator(noId);
-        assertEq(no.totalDepositedKeys, depositedKeysBefore + keysCount);
+        uint256 deposited = no.totalDepositedKeys - depositedKeysBefore;
+        assertGt(deposited, 0);
+        if (!isStakingRouterUpgraded) assertEq(deposited, keysCount);
     }
 
     function test_routerDepositOneBatch() public assertInvariants {
@@ -106,10 +118,14 @@ abstract contract StakingRouterIntegrationTestBase is ModuleTypeBase {
             integrationHelpers.addNodeOperator(nextAddress(), keysCount - depositableValidatorsCount);
         }
 
-        _ensureStakingRouterCanDeposit(moduleId);
+        if (isStakingRouterUpgraded) _ensureStakingRouterCanDeposit(moduleId);
         vm.prank(locator.depositSecurityModule());
         vm.startSnapshotGas("CSM.lidoDepositCSM_30keys");
-        stakingRouter.deposit(moduleId, "");
+        if (isStakingRouterUpgraded) {
+            stakingRouter.deposit(moduleId, "");
+        } else {
+            _legacyLidoDeposit(keysCount, moduleId, "");
+        }
         vm.stopSnapshotGas();
     }
 
@@ -175,7 +191,7 @@ abstract contract StakingRouterIntegrationTestBase is ModuleTypeBase {
 
         hugeDeposit();
 
-        routerDepositWithNoGasMetering();
+        moduleDepositWithNoGasMetering(keysCount);
 
         uint256 newExited = exitedKeysBefore + 1;
         vm.prank(agent);
@@ -196,7 +212,7 @@ abstract contract StakingRouterIntegrationTestBase is ModuleTypeBase {
 
         hugeDeposit();
 
-        routerDepositWithNoGasMetering();
+        uint256 depositedDelta = moduleDepositWithNoGasMetering(keysCount);
 
         uint256 exitedKeysBefore = module.getNodeOperator(noId).totalExitedKeys;
         uint256 newExited = exitedKeysBefore + 1;
@@ -209,8 +225,8 @@ abstract contract StakingRouterIntegrationTestBase is ModuleTypeBase {
 
         IStakingRouter.StakingModuleSummary memory summary = stakingRouter.getStakingModuleSummary(moduleId);
         assertEq(summary.totalExitedValidators, summaryOld.totalExitedValidators + 1);
-        assertEq(summary.totalDepositedValidators, summaryOld.totalDepositedValidators + keysCount);
-        assertEq(summary.depositableValidatorsCount, summaryOld.depositableValidatorsCount - keysCount);
+        assertEq(summary.totalDepositedValidators, summaryOld.totalDepositedValidators + depositedDelta);
+        assertEq(summary.depositableValidatorsCount + depositedDelta, summaryOld.depositableValidatorsCount);
     }
 
     function test_getNodeOperatorSummary() public assertInvariants {
@@ -223,7 +239,7 @@ abstract contract StakingRouterIntegrationTestBase is ModuleTypeBase {
         uint256 exited = no.totalExitedKeys;
 
         hugeDeposit();
-        routerDepositWithNoGasMetering();
+        moduleDepositWithNoGasMetering(keysCount);
 
         vm.prank(agent);
         stakingRouter.reportStakingModuleExitedValidatorsCountByNodeOperator(
@@ -239,8 +255,10 @@ abstract contract StakingRouterIntegrationTestBase is ModuleTypeBase {
         assertEq(summary.refundedValidatorsCount, 0);
         assertEq(summary.stuckPenaltyEndTimestamp, 0);
         assertEq(summary.totalExitedValidators, exited);
-        assertEq(summary.totalDepositedValidators, depositedValidatorsBefore + keysCount);
-        assertEq(summary.depositableValidatorsCount, depositableValidatorsCount - keysCount);
+        uint256 depositedDelta = summary.totalDepositedValidators - depositedValidatorsBefore;
+        assertGt(depositedDelta, 0);
+        if (!isStakingRouterUpgraded) assertEq(depositedDelta, keysCount);
+        assertEq(summary.depositableValidatorsCount + depositedDelta, depositableValidatorsCount);
     }
 
     function test_unsafeSetExitedValidatorsCount() public assertInvariants {
@@ -251,7 +269,7 @@ abstract contract StakingRouterIntegrationTestBase is ModuleTypeBase {
 
         for (;;) {
             (noId, keysCount) = integrationHelpers.getDepositableNodeOperator(nextAddress());
-            routerDepositWithNoGasMetering();
+            moduleDepositWithNoGasMetering(keysCount);
             NodeOperator memory no = module.getNodeOperator(noId);
             /// we need to be sure there are more than 1 keys for further checks
             if (no.totalDepositedKeys > 1) {
@@ -304,7 +322,11 @@ abstract contract StakingRouterIntegrationTestBase is ModuleTypeBase {
         assertEq(exitPenaltyInfo.delayFee.value, expectedPenalty);
     }
 
-    function _getExpectedRouterDepositRequestCount() internal view returns (uint256 expected) {
+    function _getExpectedRouterDepositRequestCount() internal returns (uint256 expected) {
+        if (!isStakingRouterUpgraded) {
+            // Skip: request-count logic depends on router-v2 and Lido-v2 deposit interfaces.
+            vm.skip(true, "Request-count logic depends on router-v2 and Lido-v2 deposit interfaces");
+        }
         uint256 byAmount = stakingRouter.getStakingModuleMaxDepositsCount(moduleId, lido.getDepositableEther());
         uint256 maxPerBlock = stakingRouter.getStakingModuleMaxDepositsPerBlock(moduleId);
         (, , uint256 depositableValidatorsCount) = module.getStakingModuleSummary();

--- a/test/fork/integration/csm/CleanDepositQueue.t.sol
+++ b/test/fork/integration/csm/CleanDepositQueue.t.sol
@@ -1,0 +1,110 @@
+// SPDX-FileCopyrightText: 2026 Lido <info@lido.fi>
+// SPDX-License-Identifier: GPL-3.0
+
+pragma solidity 0.8.33;
+
+import { ICSModule } from "src/interfaces/ICSModule.sol";
+import { NodeOperator } from "src/interfaces/IBaseModule.sol";
+
+import { CSMIntegrationBase } from "../common/ModuleTypeBase.sol";
+
+contract CleanDepositQueueTestCSM is CSMIntegrationBase {
+    address internal nodeOperator;
+    uint256 internal defaultNoId;
+    uint256 internal initialKeysCount = 5;
+
+    modifier assertInvariants() {
+        _;
+        vm.pauseGasMetering();
+        uint256 noCount = module.getNodeOperatorsCount();
+        assertModuleKeys(module);
+        assertModuleEnqueuedCount(module);
+        assertModuleUnusedStorageSlots(module);
+        assertAccountingTotalBondShares(noCount, lido, accounting);
+        assertAccountingBurnerApproval(lido, address(accounting), locator.burner());
+        assertAccountingUnusedStorageSlots(accounting);
+        assertFeeDistributorClaimableShares(lido, feeDistributor);
+        assertFeeDistributorTree(feeDistributor);
+        assertFeeOracleUnusedStorageSlots(oracle);
+        vm.resumeGasMetering();
+    }
+
+    function setUp() public {
+        _setUpModule();
+
+        vm.startPrank(module.getRoleMember(module.DEFAULT_ADMIN_ROLE(), 0));
+        module.grantRole(module.DEFAULT_ADMIN_ROLE(), address(this));
+        vm.stopPrank();
+
+        handleStakingLimit();
+        handleBunkerMode();
+
+        nodeOperator = nextAddress("NodeOperator");
+        defaultNoId = integrationHelpers.addNodeOperator(nodeOperator, initialKeysCount);
+    }
+
+    function test_cleanDepositQueue_afterKeyRemoval() public assertInvariants {
+        ICSModule csm = ICSModule(address(module));
+
+        NodeOperator memory noBefore = module.getNodeOperator(defaultNoId);
+        uint256 enqueuedBefore = noBefore.enqueuedCount;
+        assertTrue(enqueuedBefore > 0, "NO should have enqueued keys");
+
+        // Remove all non-deposited keys to make queue entries stale
+        uint256 keysToRemove = initialKeysCount;
+        vm.prank(nodeOperator);
+        module.removeKeys(defaultNoId, 0, keysToRemove);
+
+        NodeOperator memory noAfterRemoval = module.getNodeOperator(defaultNoId);
+        assertEq(noAfterRemoval.depositableValidatorsCount, 0, "Depositable count should be 0 after removing all keys");
+        assertTrue(noAfterRemoval.enqueuedCount > 0, "NO should have stale enqueued keys before cleanup");
+
+        // Clean the queue — stale entries should be removed
+        (uint256 removed, ) = csm.cleanDepositQueue(type(uint256).max);
+        assertTrue(removed > 0, "Should remove stale batches");
+
+        NodeOperator memory noAfterClean = module.getNodeOperator(defaultNoId);
+        assertEq(noAfterClean.enqueuedCount, 0, "Enqueued count should be 0 after cleanup");
+    }
+
+    function test_cleanDepositQueue_multipleStaleBatches() public assertInvariants {
+        ICSModule csm = ICSModule(address(module));
+
+        // Add a second NO with keys
+        address nodeOperator2 = nextAddress("NodeOperator2");
+        uint256 noId2 = integrationHelpers.addNodeOperator(nodeOperator2, 3);
+
+        // Remove all keys from both NOs
+        vm.prank(nodeOperator);
+        module.removeKeys(defaultNoId, 0, initialKeysCount);
+
+        vm.prank(nodeOperator2);
+        module.removeKeys(noId2, 0, 3);
+
+        NodeOperator memory no1AfterRemoval = module.getNodeOperator(defaultNoId);
+        NodeOperator memory no2AfterRemoval = module.getNodeOperator(noId2);
+        assertTrue(no1AfterRemoval.enqueuedCount > 0, "NO1 should have stale enqueued keys before cleanup");
+        assertTrue(no2AfterRemoval.enqueuedCount > 0, "NO2 should have stale enqueued keys before cleanup");
+
+        // Clean the queue
+        (uint256 removed, ) = csm.cleanDepositQueue(type(uint256).max);
+        assertTrue(removed > 1, "Should remove multiple stale batches");
+
+        NodeOperator memory no1 = module.getNodeOperator(defaultNoId);
+        NodeOperator memory no2 = module.getNodeOperator(noId2);
+        assertEq(no1.enqueuedCount, 0, "NO1 enqueued should be 0");
+        assertEq(no2.enqueuedCount, 0, "NO2 enqueued should be 0");
+    }
+
+    function test_cleanDepositQueue_noop_whenNoStale() public assertInvariants {
+        ICSModule csm = ICSModule(address(module));
+
+        // Live forks can already contain stale batches from other operators.
+        // First cleanup establishes a deterministic baseline for this test.
+        csm.cleanDepositQueue(type(uint256).max);
+
+        // Second cleanup should be a noop.
+        (uint256 removed, ) = csm.cleanDepositQueue(type(uint256).max);
+        assertEq(removed, 0, "Nothing should be removed from clean queue");
+    }
+}

--- a/test/fork/integration/csm/DepositInfoRefresh.t.sol
+++ b/test/fork/integration/csm/DepositInfoRefresh.t.sol
@@ -51,9 +51,6 @@ contract DepositInfoRefreshTestCSM is CSMIntegrationBase {
     function test_depositInfoRefreshPipeline() public assertInvariants {
         ICSModule csm = ICSModule(address(module));
         uint256 curveId = accounting.getBondCurveId(defaultNoId);
-        // Keep per-call work bounded for large mainnet operator sets.
-        uint256 batchSize = 64;
-
         // Update bond curve to trigger full deposit info refresh
         IBondCurve.BondCurveData memory curveData = accounting.getBondCurve(defaultNoId);
         IBondCurve.BondCurveIntervalInput[] memory newCurve = new IBondCurve.BondCurveIntervalInput[](
@@ -78,14 +75,7 @@ contract DepositInfoRefreshTestCSM is CSMIntegrationBase {
         vm.expectRevert(IBaseModule.DepositInfoIsNotUpToDate.selector);
         csm.cleanDepositQueue(1);
 
-        // Process in batches
-        uint256 operatorsLeft = toUpdate;
-        while (operatorsLeft > 0) {
-            uint256 prev = operatorsLeft;
-            uint256 count = prev > batchSize ? batchSize : prev;
-            operatorsLeft = module.batchDepositInfoUpdate(count);
-            assertLt(operatorsLeft, prev, "Deposit-info refresh should make progress");
-        }
+        integrationHelpers.runFullBatchDepositInfoUpdate();
 
         assertEq(module.getNodeOperatorDepositInfoToUpdateCount(), 0, "All operators should be updated");
 

--- a/test/fork/integration/csm/DepositInfoRefresh.t.sol
+++ b/test/fork/integration/csm/DepositInfoRefresh.t.sol
@@ -1,0 +1,95 @@
+// SPDX-FileCopyrightText: 2026 Lido <info@lido.fi>
+// SPDX-License-Identifier: GPL-3.0
+
+pragma solidity 0.8.33;
+
+import { ICSModule } from "src/interfaces/ICSModule.sol";
+import { IBaseModule } from "src/interfaces/IBaseModule.sol";
+import { IBondCurve } from "src/interfaces/IBondCurve.sol";
+
+import { CSMIntegrationBase } from "../common/ModuleTypeBase.sol";
+
+contract DepositInfoRefreshTestCSM is CSMIntegrationBase {
+    address internal nodeOperator;
+    uint256 internal defaultNoId;
+    uint256 internal initialKeysCount = 5;
+
+    modifier assertInvariants() {
+        _;
+        vm.pauseGasMetering();
+        uint256 noCount = module.getNodeOperatorsCount();
+        assertModuleKeys(module);
+        assertModuleEnqueuedCount(module);
+        assertModuleUnusedStorageSlots(module);
+        assertAccountingTotalBondShares(noCount, lido, accounting);
+        assertAccountingBurnerApproval(lido, address(accounting), locator.burner());
+        assertAccountingUnusedStorageSlots(accounting);
+        assertFeeDistributorClaimableShares(lido, feeDistributor);
+        assertFeeDistributorTree(feeDistributor);
+        assertFeeOracleUnusedStorageSlots(oracle);
+        vm.resumeGasMetering();
+    }
+
+    function setUp() public {
+        _setUpModule();
+
+        vm.startPrank(module.getRoleMember(module.DEFAULT_ADMIN_ROLE(), 0));
+        module.grantRole(module.DEFAULT_ADMIN_ROLE(), address(this));
+        vm.stopPrank();
+
+        vm.startPrank(accounting.getRoleMember(accounting.DEFAULT_ADMIN_ROLE(), 0));
+        accounting.grantRole(accounting.DEFAULT_ADMIN_ROLE(), address(this));
+        vm.stopPrank();
+
+        handleStakingLimit();
+        handleBunkerMode();
+
+        nodeOperator = nextAddress("NodeOperator");
+        defaultNoId = integrationHelpers.addNodeOperator(nodeOperator, initialKeysCount);
+    }
+
+    function test_depositInfoRefreshPipeline() public assertInvariants {
+        ICSModule csm = ICSModule(address(module));
+        uint256 curveId = accounting.getBondCurveId(defaultNoId);
+        // Keep per-call work bounded for large mainnet operator sets.
+        uint256 batchSize = 64;
+
+        // Update bond curve to trigger full deposit info refresh
+        IBondCurve.BondCurveData memory curveData = accounting.getBondCurve(defaultNoId);
+        IBondCurve.BondCurveIntervalInput[] memory newCurve = new IBondCurve.BondCurveIntervalInput[](
+            curveData.intervals.length
+        );
+        for (uint256 i; i < curveData.intervals.length; ++i) {
+            newCurve[i] = IBondCurve.BondCurveIntervalInput({
+                minKeysCount: curveData.intervals[i].minKeysCount,
+                trend: curveData.intervals[i].trend
+            });
+        }
+
+        bytes32 manageCurvesRole = accounting.MANAGE_BOND_CURVES_ROLE();
+        accounting.grantRole(manageCurvesRole, address(this));
+        accounting.updateBondCurve(curveId, newCurve);
+
+        // Deposit info is now stale
+        uint256 toUpdate = module.getNodeOperatorDepositInfoToUpdateCount();
+        assertTrue(toUpdate > 0, "Deposit info should need update after curve change");
+
+        // cleanDepositQueue should revert while deposit info is stale
+        vm.expectRevert(IBaseModule.DepositInfoIsNotUpToDate.selector);
+        csm.cleanDepositQueue(1);
+
+        // Process in batches
+        uint256 operatorsLeft = toUpdate;
+        while (operatorsLeft > 0) {
+            uint256 prev = operatorsLeft;
+            uint256 count = prev > batchSize ? batchSize : prev;
+            operatorsLeft = module.batchDepositInfoUpdate(count);
+            assertLt(operatorsLeft, prev, "Deposit-info refresh should make progress");
+        }
+
+        assertEq(module.getNodeOperatorDepositInfoToUpdateCount(), 0, "All operators should be updated");
+
+        // cleanDepositQueue should now succeed
+        csm.cleanDepositQueue(1);
+    }
+}

--- a/test/fork/integration/csm/ParametersRegistry.t.sol
+++ b/test/fork/integration/csm/ParametersRegistry.t.sol
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: 2025 Lido <info@lido.fi>
+// SPDX-License-Identifier: GPL-3.0
+
+pragma solidity 0.8.33;
+
+import { ParametersRegistryTestBase } from "../common/ParametersRegistry.t.sol";
+import { CSMIntegrationBase } from "../common/ModuleTypeBase.sol";
+
+contract ParametersRegistryTestCSM is ParametersRegistryTestBase, CSMIntegrationBase {
+    function test_changeKeyRemovalCharge() public assertInvariants {
+        _assertChangeKeyRemovalCharge();
+    }
+
+    function test_setQueueConfig() public assertInvariants {
+        _assertSetQueueConfig();
+    }
+}

--- a/test/fork/integration/csm/StakingRouter.t.sol
+++ b/test/fork/integration/csm/StakingRouter.t.sol
@@ -10,6 +10,10 @@ import { NodeOperator } from "src/interfaces/IBaseModule.sol";
 contract StakingRouterIntegrationTestCSM is StakingRouterIntegrationTestBase, CSMIntegrationBase {
     function setUp() public override {
         super.setUp();
+        if (!isStakingRouterUpgraded) {
+            // Skip: this suite validates router-v2 deposit behavior unavailable on legacy core/router versions.
+            vm.skip(true, "Suite requires upgraded staking router version for router-v2 deposit behavior");
+        }
 
         _maximizeModuleShare(moduleId);
         _disableDepositsForOtherModules(moduleId);

--- a/test/fork/integration/csm/StakingRouter.t.sol
+++ b/test/fork/integration/csm/StakingRouter.t.sol
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: 2026 Lido <info@lido.fi>
+// SPDX-License-Identifier: GPL-3.0
+
+pragma solidity 0.8.33;
+
+import { CSMIntegrationBase } from "../common/ModuleTypeBase.sol";
+import { StakingRouterIntegrationTestBase } from "../common/StakingRouter.t.sol";
+import { NodeOperator } from "src/interfaces/IBaseModule.sol";
+
+contract StakingRouterIntegrationTestCSM is StakingRouterIntegrationTestBase, CSMIntegrationBase {
+    function setUp() public override {
+        super.setUp();
+
+        _maximizeModuleShare(moduleId);
+        _disableDepositsForOtherModules(moduleId);
+        hugeDeposit();
+        _ensureStakingRouterCanDeposit(moduleId);
+    }
+
+    function test_routerDeposit_happyPath_callsObtainDepositDataAndUsesReturnedCount() public assertInvariants {
+        (uint256 noId, ) = integrationHelpers.getDepositableNodeOperator(nextAddress());
+        NodeOperator memory noBefore = module.getNodeOperator(noId);
+        assertGt(noBefore.depositableValidatorsCount, 0);
+
+        (, uint256 depositedBefore, ) = module.getStakingModuleSummary();
+
+        uint256 requestedDeposits = _getExpectedRouterDepositRequestCount();
+        assertGt(requestedDeposits, 0);
+        vm.expectCall(
+            address(module),
+            abi.encodeWithSelector(module.obtainDepositData.selector, requestedDeposits, "")
+        );
+        vm.prank(locator.depositSecurityModule());
+        stakingRouter.deposit(moduleId, "");
+
+        (, uint256 depositedAfter, ) = module.getStakingModuleSummary();
+        uint256 actualDeposits = depositedAfter - depositedBefore;
+        assertEq(depositedAfter - depositedBefore, actualDeposits);
+        assertEq(actualDeposits, requestedDeposits);
+
+        NodeOperator memory noAfter = module.getNodeOperator(noId);
+        uint256 depositedDelta = noAfter.totalDepositedKeys - noBefore.totalDepositedKeys;
+        uint256 depositableDelta = noBefore.depositableValidatorsCount - noAfter.depositableValidatorsCount;
+        assertGt(depositedDelta, 0);
+        assertEq(depositedDelta, depositableDelta);
+    }
+}

--- a/test/fork/integration/csm0x02/ParametersRegistry.t.sol
+++ b/test/fork/integration/csm0x02/ParametersRegistry.t.sol
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: 2025 Lido <info@lido.fi>
+// SPDX-License-Identifier: GPL-3.0
+
+pragma solidity 0.8.33;
+
+import { ParametersRegistryTestBase } from "../common/ParametersRegistry.t.sol";
+import { CSM0x02IntegrationBase } from "../common/ModuleTypeBase.sol";
+
+contract ParametersRegistryTestCSM0x02 is ParametersRegistryTestBase, CSM0x02IntegrationBase {
+    function test_changeKeyRemovalCharge() public assertInvariants {
+        _assertChangeKeyRemovalCharge();
+    }
+
+    function test_setQueueConfig() public assertInvariants {
+        _assertSetQueueConfig();
+    }
+}

--- a/test/fork/integration/csm0x02/StakingRouter.t.sol
+++ b/test/fork/integration/csm0x02/StakingRouter.t.sol
@@ -22,6 +22,10 @@ contract StakingRouterIntegrationTestCSM0x02 is StakingRouterIntegrationTestBase
 
     function setUp() public override {
         super.setUp();
+        if (!isStakingRouterUpgraded) {
+            // Skip: this suite depends on router/core v2 APIs and is not executable on the old router version.
+            vm.skip(true, "Suite requires upgraded staking router version for router/core v2 APIs");
+        }
 
         reporter = stakingRouter.getRoleMember(stakingRouter.REPORT_EXITED_VALIDATORS_ROLE(), 0);
         topUpGateway = locator.topUpGateway();

--- a/test/fork/integration/csm0x02/StakingRouter.t.sol
+++ b/test/fork/integration/csm0x02/StakingRouter.t.sol
@@ -1,0 +1,351 @@
+// SPDX-FileCopyrightText: 2026 Lido <info@lido.fi>
+// SPDX-License-Identifier: GPL-3.0
+
+pragma solidity 0.8.33;
+
+import { IStakingModuleV2 } from "src/interfaces/IStakingModule.sol";
+import { ICSModule } from "src/interfaces/ICSModule.sol";
+import { NodeOperator } from "src/interfaces/IBaseModule.sol";
+import { WithdrawnValidatorLib } from "src/lib/WithdrawnValidatorLib.sol";
+import { SigningKeys } from "src/lib/SigningKeys.sol";
+
+import { CSM0x02IntegrationBase } from "../common/ModuleTypeBase.sol";
+import { StakingRouterIntegrationTestBase } from "../common/StakingRouter.t.sol";
+
+contract StakingRouterIntegrationTestCSM0x02 is StakingRouterIntegrationTestBase, CSM0x02IntegrationBase {
+    uint256 internal constant KEY_ADDED_BALANCE_CAP =
+        WithdrawnValidatorLib.MAX_EFFECTIVE_BALANCE - WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE;
+    uint256 internal constant TOP_UP_ALLOCATION_PROBE_AMOUNT = 100_000 ether;
+
+    address internal reporter;
+    address internal topUpGateway;
+
+    function setUp() public override {
+        super.setUp();
+
+        reporter = stakingRouter.getRoleMember(stakingRouter.REPORT_EXITED_VALIDATORS_ROLE(), 0);
+        topUpGateway = locator.topUpGateway();
+
+        _maximizeModuleShare(moduleId);
+        _disableDepositsForOtherModules(moduleId);
+        hugeDeposit();
+        _ensureStakingRouterCanDeposit(moduleId);
+    }
+
+    function test_routerDeposit_happyPath_callsObtainDepositDataAndUsesReturnedCount() public assertInvariants {
+        (uint256 noId, ) = integrationHelpers.getDepositableNodeOperator(nextAddress());
+        NodeOperator memory noBefore = module.getNodeOperator(noId);
+        assertGt(noBefore.depositableValidatorsCount, 0);
+
+        (, uint256 depositedBefore, ) = module.getStakingModuleSummary();
+
+        uint256 requestedDeposits = _getExpectedRouterDepositRequestCount();
+        assertGt(requestedDeposits, 0);
+        vm.expectCall(
+            address(module),
+            abi.encodeWithSelector(module.obtainDepositData.selector, requestedDeposits, "")
+        );
+        vm.prank(locator.depositSecurityModule());
+        stakingRouter.deposit(moduleId, "");
+
+        (, uint256 depositedAfter, ) = module.getStakingModuleSummary();
+        uint256 actualDeposits = depositedAfter - depositedBefore;
+        assertEq(depositedAfter - depositedBefore, actualDeposits);
+        assertEq(actualDeposits, requestedDeposits);
+
+        NodeOperator memory noAfter = module.getNodeOperator(noId);
+        uint256 depositedDelta = noAfter.totalDepositedKeys - noBefore.totalDepositedKeys;
+        uint256 depositableDelta = noBefore.depositableValidatorsCount - noAfter.depositableValidatorsCount;
+        assertGt(depositedDelta, 0);
+        assertEq(depositedDelta, depositableDelta);
+    }
+
+    function test_routerTopUp_callsAllocateDeposits() public assertInvariants {
+        (uint256 noId, uint256 keyIndex, bytes memory pubkey) = integrationHelpers.getDepositableTopUpNodeOperator(
+            nextAddress()
+        );
+
+        (uint256 expectedMaxDepositAmount, ) = stakingRouter.getTopUpAllocation(TOP_UP_ALLOCATION_PROBE_AMOUNT);
+        uint256 nonceBefore = module.getNonce();
+
+        (
+            uint256[] memory keyIndices,
+            uint256[] memory operatorIds,
+            bytes[] memory pubkeys,
+            uint256[] memory topUpLimits
+        ) = _singleTopUpArrays(noId, keyIndex, pubkey, 1 ether);
+
+        vm.expectCall(
+            address(module),
+            abi.encodeWithSelector(
+                IStakingModuleV2.allocateDeposits.selector,
+                expectedMaxDepositAmount,
+                pubkeys,
+                keyIndices,
+                operatorIds,
+                topUpLimits
+            )
+        );
+
+        vm.prank(topUpGateway);
+        stakingRouter.topUp(moduleId, keyIndices, operatorIds, pubkeys, topUpLimits);
+
+        assertEq(module.getNonce(), nonceBefore + 1);
+    }
+
+    function test_routerTopUp_updatesKeyAddedBalance() public assertInvariants {
+        (uint256 noId, uint256 keyIndex, bytes memory pubkey) = integrationHelpers.getDepositableTopUpNodeOperator(
+            nextAddress()
+        );
+
+        uint256 topUpLimit = 1 ether;
+        (uint256 expectedMaxDepositAmount, ) = stakingRouter.getTopUpAllocation(TOP_UP_ALLOCATION_PROBE_AMOUNT);
+        uint256 keyAddedBalanceBefore = module.getKeyAddedBalance(noId, keyIndex);
+        uint256 remainingCapacity = _remainingTopUpCapacity(noId, keyIndex);
+        uint256 cappedLimit = topUpLimit < remainingCapacity ? topUpLimit : remainingCapacity;
+        uint256 expectedAllocation = expectedMaxDepositAmount < cappedLimit ? expectedMaxDepositAmount : cappedLimit;
+
+        (
+            uint256[] memory keyIndices,
+            uint256[] memory operatorIds,
+            bytes[] memory pubkeys,
+            uint256[] memory topUpLimits
+        ) = _singleTopUpArrays(noId, keyIndex, pubkey, topUpLimit);
+
+        vm.prank(topUpGateway);
+        stakingRouter.topUp(moduleId, keyIndices, operatorIds, pubkeys, topUpLimits);
+
+        uint256 keyAddedBalanceAfter = module.getKeyAddedBalance(noId, keyIndex);
+        assertEq(keyAddedBalanceAfter - keyAddedBalanceBefore, expectedAllocation);
+    }
+
+    function test_routerTopUp_fullTopUpDequeuesOneQueueItem() public assertInvariants {
+        (uint256 noId, uint256 keyIndex, bytes memory pubkey) = integrationHelpers.getDepositableTopUpNodeOperator(
+            nextAddress()
+        );
+
+        uint256 topUpLimit = 1;
+        (uint256 expectedMaxDepositAmount, ) = stakingRouter.getTopUpAllocation(TOP_UP_ALLOCATION_PROBE_AMOUNT);
+        assertGt(expectedMaxDepositAmount, 0);
+
+        (, , uint256 queueLengthBefore, ) = module.getTopUpQueue();
+        assertGt(queueLengthBefore, 0);
+
+        (
+            uint256[] memory keyIndices,
+            uint256[] memory operatorIds,
+            bytes[] memory pubkeys,
+            uint256[] memory topUpLimits
+        ) = _singleTopUpArrays(noId, keyIndex, pubkey, topUpLimit);
+
+        vm.prank(topUpGateway);
+        stakingRouter.topUp(moduleId, keyIndices, operatorIds, pubkeys, topUpLimits);
+
+        (, , uint256 queueLengthAfter, ) = module.getTopUpQueue();
+        assertEq(queueLengthAfter + 1, queueLengthBefore);
+    }
+
+    function test_routerTopUp_queueLimitUtilization_unblocksSingleDepositSlot() public assertInvariants {
+        uint256 appliedLimit = _forceTopUpQueueOneFreeSlot();
+        uint256 depositedAfterFirst = _depositOneThroughRouterAndAssertRequestedOne();
+
+        (, , uint256 queueLengthAfterFirst, ) = module.getTopUpQueue();
+        assertEq(queueLengthAfterFirst, appliedLimit);
+
+        (uint256 noId, uint256 keyIndex, bytes memory pubkey) = integrationHelpers.getDepositableTopUpNodeOperator(
+            nextAddress()
+        );
+        (
+            uint256[] memory keyIndices,
+            uint256[] memory operatorIds,
+            bytes[] memory pubkeys,
+            uint256[] memory topUpLimits
+        ) = _singleTopUpArrays(noId, keyIndex, pubkey, 1 ether);
+
+        vm.prank(topUpGateway);
+        stakingRouter.topUp(moduleId, keyIndices, operatorIds, pubkeys, topUpLimits);
+
+        (, , uint256 queueLengthAfterTopUp, ) = module.getTopUpQueue();
+        assertEq(queueLengthAfterTopUp + 1, queueLengthAfterFirst);
+
+        uint256 depositedAfterSecond = _depositOneThroughRouterAndAssertRequestedOne();
+        assertEq(depositedAfterSecond, depositedAfterFirst + 1);
+
+        (, , uint256 queueLengthAfterSecond, ) = module.getTopUpQueue();
+        assertEq(queueLengthAfterSecond, appliedLimit);
+    }
+
+    function test_routerTopUp_revertsOnInvalidSigningKey() public {
+        (uint256 noId, uint256 keyIndex, ) = integrationHelpers.getDepositableTopUpNodeOperator(nextAddress());
+        bytes memory invalidPubkey = new bytes(48);
+        (
+            uint256[] memory keyIndices,
+            uint256[] memory operatorIds,
+            bytes[] memory pubkeys,
+            uint256[] memory topUpLimits
+        ) = _singleTopUpArrays(noId, keyIndex, invalidPubkey, 1 ether);
+
+        vm.expectRevert(SigningKeys.InvalidSigningKey.selector);
+        vm.prank(topUpGateway);
+        stakingRouter.topUp(moduleId, keyIndices, operatorIds, pubkeys, topUpLimits);
+    }
+
+    function test_routerTopUp_revertsOnInvalidTopUpOrder() public {
+        (uint256 queueNoId, uint256 keyIndex, bytes memory pubkey) = integrationHelpers.getDepositableTopUpNodeOperator(
+            nextAddress()
+        );
+
+        (
+            uint256[] memory keyIndices,
+            uint256[] memory operatorIds,
+            bytes[] memory pubkeys,
+            uint256[] memory topUpLimits
+        ) = _singleTopUpArrays(queueNoId + 1, keyIndex, pubkey, 1 ether);
+
+        vm.expectRevert(ICSModule.InvalidTopUpOrder.selector);
+        vm.prank(topUpGateway);
+        stakingRouter.topUp(moduleId, keyIndices, operatorIds, pubkeys, topUpLimits);
+    }
+
+    function test_routerTopUp_revertsOnUnexpectedExtraKey() public {
+        (uint256 noId, uint256 keyIndex, bytes memory pubkey) = integrationHelpers.getDepositableTopUpNodeOperator(
+            nextAddress()
+        );
+
+        uint256 remainingCapacity = _remainingTopUpCapacity(noId, keyIndex);
+        assertGt(remainingCapacity, 0);
+
+        uint256 topUpLimit = remainingCapacity + 1 ether;
+        uint256 mockedDepositableEther = remainingCapacity > 1 ether ? remainingCapacity - 1 ether : 0;
+        vm.mockCall(
+            address(lido),
+            abi.encodeWithSelector(lido.getDepositableEther.selector),
+            abi.encode(mockedDepositableEther)
+        );
+
+        uint256[] memory keyIndices = new uint256[](2);
+        keyIndices[0] = keyIndex;
+        keyIndices[1] = keyIndex;
+
+        uint256[] memory operatorIds = new uint256[](2);
+        operatorIds[0] = noId;
+        operatorIds[1] = noId;
+
+        bytes[] memory pubkeys = new bytes[](2);
+        pubkeys[0] = pubkey;
+        pubkeys[1] = pubkey;
+
+        uint256[] memory topUpLimits = new uint256[](2);
+        topUpLimits[0] = topUpLimit;
+        topUpLimits[1] = topUpLimit;
+
+        vm.expectRevert(ICSModule.UnexpectedExtraKey.selector);
+        vm.prank(topUpGateway);
+        stakingRouter.topUp(moduleId, keyIndices, operatorIds, pubkeys, topUpLimits);
+    }
+
+    function test_reportStakingModuleOperatorBalances_callsUpdateOperatorBalances() public assertInvariants {
+        (uint256 noId, ) = integrationHelpers.getDepositableNodeOperator(nextAddress());
+
+        bytes memory nodeOperatorIds = _encodeNodeOperatorId(noId);
+        bytes memory totalBalancesGwei = _encodeUint128Value(123);
+
+        vm.expectCall(address(module), abi.encodeWithSelector(IStakingModuleV2.updateOperatorBalances.selector));
+
+        uint256 nonceBefore = module.getNonce();
+
+        vm.prank(reporter);
+        stakingRouter.reportStakingModuleOperatorBalances(moduleId, nodeOperatorIds, totalBalancesGwei);
+
+        // CSM0x02 intentionally treats this hook as a no-op for module state.
+        assertEq(module.getNonce(), nonceBefore);
+    }
+
+    function _remainingTopUpCapacity(uint256 noId, uint256 keyIndex) internal view returns (uint256) {
+        uint256 keyAddedBalance = module.getKeyAddedBalance(noId, keyIndex);
+        if (keyAddedBalance >= KEY_ADDED_BALANCE_CAP) return 0;
+        return KEY_ADDED_BALANCE_CAP - keyAddedBalance;
+    }
+
+    function _forceTopUpQueueOneFreeSlot() internal returns (uint256 appliedLimit) {
+        integrationHelpers.getDepositableNodeOperator(nextAddress());
+
+        bool enabled;
+        uint256 queueLimit;
+        uint256 queueLengthBefore;
+        (enabled, queueLimit, queueLengthBefore, ) = module.getTopUpQueue();
+        assertTrue(enabled);
+
+        if (queueLengthBefore == type(uint8).max) {
+            (uint256 noId, uint256 keyIndex, bytes memory pubkey) = integrationHelpers.getDepositableTopUpNodeOperator(
+                nextAddress()
+            );
+            (
+                uint256[] memory keyIndices,
+                uint256[] memory operatorIds,
+                bytes[] memory pubkeys,
+                uint256[] memory topUpLimits
+            ) = _singleTopUpArrays(noId, keyIndex, pubkey, 1 ether);
+
+            vm.prank(topUpGateway);
+            stakingRouter.topUp(moduleId, keyIndices, operatorIds, pubkeys, topUpLimits);
+
+            (, queueLimit, queueLengthBefore, ) = module.getTopUpQueue();
+        }
+
+        uint256 targetLimit = queueLengthBefore + 1;
+        if (queueLimit != targetLimit) {
+            if (!module.hasRole(module.MANAGE_TOP_UP_QUEUE_ROLE(), address(this))) {
+                module.grantRole(module.MANAGE_TOP_UP_QUEUE_ROLE(), address(this));
+            }
+            module.setTopUpQueueLimit(targetLimit);
+        }
+
+        uint256 queueLengthStart;
+        (, appliedLimit, queueLengthStart, ) = module.getTopUpQueue();
+        assertEq(appliedLimit, targetLimit);
+        assertEq(queueLengthStart + 1, appliedLimit);
+    }
+
+    function _depositOneThroughRouterAndAssertRequestedOne() internal returns (uint256 depositedAfter) {
+        (, uint256 depositedBefore, ) = module.getStakingModuleSummary();
+        uint256 requestedDeposits = _getExpectedRouterDepositRequestCount();
+        assertEq(requestedDeposits, 1);
+        vm.expectCall(
+            address(module),
+            abi.encodeWithSelector(module.obtainDepositData.selector, requestedDeposits, "")
+        );
+        vm.prank(locator.depositSecurityModule());
+        stakingRouter.deposit(moduleId, "");
+        (, depositedAfter, ) = module.getStakingModuleSummary();
+        assertEq(depositedAfter, depositedBefore + 1);
+    }
+
+    function _singleTopUpArrays(
+        uint256 noId,
+        uint256 keyIndex,
+        bytes memory pubkey,
+        uint256 topUpLimit
+    )
+        internal
+        pure
+        returns (
+            uint256[] memory keyIndices,
+            uint256[] memory operatorIds,
+            bytes[] memory pubkeys,
+            uint256[] memory topUpLimits
+        )
+    {
+        keyIndices = new uint256[](1);
+        keyIndices[0] = keyIndex;
+
+        operatorIds = new uint256[](1);
+        operatorIds[0] = noId;
+
+        pubkeys = new bytes[](1);
+        pubkeys[0] = pubkey;
+
+        topUpLimits = new uint256[](1);
+        topUpLimits[0] = topUpLimit;
+    }
+}

--- a/test/fork/integration/curated/DepositInfoRefresh.t.sol
+++ b/test/fork/integration/curated/DepositInfoRefresh.t.sol
@@ -1,0 +1,144 @@
+// SPDX-FileCopyrightText: 2026 Lido <info@lido.fi>
+// SPDX-License-Identifier: GPL-3.0
+
+pragma solidity 0.8.33;
+
+import { IMetaRegistry } from "src/interfaces/IMetaRegistry.sol";
+import { IBondCurve } from "src/interfaces/IBondCurve.sol";
+
+import { CuratedIntegrationBase } from "../common/ModuleTypeBase.sol";
+
+contract DepositInfoRefreshTestCurated is CuratedIntegrationBase {
+    function setUp() public {
+        _setUpModule();
+
+        address admin = metaRegistry.getRoleMember(metaRegistry.DEFAULT_ADMIN_ROLE(), 0);
+        vm.startPrank(admin);
+        metaRegistry.grantRole(metaRegistry.MANAGE_OPERATOR_GROUPS_ROLE(), address(this));
+        metaRegistry.grantRole(metaRegistry.SET_BOND_CURVE_WEIGHT_ROLE(), address(this));
+        vm.stopPrank();
+    }
+
+    function test_refreshAfterBondCurveWeightUpdate() public {
+        address noAddr = nextAddress("Operator");
+        uint256 noId = integrationHelpers.addNodeOperator(noAddr, 3);
+        uint256 curveId = accounting.getBondCurveId(noId);
+
+        // Verify operator can deposit before weight change
+        (, , uint256 depositableBefore) = module.getStakingModuleSummary();
+        assertGt(depositableBefore, 0, "should have depositable keys");
+
+        // Set weight to 0 — triggers requestFullDepositInfoUpdate
+        metaRegistry.setBondCurveWeight(curveId, 0);
+        metaRegistry.refreshOperatorWeight(noId);
+
+        // Deposit info is stale after weight change, run batch update
+        _runFullBatchUpdate();
+
+        // obtainDepositData should now return 0 keys (weight is zero)
+        vm.prank(address(stakingRouter));
+        (bytes memory pubkeys, ) = module.obtainDepositData(10, "");
+        assertEq(pubkeys.length, 0, "should not deposit with zero weight");
+
+        // Restore weight
+        metaRegistry.setBondCurveWeight(curveId, 1);
+        metaRegistry.refreshOperatorWeight(noId);
+
+        // Run batch update to refresh deposit info
+        _runFullBatchUpdate();
+
+        // Now deposits should work again
+        (, , uint256 depositableAfter) = module.getStakingModuleSummary();
+        assertGt(depositableAfter, 0, "should have depositable keys after weight restore");
+    }
+
+    function test_refreshAfterAccountingCurveUpdate() public {
+        address noAddr = nextAddress("Operator");
+        uint256 noId = integrationHelpers.addNodeOperator(noAddr, 3);
+        uint256 curveId = accounting.getBondCurveId(noId);
+
+        (, , uint256 depositableBefore) = module.getStakingModuleSummary();
+        assertGt(depositableBefore, 0, "should have depositable keys");
+
+        // Update the bond curve in Accounting (requires MANAGE_BOND_CURVES_ROLE)
+        address accAdmin = accounting.getRoleMember(accounting.DEFAULT_ADMIN_ROLE(), 0);
+        vm.startPrank(accAdmin);
+        accounting.grantRole(accounting.MANAGE_BOND_CURVES_ROLE(), address(this));
+        vm.stopPrank();
+
+        // Create a curve with a higher bond requirement
+        IBondCurve.BondCurveIntervalInput[] memory newCurve = new IBondCurve.BondCurveIntervalInput[](1);
+        newCurve[0] = IBondCurve.BondCurveIntervalInput({ minKeysCount: 1, trend: 64 ether });
+        accounting.updateBondCurve(curveId, newCurve);
+
+        // Run batch update to refresh deposit info
+        _runFullBatchUpdate();
+
+        // Depositable count may have decreased due to higher bond requirement
+        (, , uint256 depositableAfter) = module.getStakingModuleSummary();
+        // The exact count depends on the operator's existing bond vs new curve,
+        // but the batch update should complete without error
+    }
+
+    function test_refreshAfterGroupChange() public {
+        address addr1 = nextAddress("Op1");
+        address addr2 = nextAddress("Op2");
+        uint256 noId1 = integrationHelpers.addNodeOperator(addr1, 3);
+        uint256 noId2 = integrationHelpers.addNodeOperator(addr2, 3);
+
+        // Bump curve weight so mulDiv(weight, 5000, 10000) > 0
+        uint256 curveId = accounting.getBondCurveId(noId1);
+        if (metaRegistry.getBondCurveWeight(curveId) < 10000) {
+            metaRegistry.setBondCurveWeight(curveId, 10000);
+        }
+
+        // Remove both from their default groups
+        uint256 g1 = metaRegistry.getNodeOperatorGroupId(noId1);
+        uint256 g2 = metaRegistry.getNodeOperatorGroupId(noId2);
+        if (g1 != metaRegistry.NO_GROUP_ID()) _clearGroup(g1);
+        if (g2 != metaRegistry.NO_GROUP_ID() && g2 != g1) _clearGroup(g2);
+
+        _runFullBatchUpdate();
+
+        // Operators with no group have weight=0 → depositable=0
+        assertEq(metaRegistry.getNodeOperatorWeight(noId1), 0, "weight should be 0 outside group");
+
+        // Create a new group with both operators
+        IMetaRegistry.SubNodeOperator[] memory subs = new IMetaRegistry.SubNodeOperator[](2);
+        subs[0] = IMetaRegistry.SubNodeOperator({ nodeOperatorId: uint64(noId1), share: 5000 });
+        subs[1] = IMetaRegistry.SubNodeOperator({ nodeOperatorId: uint64(noId2), share: 5000 });
+
+        metaRegistry.createOrUpdateOperatorGroup(
+            metaRegistry.NO_GROUP_ID(),
+            IMetaRegistry.OperatorGroup({
+                subNodeOperators: subs,
+                externalOperators: new IMetaRegistry.ExternalOperator[](0)
+            })
+        );
+
+        _runFullBatchUpdate();
+
+        // Weights should now be positive
+        assertGt(metaRegistry.getNodeOperatorWeight(noId1), 0, "weight should be positive in group");
+        assertGt(metaRegistry.getNodeOperatorWeight(noId2), 0, "weight should be positive in group");
+    }
+
+    // ─── Helpers ─────────────────────────────────────────────────
+
+    function _clearGroup(uint256 groupId) internal {
+        metaRegistry.createOrUpdateOperatorGroup(
+            groupId,
+            IMetaRegistry.OperatorGroup({
+                subNodeOperators: new IMetaRegistry.SubNodeOperator[](0),
+                externalOperators: new IMetaRegistry.ExternalOperator[](0)
+            })
+        );
+    }
+
+    function _runFullBatchUpdate() internal {
+        uint256 operatorsLeft = module.batchDepositInfoUpdate(module.getNodeOperatorsCount());
+        while (operatorsLeft > 0) {
+            operatorsLeft = module.batchDepositInfoUpdate(operatorsLeft);
+        }
+    }
+}

--- a/test/fork/integration/curated/DepositInfoRefresh.t.sol
+++ b/test/fork/integration/curated/DepositInfoRefresh.t.sol
@@ -33,7 +33,7 @@ contract DepositInfoRefreshTestCurated is CuratedIntegrationBase {
         metaRegistry.refreshOperatorWeight(noId);
 
         // Deposit info is stale after weight change, run batch update
-        _runFullBatchUpdate();
+        integrationHelpers.runFullBatchDepositInfoUpdate();
 
         // obtainDepositData should now return 0 keys (weight is zero)
         vm.prank(address(stakingRouter));
@@ -45,7 +45,7 @@ contract DepositInfoRefreshTestCurated is CuratedIntegrationBase {
         metaRegistry.refreshOperatorWeight(noId);
 
         // Run batch update to refresh deposit info
-        _runFullBatchUpdate();
+        integrationHelpers.runFullBatchDepositInfoUpdate();
 
         // Now deposits should work again
         (, , uint256 depositableAfter) = module.getStakingModuleSummary();
@@ -72,7 +72,7 @@ contract DepositInfoRefreshTestCurated is CuratedIntegrationBase {
         accounting.updateBondCurve(curveId, newCurve);
 
         // Run batch update to refresh deposit info
-        _runFullBatchUpdate();
+        integrationHelpers.runFullBatchDepositInfoUpdate();
 
         // Depositable count may have decreased due to higher bond requirement
         (, , uint256 depositableAfter) = module.getStakingModuleSummary();
@@ -98,7 +98,7 @@ contract DepositInfoRefreshTestCurated is CuratedIntegrationBase {
         if (g1 != metaRegistry.NO_GROUP_ID()) _clearGroup(g1);
         if (g2 != metaRegistry.NO_GROUP_ID() && g2 != g1) _clearGroup(g2);
 
-        _runFullBatchUpdate();
+        integrationHelpers.runFullBatchDepositInfoUpdate();
 
         // Operators with no group have weight=0 → depositable=0
         assertEq(metaRegistry.getNodeOperatorWeight(noId1), 0, "weight should be 0 outside group");
@@ -116,7 +116,7 @@ contract DepositInfoRefreshTestCurated is CuratedIntegrationBase {
             })
         );
 
-        _runFullBatchUpdate();
+        integrationHelpers.runFullBatchDepositInfoUpdate();
 
         // Weights should now be positive
         assertGt(metaRegistry.getNodeOperatorWeight(noId1), 0, "weight should be positive in group");
@@ -133,12 +133,5 @@ contract DepositInfoRefreshTestCurated is CuratedIntegrationBase {
                 externalOperators: new IMetaRegistry.ExternalOperator[](0)
             })
         );
-    }
-
-    function _runFullBatchUpdate() internal {
-        uint256 operatorsLeft = module.batchDepositInfoUpdate(module.getNodeOperatorsCount());
-        while (operatorsLeft > 0) {
-            operatorsLeft = module.batchDepositInfoUpdate(operatorsLeft);
-        }
     }
 }

--- a/test/fork/integration/curated/MetaRegistry.t.sol
+++ b/test/fork/integration/curated/MetaRegistry.t.sol
@@ -1,0 +1,211 @@
+// SPDX-FileCopyrightText: 2026 Lido <info@lido.fi>
+// SPDX-License-Identifier: GPL-3.0
+
+pragma solidity 0.8.33;
+
+import { OperatorMetadata, IMetaRegistry } from "src/interfaces/IMetaRegistry.sol";
+import { CuratedIntegrationBase } from "../common/ModuleTypeBase.sol";
+
+contract MetaRegistryIntegrationTestCurated is CuratedIntegrationBase {
+    function setUp() public {
+        _setUpModule();
+
+        address admin = metaRegistry.getRoleMember(metaRegistry.DEFAULT_ADMIN_ROLE(), 0);
+        vm.startPrank(admin);
+        metaRegistry.grantRole(metaRegistry.SET_OPERATOR_INFO_ROLE(), address(this));
+        metaRegistry.grantRole(metaRegistry.MANAGE_OPERATOR_GROUPS_ROLE(), address(this));
+        metaRegistry.grantRole(metaRegistry.SET_BOND_CURVE_WEIGHT_ROLE(), address(this));
+        vm.stopPrank();
+    }
+
+    // ─── Metadata ────────────────────────────────────────────────
+
+    function test_setMetadataAsAdmin() public {
+        address noAddr = nextAddress("Operator");
+        uint256 noId = integrationHelpers.addNodeOperator(noAddr, 1);
+
+        OperatorMetadata memory meta = OperatorMetadata({
+            name: "AdminSetName",
+            description: "AdminSetDesc",
+            ownerEditsRestricted: true
+        });
+        metaRegistry.setOperatorMetadataAsAdmin(noId, meta);
+
+        OperatorMetadata memory stored = metaRegistry.getOperatorMetadata(noId);
+        assertEq(stored.name, meta.name);
+        assertEq(stored.description, meta.description);
+        assertTrue(stored.ownerEditsRestricted);
+    }
+
+    function test_setMetadataAsOwner() public {
+        address owner = nextAddress("Owner");
+        uint256 noId = integrationHelpers.addNodeOperator(owner, 1);
+
+        vm.prank(owner);
+        metaRegistry.setOperatorMetadataAsOwner(noId, "OwnerName", "OwnerDesc");
+
+        OperatorMetadata memory stored = metaRegistry.getOperatorMetadata(noId);
+        assertEq(stored.name, "OwnerName");
+        assertEq(stored.description, "OwnerDesc");
+    }
+
+    // ─── Operator Groups ─────────────────────────────────────────
+
+    function test_createOperatorGroup() public {
+        address noAddr = nextAddress("Operator");
+        uint256 noId = integrationHelpers.addNodeOperator(noAddr, 1);
+
+        // Remove from default group first
+        uint256 currentGroupId = metaRegistry.getNodeOperatorGroupId(noId);
+        if (currentGroupId != metaRegistry.NO_GROUP_ID()) {
+            _clearGroup(currentGroupId);
+        }
+
+        IMetaRegistry.SubNodeOperator[] memory subs = new IMetaRegistry.SubNodeOperator[](1);
+        subs[0] = IMetaRegistry.SubNodeOperator({ nodeOperatorId: uint64(noId), share: 10000 });
+
+        IMetaRegistry.OperatorGroup memory group = IMetaRegistry.OperatorGroup({
+            subNodeOperators: subs,
+            externalOperators: new IMetaRegistry.ExternalOperator[](0)
+        });
+
+        uint256 countBefore = metaRegistry.getOperatorGroupsCount();
+        metaRegistry.createOrUpdateOperatorGroup(metaRegistry.NO_GROUP_ID(), group);
+        uint256 countAfter = metaRegistry.getOperatorGroupsCount();
+
+        assertEq(countAfter, countBefore + 1);
+        uint256 newGroupId = countAfter - 1;
+        assertEq(metaRegistry.getNodeOperatorGroupId(noId), newGroupId);
+        assertGt(metaRegistry.getNodeOperatorWeight(noId), 0);
+    }
+
+    function test_updateOperatorGroup() public {
+        (uint256 noId1, uint256 noId2, uint256 groupId) = _createTwoOperatorGroup(5000, 5000);
+
+        uint256 weightBefore1 = metaRegistry.getNodeOperatorWeight(noId1);
+        uint256 weightBefore2 = metaRegistry.getNodeOperatorWeight(noId2);
+        assertEq(weightBefore1, weightBefore2);
+
+        // Update shares: 80/20
+        IMetaRegistry.SubNodeOperator[] memory subs = new IMetaRegistry.SubNodeOperator[](2);
+        subs[0] = IMetaRegistry.SubNodeOperator({ nodeOperatorId: uint64(noId1), share: 8000 });
+        subs[1] = IMetaRegistry.SubNodeOperator({ nodeOperatorId: uint64(noId2), share: 2000 });
+
+        metaRegistry.createOrUpdateOperatorGroup(
+            groupId,
+            IMetaRegistry.OperatorGroup({
+                subNodeOperators: subs,
+                externalOperators: new IMetaRegistry.ExternalOperator[](0)
+            })
+        );
+
+        uint256 weightAfter1 = metaRegistry.getNodeOperatorWeight(noId1);
+        uint256 weightAfter2 = metaRegistry.getNodeOperatorWeight(noId2);
+        assertGt(weightAfter1, weightAfter2);
+    }
+
+    function test_clearOperatorGroup() public {
+        address noAddr = nextAddress("Operator");
+        uint256 noId = integrationHelpers.addNodeOperator(noAddr, 1);
+
+        uint256 groupId = metaRegistry.getNodeOperatorGroupId(noId);
+        _clearGroup(groupId);
+
+        assertEq(metaRegistry.getNodeOperatorGroupId(noId), metaRegistry.NO_GROUP_ID());
+        assertEq(metaRegistry.getNodeOperatorWeight(noId), 0);
+
+        // Depositable count should be 0 when weight is 0
+        (, , uint256 depositableAfter) = module.getStakingModuleSummary();
+        // Weight=0 means no deposits can happen for this operator
+        // (global depositable may still be > 0 from other operators)
+    }
+
+    // ─── Bond Curve Weight ───────────────────────────────────────
+
+    function test_setBondCurveWeight() public {
+        address noAddr = nextAddress("Operator");
+        uint256 noId = integrationHelpers.addNodeOperator(noAddr, 1);
+        uint256 curveId = accounting.getBondCurveId(noId);
+
+        uint256 currentWeight = metaRegistry.getBondCurveWeight(curveId);
+        uint256 newWeight = currentWeight + 1;
+        uint256 nonceBefore = module.getNonce();
+
+        metaRegistry.setBondCurveWeight(curveId, newWeight);
+
+        assertEq(metaRegistry.getBondCurveWeight(curveId), newWeight);
+        // setBondCurveWeight triggers requestFullDepositInfoUpdate on the module
+        assertGt(module.getNonce(), nonceBefore);
+        assertEq(module.getNodeOperatorDepositInfoToUpdateCount(), module.getNodeOperatorsCount());
+    }
+
+    function test_refreshOperatorWeight() public {
+        address noAddr = nextAddress("Operator");
+        uint256 noId = integrationHelpers.addNodeOperator(noAddr, 1);
+        uint256 curveId = accounting.getBondCurveId(noId);
+
+        uint256 currentWeight = metaRegistry.getBondCurveWeight(curveId);
+        uint256 newWeight = currentWeight * 2 + 1;
+
+        // Change curve weight (does NOT auto-update operator weights)
+        metaRegistry.setBondCurveWeight(curveId, newWeight);
+
+        // Refresh must update the operator's effective weight
+        uint256 weightBefore = metaRegistry.getNodeOperatorWeight(noId);
+        metaRegistry.refreshOperatorWeight(noId);
+        uint256 weightAfter = metaRegistry.getNodeOperatorWeight(noId);
+
+        // Weight should have changed after refresh
+        assertTrue(weightAfter != weightBefore);
+        assertGt(weightAfter, 0);
+    }
+
+    // ─── Helpers ─────────────────────────────────────────────────
+
+    function _clearGroup(uint256 groupId) internal {
+        metaRegistry.createOrUpdateOperatorGroup(
+            groupId,
+            IMetaRegistry.OperatorGroup({
+                subNodeOperators: new IMetaRegistry.SubNodeOperator[](0),
+                externalOperators: new IMetaRegistry.ExternalOperator[](0)
+            })
+        );
+    }
+
+    function _createTwoOperatorGroup(
+        uint16 share1,
+        uint16 share2
+    ) internal returns (uint256 noId1, uint256 noId2, uint256 groupId) {
+        address addr1 = nextAddress("Op1");
+        address addr2 = nextAddress("Op2");
+        noId1 = integrationHelpers.addNodeOperator(addr1, 1);
+        noId2 = integrationHelpers.addNodeOperator(addr2, 1);
+
+        // Bump curve weight so mulDiv(weight, share, 10000) > 0 for fractional shares
+        uint256 curveId = accounting.getBondCurveId(noId1);
+        uint256 curveWeight = metaRegistry.getBondCurveWeight(curveId);
+        if (curveWeight < 10000) {
+            metaRegistry.setBondCurveWeight(curveId, 10000);
+        }
+
+        // Remove both from their default groups
+        uint256 g1 = metaRegistry.getNodeOperatorGroupId(noId1);
+        uint256 g2 = metaRegistry.getNodeOperatorGroupId(noId2);
+        if (g1 != metaRegistry.NO_GROUP_ID()) _clearGroup(g1);
+        if (g2 != metaRegistry.NO_GROUP_ID() && g2 != g1) _clearGroup(g2);
+
+        IMetaRegistry.SubNodeOperator[] memory subs = new IMetaRegistry.SubNodeOperator[](2);
+        subs[0] = IMetaRegistry.SubNodeOperator({ nodeOperatorId: uint64(noId1), share: share1 });
+        subs[1] = IMetaRegistry.SubNodeOperator({ nodeOperatorId: uint64(noId2), share: share2 });
+
+        uint256 countBefore = metaRegistry.getOperatorGroupsCount();
+        metaRegistry.createOrUpdateOperatorGroup(
+            metaRegistry.NO_GROUP_ID(),
+            IMetaRegistry.OperatorGroup({
+                subNodeOperators: subs,
+                externalOperators: new IMetaRegistry.ExternalOperator[](0)
+            })
+        );
+        groupId = countBefore; // new group gets index = old count
+    }
+}

--- a/test/fork/integration/curated/StakingRouter.t.sol
+++ b/test/fork/integration/curated/StakingRouter.t.sol
@@ -20,6 +20,10 @@ contract StakingRouterIntegrationTestCurated is StakingRouterIntegrationTestBase
 
     function setUp() public override {
         super.setUp();
+        if (!isStakingRouterUpgraded) {
+            // Skip: this suite depends on router/core v2 APIs and is not executable on the old router version.
+            vm.skip(true, "Suite requires upgraded staking router version for router/core v2 APIs");
+        }
 
         reporter = stakingRouter.getRoleMember(stakingRouter.REPORT_EXITED_VALIDATORS_ROLE(), 0);
         topUpGateway = locator.topUpGateway();

--- a/test/fork/integration/curated/StakingRouter.t.sol
+++ b/test/fork/integration/curated/StakingRouter.t.sol
@@ -1,0 +1,237 @@
+// SPDX-FileCopyrightText: 2026 Lido <info@lido.fi>
+// SPDX-License-Identifier: GPL-3.0
+
+pragma solidity 0.8.33;
+
+import { IBaseModule } from "src/interfaces/IBaseModule.sol";
+import { IStakingModuleV2 } from "src/interfaces/IStakingModule.sol";
+import { ICuratedModule } from "src/interfaces/ICuratedModule.sol";
+import { SigningKeys } from "src/lib/SigningKeys.sol";
+import { MetaRegistry } from "src/MetaRegistry.sol";
+
+import { CuratedIntegrationBase } from "../common/ModuleTypeBase.sol";
+import { StakingRouterIntegrationTestBase } from "../common/StakingRouter.t.sol";
+
+contract StakingRouterIntegrationTestCurated is StakingRouterIntegrationTestBase, CuratedIntegrationBase {
+    uint256 internal constant TOP_UP_ALLOCATION_PROBE_AMOUNT = 10_000_000 ether;
+
+    address internal reporter;
+    address internal topUpGateway;
+
+    function setUp() public override {
+        super.setUp();
+
+        reporter = stakingRouter.getRoleMember(stakingRouter.REPORT_EXITED_VALIDATORS_ROLE(), 0);
+        topUpGateway = locator.topUpGateway();
+
+        _maximizeModuleShare(moduleId);
+        _disableDepositsForOtherModules(moduleId);
+        hugeDeposit();
+        _ensureStakingRouterCanDeposit(moduleId);
+    }
+
+    function test_routerDeposit_happyPath_callsObtainDepositDataAndUsesReturnedCount() public assertInvariants {
+        integrationHelpers.getDepositableNodeOperator(nextAddress());
+
+        (, uint256 depositedBefore, ) = module.getStakingModuleSummary();
+
+        uint256 requestedDeposits = _getExpectedRouterDepositRequestCount();
+        assertGt(requestedDeposits, 0);
+        vm.expectCall(
+            address(module),
+            abi.encodeWithSelector(module.obtainDepositData.selector, requestedDeposits, "")
+        );
+        vm.prank(locator.depositSecurityModule());
+        stakingRouter.deposit(moduleId, "");
+
+        (, uint256 depositedAfter, ) = module.getStakingModuleSummary();
+        uint256 actualDeposits = depositedAfter - depositedBefore;
+        assertEq(depositedAfter - depositedBefore, actualDeposits);
+        assertGt(actualDeposits, 0);
+        assertLe(actualDeposits, requestedDeposits);
+    }
+
+    function test_routerDeposit_curatedCanReturnLessThanRequested() public assertInvariants {
+        integrationHelpers.getDepositableNodeOperator(nextAddress());
+
+        _setAllCuratedCurveWeightsToZero();
+
+        (, uint256 depositedBefore, ) = module.getStakingModuleSummary();
+
+        uint256 requestedDeposits = _getExpectedRouterDepositRequestCount();
+        assertGt(requestedDeposits, 0);
+        vm.expectCall(
+            address(module),
+            abi.encodeWithSelector(module.obtainDepositData.selector, requestedDeposits, "")
+        );
+        vm.prank(locator.depositSecurityModule());
+        stakingRouter.deposit(moduleId, "");
+
+        (, uint256 depositedAfter, ) = module.getStakingModuleSummary();
+        uint256 actualDeposits = depositedAfter - depositedBefore;
+        assertEq(depositedAfter - depositedBefore, actualDeposits);
+        assertLt(actualDeposits, requestedDeposits);
+    }
+
+    function test_routerTopUp_callsAllocateDeposits() public assertInvariants {
+        (uint256 noId, uint256 keyIndex, bytes memory pubkey) = integrationHelpers.getDepositableTopUpNodeOperator(
+            nextAddress()
+        );
+
+        (
+            uint256[] memory keyIndices,
+            uint256[] memory operatorIds,
+            bytes[] memory pubkeys,
+            uint256[] memory topUpLimits
+        ) = _singleTopUpArrays(noId, keyIndex, pubkey, 1 ether);
+
+        (uint256 expectedMaxDepositAmount, ) = stakingRouter.getTopUpAllocation(TOP_UP_ALLOCATION_PROBE_AMOUNT);
+        uint256 keyAddedBalanceBefore = module.getKeyAddedBalance(noId, keyIndex);
+        ICuratedModule curatedModule = ICuratedModule(address(module));
+        uint256 operatorBalanceBefore = curatedModule.getNodeOperatorBalance(noId);
+
+        vm.expectCall(
+            address(module),
+            abi.encodeWithSelector(
+                IStakingModuleV2.allocateDeposits.selector,
+                expectedMaxDepositAmount,
+                pubkeys,
+                keyIndices,
+                operatorIds,
+                topUpLimits
+            )
+        );
+
+        vm.prank(topUpGateway);
+        stakingRouter.topUp(moduleId, keyIndices, operatorIds, pubkeys, topUpLimits);
+
+        uint256 keyAddedBalanceAfter = module.getKeyAddedBalance(noId, keyIndex);
+        uint256 operatorBalanceAfter = curatedModule.getNodeOperatorBalance(noId);
+        uint256 keyDelta = keyAddedBalanceAfter - keyAddedBalanceBefore;
+        uint256 operatorDelta = operatorBalanceAfter - operatorBalanceBefore;
+
+        assertEq(operatorDelta, keyDelta);
+        assertLe(keyDelta, topUpLimits[0]);
+        assertLe(keyDelta, expectedMaxDepositAmount);
+        assertEq(keyDelta % 1 ether, 0);
+    }
+
+    function test_routerTopUp_subEtherLimitDoesNotAllocate() public assertInvariants {
+        (uint256 noId, uint256 keyIndex, bytes memory pubkey) = integrationHelpers.getDepositableTopUpNodeOperator(
+            nextAddress()
+        );
+
+        (
+            uint256[] memory keyIndices,
+            uint256[] memory operatorIds,
+            bytes[] memory pubkeys,
+            uint256[] memory topUpLimits
+        ) = _singleTopUpArrays(noId, keyIndex, pubkey, 0.5 ether);
+
+        ICuratedModule curatedModule = ICuratedModule(address(module));
+        uint256 keyAddedBalanceBefore = module.getKeyAddedBalance(noId, keyIndex);
+        uint256 operatorBalanceBefore = curatedModule.getNodeOperatorBalance(noId);
+
+        vm.prank(topUpGateway);
+        stakingRouter.topUp(moduleId, keyIndices, operatorIds, pubkeys, topUpLimits);
+
+        assertEq(module.getKeyAddedBalance(noId, keyIndex), keyAddedBalanceBefore);
+        assertEq(curatedModule.getNodeOperatorBalance(noId), operatorBalanceBefore);
+    }
+
+    function test_routerTopUp_revertsOnInvalidSigningKey() public {
+        (uint256 noId, uint256 keyIndex, ) = integrationHelpers.getDepositableTopUpNodeOperator(nextAddress());
+        bytes memory invalidPubkey = new bytes(48);
+        (
+            uint256[] memory keyIndices,
+            uint256[] memory operatorIds,
+            bytes[] memory pubkeys,
+            uint256[] memory topUpLimits
+        ) = _singleTopUpArrays(noId, keyIndex, invalidPubkey, 1 ether);
+
+        vm.expectRevert(SigningKeys.InvalidSigningKey.selector);
+        vm.prank(topUpGateway);
+        stakingRouter.topUp(moduleId, keyIndices, operatorIds, pubkeys, topUpLimits);
+    }
+
+    function test_reportStakingModuleOperatorBalances_callsUpdateOperatorBalances() public assertInvariants {
+        (uint256 noId, ) = integrationHelpers.getDepositableNodeOperator(nextAddress());
+
+        bytes memory nodeOperatorIds = _encodeNodeOperatorId(noId);
+        ICuratedModule curatedModule = ICuratedModule(address(module));
+        uint256 balanceBefore = curatedModule.getNodeOperatorBalance(noId);
+        uint256 balanceBeforeGwei = balanceBefore / 1 gwei;
+        uint256 reportedBalanceGwei = balanceBeforeGwei + 1;
+        bytes memory totalBalancesGwei = _encodeUint128Value(reportedBalanceGwei);
+
+        vm.expectCall(address(module), abi.encodeWithSelector(IStakingModuleV2.updateOperatorBalances.selector));
+
+        uint256 nonceBefore = module.getNonce();
+
+        vm.prank(reporter);
+        stakingRouter.reportStakingModuleOperatorBalances(moduleId, nodeOperatorIds, totalBalancesGwei);
+
+        assertEq(module.getNonce(), nonceBefore + 1);
+        uint256 balanceAfter = curatedModule.getNodeOperatorBalance(noId);
+        assertEq(balanceAfter, reportedBalanceGwei * 1 gwei);
+        assertTrue(balanceAfter != balanceBefore);
+    }
+
+    function test_reportStakingModuleOperatorBalances_revertsOnUnknownNodeOperator() public {
+        uint256 unknownNoId = module.getNodeOperatorsCount();
+        bytes memory nodeOperatorIds = _encodeNodeOperatorId(unknownNoId);
+        bytes memory totalBalancesGwei = _encodeUint128Value(1);
+
+        vm.expectRevert(IBaseModule.NodeOperatorDoesNotExist.selector);
+        vm.prank(reporter);
+        stakingRouter.reportStakingModuleOperatorBalances(moduleId, nodeOperatorIds, totalBalancesGwei);
+    }
+
+    function _singleTopUpArrays(
+        uint256 noId,
+        uint256 keyIndex,
+        bytes memory pubkey,
+        uint256 topUpLimit
+    )
+        internal
+        pure
+        returns (
+            uint256[] memory keyIndices,
+            uint256[] memory operatorIds,
+            bytes[] memory pubkeys,
+            uint256[] memory topUpLimits
+        )
+    {
+        keyIndices = new uint256[](1);
+        keyIndices[0] = keyIndex;
+
+        operatorIds = new uint256[](1);
+        operatorIds[0] = noId;
+
+        pubkeys = new bytes[](1);
+        pubkeys[0] = pubkey;
+
+        topUpLimits = new uint256[](1);
+        topUpLimits[0] = topUpLimit;
+    }
+
+    function _setAllCuratedCurveWeightsToZero() internal {
+        MetaRegistry registry = MetaRegistry(address(ICuratedModule(address(module)).META_REGISTRY()));
+
+        address admin = registry.getRoleMember(registry.DEFAULT_ADMIN_ROLE(), 0);
+        bytes32 role = registry.SET_BOND_CURVE_WEIGHT_ROLE();
+        if (!registry.hasRole(role, address(this))) {
+            vm.prank(admin);
+            registry.grantRole(role, address(this));
+        }
+
+        uint256 operatorsCount = module.getNodeOperatorsCount();
+        for (uint256 i; i < operatorsCount; ++i) {
+            uint256 curveId = accounting.getBondCurveId(i);
+            if (registry.getBondCurveWeight(curveId) != 0) {
+                registry.setBondCurveWeight(curveId, 0);
+            }
+            registry.refreshOperatorWeight(i);
+        }
+    }
+}

--- a/test/fork/utils/TwoPhaseFrameConfigUpdate.t.sol
+++ b/test/fork/utils/TwoPhaseFrameConfigUpdate.t.sol
@@ -108,7 +108,7 @@ contract TwoPhaseFrameConfigUpdateTest is Test, Utilities, DeploymentFixtures {
 
     function test_deployParams() public {
         Env memory env = envVars();
-        vm.skip(_isEmpty(env.UTILS_DEPLOY_CONFIG));
+        vm.skip(_isEmpty(env.UTILS_DEPLOY_CONFIG), "UTILS_DEPLOY_CONFIG is not set");
 
         string memory utilsConfig = vm.readFile(env.UTILS_DEPLOY_CONFIG);
         bytes memory encodedParams = vm.parseJsonBytes(utilsConfig, ".TwoPhaseFrameConfigUpdateParams");
@@ -181,7 +181,7 @@ contract TwoPhaseFrameConfigUpdateTest is Test, Utilities, DeploymentFixtures {
 
     function _utilsDeployBlockNumber(string memory utilsDeployConfigPath) internal returns (uint256 deployBlockNumber) {
         string memory transactionsPath = string.concat(_dirOf(utilsDeployConfigPath), "transactions.json");
-        vm.skip(!vm.exists(transactionsPath));
+        vm.skip(!vm.exists(transactionsPath), "transactions.json does not exist near UTILS_DEPLOY_CONFIG");
 
         string memory transactionsJson = vm.readFile(transactionsPath);
         string memory deployBlockNumberHex = vm.parseJsonString(transactionsJson, ".receipts[0].blockNumber");

--- a/test/fork/vote-upgrade/V3Upgrade.t.sol
+++ b/test/fork/vote-upgrade/V3Upgrade.t.sol
@@ -49,14 +49,14 @@ contract V3UpgradeTestBase is Test, Utilities, DeploymentFixtures, InvariantAsse
 
         string memory config = vm.readFile(env.DEPLOY_CONFIG);
         if (vm.keyExistsJson(config, ".CuratedModule")) {
-            vm.skip(true);
+            vm.skip(true, "Curated deployment config detected; this suite targets CSM upgrade flow");
         }
         if (
             vm.parseJsonAddress(config, ".VettedGateFactory") == address(0) &&
             vm.parseJsonAddress(config, ".VettedGate") == address(0) &&
             vm.parseJsonAddress(config, ".VettedGateImpl") == address(0)
         ) {
-            vm.skip(true);
+            vm.skip(true, "CSM0x02 deployment config detected; this suite targets legacy CSM upgrade flow");
         }
         deploymentConfig = parseDeploymentConfig(config);
         deployParams = parseDeployParams(env.DEPLOY_CONFIG);

--- a/test/helpers/Fixtures.sol
+++ b/test/helpers/Fixtures.sol
@@ -38,6 +38,7 @@ import { GIndex } from "src/lib/GIndex.sol";
 import { IACL } from "src/interfaces/IACL.sol";
 import { IKernel } from "src/interfaces/IKernel.sol";
 import { Batch } from "src/lib/DepositQueueLib.sol";
+import { BaseOracle } from "src/lib/base-oracle/BaseOracle.sol";
 
 import { Utilities } from "./Utilities.sol";
 import { MerkleTree } from "./MerkleTree.sol";
@@ -701,6 +702,46 @@ contract DeploymentHelpers is Test {
     }
 }
 
+interface IAccountingOracle {
+    struct ReportData {
+        uint256 consensusVersion;
+        uint256 refSlot;
+        uint256 clActiveBalanceGwei;
+        uint256 clPendingBalanceGwei;
+        uint256[] stakingModuleIdsWithNewlyExitedValidators;
+        uint256[] numExitedValidatorsByStakingModule;
+        uint256[] stakingModuleIdsWithUpdatedBalance;
+        uint256[] activeBalancesGweiByStakingModule;
+        uint256[] pendingBalancesGweiByStakingModule;
+        uint256 withdrawalVaultBalance;
+        uint256 elRewardsVaultBalance;
+        uint256 sharesRequestedToBurn;
+        uint256[] withdrawalFinalizationBatches;
+        uint256 simulatedShareRate;
+        bool isBunkerMode;
+        bytes32 vaultsDataTreeRoot;
+        string vaultsDataTreeCid;
+        uint256 extraDataFormat;
+        bytes32 extraDataHash;
+        uint256 extraDataItemsCount;
+    }
+
+    function getConsensusVersion() external view returns (uint256);
+
+    function getContractVersion() external view returns (uint256);
+
+    function submitReportData(ReportData calldata data, uint256 contractVersion) external;
+
+    function submitReportExtraDataEmpty() external;
+}
+
+interface ILidoBalanceStats {
+    function getBalanceStats()
+        external
+        view
+        returns (uint256 clActiveBalance, uint256 clPendingBalance, uint256 depositedBalance);
+}
+
 abstract contract DeploymentFixturesBase is StdCheats, DeploymentHelpers {
     enum ModuleType {
         Unknown,
@@ -746,6 +787,7 @@ abstract contract DeploymentFixturesBase is StdCheats, DeploymentHelpers {
     address[] public curatedGates;
 
     error ModuleNotFound();
+    error CannotEnableStakingRouterDeposits();
 
     function initializeFromDeployment() public {
         Env memory env = envVars();
@@ -881,6 +923,121 @@ abstract contract DeploymentFixturesBase is StdCheats, DeploymentHelpers {
         lido.submit{ value: 1e7 ether }(address(0));
     }
 
+    function _ensureStakingRouterCanDeposit(uint256 moduleId) internal {
+        if (stakingRouter.canDeposit(moduleId)) return;
+
+        IAccountingOracle accountingOracle = IAccountingOracle(locator.accountingOracle());
+        HashConsensus accountingConsensus = HashConsensus(BaseOracle(address(accountingOracle)).getConsensusContract());
+
+        _waitForNextRefSlot(accountingConsensus);
+
+        (uint256 refSlot, ) = accountingConsensus.getCurrentFrame();
+        uint256 consensusVersion = accountingOracle.getConsensusVersion();
+
+        (uint256 clActiveBalance, uint256 clPendingBalance, uint256 depositedBalance) = ILidoBalanceStats(address(lido))
+            .getBalanceStats();
+
+        IAccountingOracle.ReportData memory report = IAccountingOracle.ReportData({
+            consensusVersion: consensusVersion,
+            refSlot: refSlot,
+            clActiveBalanceGwei: clActiveBalance / 1 gwei,
+            clPendingBalanceGwei: (clPendingBalance + depositedBalance) / 1 gwei,
+            stakingModuleIdsWithNewlyExitedValidators: new uint256[](0),
+            numExitedValidatorsByStakingModule: new uint256[](0),
+            stakingModuleIdsWithUpdatedBalance: new uint256[](0),
+            activeBalancesGweiByStakingModule: new uint256[](0),
+            pendingBalancesGweiByStakingModule: new uint256[](0),
+            withdrawalVaultBalance: 0,
+            elRewardsVaultBalance: 0,
+            sharesRequestedToBurn: 0,
+            withdrawalFinalizationBatches: new uint256[](0),
+            simulatedShareRate: 0,
+            isBunkerMode: false,
+            vaultsDataTreeRoot: bytes32(0),
+            vaultsDataTreeCid: "",
+            extraDataFormat: 0,
+            extraDataHash: bytes32(0),
+            extraDataItemsCount: 0
+        });
+
+        bytes32 reportHash = keccak256(abi.encode(report));
+        (address[] memory members, ) = accountingConsensus.getFastLaneMembers();
+        if (members.length == 0) {
+            (members, ) = accountingConsensus.getMembers();
+        }
+        for (uint256 i = 0; i < members.length; ++i) {
+            vm.prank(members[i]);
+            accountingConsensus.submitReport(refSlot, reportHash, consensusVersion);
+        }
+
+        vm.startPrank(members[0]);
+        accountingOracle.submitReportData(report, accountingOracle.getContractVersion());
+        accountingOracle.submitReportExtraDataEmpty();
+        vm.stopPrank();
+
+        if (!stakingRouter.canDeposit(moduleId)) revert CannotEnableStakingRouterDeposits();
+    }
+
+    function _disableDepositsForOtherModules(uint256 targetModuleId) internal {
+        address manager = _getStakingModuleManager();
+        uint256[] memory moduleIds = stakingRouter.getStakingModuleIds();
+
+        vm.startPrank(manager);
+        for (uint256 i; i < moduleIds.length; ++i) {
+            uint256 id = moduleIds[i];
+            if (id == targetModuleId) continue;
+            if (stakingRouter.getStakingModuleStatus(id) != uint8(IStakingRouter.StakingModuleStatus.Active)) continue;
+            stakingRouter.setStakingModuleStatus(id, uint8(IStakingRouter.StakingModuleStatus.DepositsPaused));
+        }
+        vm.stopPrank();
+    }
+
+    function _maximizeModuleShare(uint256 targetModuleId) internal {
+        IStakingRouter.StakingModule memory m = stakingRouter.getStakingModule(targetModuleId);
+        uint256 fullShare = stakingRouter.TOTAL_BASIS_POINTS();
+        if (m.stakeShareLimit == fullShare && m.priorityExitShareThreshold == fullShare) return;
+
+        address manager = _getStakingModuleManager();
+        vm.prank(manager);
+        stakingRouter.updateStakingModule(
+            targetModuleId,
+            fullShare,
+            fullShare,
+            m.stakingModuleFee,
+            m.treasuryFee,
+            m.maxDepositsPerBlock,
+            m.minDepositBlockDistance
+        );
+    }
+
+    function _getStakingModuleManager() internal returns (address manager) {
+        uint256 managersCount = stakingRouter.getRoleMemberCount(stakingRouter.STAKING_MODULE_MANAGE_ROLE());
+        if (managersCount > 0) {
+            return stakingRouter.getRoleMember(stakingRouter.STAKING_MODULE_MANAGE_ROLE(), 0);
+        }
+
+        manager = stakingRouter.getRoleMember(stakingRouter.DEFAULT_ADMIN_ROLE(), 0);
+        bytes32 role = stakingRouter.STAKING_MODULE_MANAGE_ROLE();
+        vm.prank(manager);
+        stakingRouter.grantRole(role, manager);
+    }
+
+    function _waitForNextRefSlot(HashConsensus consensus) internal {
+        (uint256 slotsPerEpoch, uint256 secondsPerSlot, uint256 genesisTime) = consensus.getChainConfig();
+        (uint256 initialEpoch, , ) = consensus.getFrameConfig();
+        uint256 epoch = (block.timestamp - genesisTime) / secondsPerSlot / slotsPerEpoch;
+        if (epoch < initialEpoch) {
+            uint256 targetTime = genesisTime + 1 + initialEpoch * slotsPerEpoch * secondsPerSlot;
+            if (targetTime > block.timestamp) {
+                vm.warp(targetTime);
+            }
+        }
+        (uint256 refSlot, ) = consensus.getCurrentFrame();
+        (, uint256 epochsPerFrame, ) = consensus.getFrameConfig();
+        uint256 nextFrameTime = genesisTime + (refSlot + slotsPerEpoch * epochsPerFrame + 1) * secondsPerSlot;
+        if (nextFrameTime > block.timestamp) vm.warp(nextFrameTime);
+    }
+
     function findModule() internal view returns (uint256) {
         uint256[] memory ids = stakingRouter.getStakingModuleIds();
         for (uint256 i = ids.length - 1; i > 0; i--) {
@@ -912,6 +1069,10 @@ interface IForkIntegrationHelpers {
         address nodeOperatorAddress,
         uint256 keysCount
     ) external returns (uint256 noId, uint256 startIndex);
+
+    function getDepositableTopUpNodeOperator(
+        address nodeOperatorAddress
+    ) external returns (uint256 noId, uint256 keyIndex, bytes memory pubkey);
 }
 
 abstract contract ForkIntegrationHelpersBase is Utilities, IForkIntegrationHelpers {
@@ -976,6 +1137,7 @@ abstract contract ForkIntegrationHelpersBase is Utilities, IForkIntegrationHelpe
 
 contract CSMIntegrationHelpers is ForkIntegrationHelpersBase {
     PermissionlessGate internal permissionlessGate;
+    error TopUpQueueIsEmpty();
 
     constructor(
         CSModule module_,
@@ -1027,6 +1189,24 @@ contract CSMIntegrationHelpers is ForkIntegrationHelpersBase {
         }
         keysCount = 5;
         noId = _addNodeOperator(nodeOperatorAddress, keysCount);
+    }
+
+    function getDepositableTopUpNodeOperator(
+        address nodeOperatorAddress
+    ) external override returns (uint256 noId, uint256 keyIndex, bytes memory pubkey) {
+        (, , uint256 length, ) = module.getTopUpQueue();
+        if (length == 0) {
+            _addNodeOperator(nodeOperatorAddress, 1);
+            vm.startPrank(address(stakingRouter));
+            module.obtainDepositData(1, "");
+            vm.stopPrank();
+
+            (, , length, ) = module.getTopUpQueue();
+            if (length == 0) revert TopUpQueueIsEmpty();
+        }
+
+        (noId, keyIndex) = module.getTopUpQueueItem(0);
+        pubkey = module.getSigningKeys(noId, keyIndex, 1);
     }
 
     function _addNodeOperator(address from, uint256 keysCount) internal override returns (uint256 nodeOperatorId) {
@@ -1097,6 +1277,13 @@ contract CuratedIntegrationHelpers is ForkIntegrationHelpersBase {
     ) external override returns (uint256 noId, uint256 keysCount) {
         keysCount = 5;
         noId = _addNodeOperator(nodeOperatorAddress, keysCount);
+    }
+
+    function getDepositableTopUpNodeOperator(
+        address nodeOperatorAddress
+    ) external override returns (uint256 noId, uint256 keyIndex, bytes memory pubkey) {
+        (noId, keyIndex) = this.getDepositedNodeOperatorWithSequentialActiveKeys(nodeOperatorAddress, 1);
+        pubkey = module.getSigningKeys(noId, keyIndex, 1);
     }
 
     function _addNodeOperator(address from, uint256 keysCount) internal override returns (uint256 nodeOperatorId) {

--- a/test/helpers/Fixtures.sol
+++ b/test/helpers/Fixtures.sol
@@ -220,8 +220,8 @@ contract DeploymentHelpers is Test {
             vm.envOr("UTILS_DEPLOY_CONFIG", string("")),
             vm.envOr("VOTE_PREV_BLOCK", uint256(0))
         );
-        vm.skip(_isEmpty(env.RPC_URL));
-        vm.skip(_isEmpty(env.DEPLOY_CONFIG));
+        vm.skip(_isEmpty(env.RPC_URL), "RPC_URL is not set");
+        vm.skip(_isEmpty(env.DEPLOY_CONFIG), "DEPLOY_CONFIG is not set");
         return env;
     }
 
@@ -742,7 +742,14 @@ interface ILidoBalanceStats {
         returns (uint256 clActiveBalance, uint256 clPendingBalance, uint256 depositedBalance);
 }
 
+interface ILidoLegacyDeposit {
+    function deposit(uint256 _maxDepositsCount, uint256 _stakingModuleId, bytes calldata _depositCalldata) external;
+}
+
 abstract contract DeploymentFixturesBase is StdCheats, DeploymentHelpers {
+    uint256 internal constant STAKING_ROUTER_OLD_CONTRACT_VERSION = 3;
+    uint256 internal constant STAKING_ROUTER_NEW_CONTRACT_VERSION = STAKING_ROUTER_OLD_CONTRACT_VERSION + 1;
+
     enum ModuleType {
         Unknown,
         Community,
@@ -788,6 +795,14 @@ abstract contract DeploymentFixturesBase is StdCheats, DeploymentHelpers {
 
     error ModuleNotFound();
     error CannotEnableStakingRouterDeposits();
+
+    function _isStakingRouterUpgraded() internal view returns (bool) {
+        return stakingRouter.getContractVersion() >= STAKING_ROUTER_NEW_CONTRACT_VERSION;
+    }
+
+    function _legacyLidoDeposit(uint256 depositsCount, uint256 moduleId, bytes memory depositCalldata) internal {
+        ILidoLegacyDeposit(address(lido)).deposit(depositsCount, moduleId, depositCalldata);
+    }
 
     function initializeFromDeployment() public {
         Env memory env = envVars();
@@ -924,6 +939,7 @@ abstract contract DeploymentFixturesBase is StdCheats, DeploymentHelpers {
     }
 
     function _ensureStakingRouterCanDeposit(uint256 moduleId) internal {
+        if (!_isStakingRouterUpgraded()) return;
         if (stakingRouter.canDeposit(moduleId)) return;
 
         IAccountingOracle accountingOracle = IAccountingOracle(locator.accountingOracle());

--- a/test/helpers/Fixtures.sol
+++ b/test/helpers/Fixtures.sol
@@ -1089,6 +1089,8 @@ interface IForkIntegrationHelpers {
     function getDepositableTopUpNodeOperator(
         address nodeOperatorAddress
     ) external returns (uint256 noId, uint256 keyIndex, bytes memory pubkey);
+
+    function runFullBatchDepositInfoUpdate() external;
 }
 
 abstract contract ForkIntegrationHelpersBase is Utilities, IForkIntegrationHelpers {
@@ -1100,6 +1102,14 @@ abstract contract ForkIntegrationHelpersBase is Utilities, IForkIntegrationHelpe
         module = module_;
         accounting = accounting_;
         stakingRouter = stakingRouter_;
+    }
+
+    function runFullBatchDepositInfoUpdate() external {
+        uint256 batchSize = 10;
+        uint256 operatorsLeft = module.batchDepositInfoUpdate(batchSize);
+        while (operatorsLeft > 0) {
+            operatorsLeft = module.batchDepositInfoUpdate(batchSize);
+        }
     }
 
     function getDepositedNodeOperator(

--- a/test/unit/CSModule.t.sol
+++ b/test/unit/CSModule.t.sol
@@ -1277,7 +1277,7 @@ contract CSMTopUpQueue is CSMCommon {
         assertEq(keyIndex, 0);
 
         uint256 to = 1;
-        vm.expectEmit(true, true, true, true, address(csm));
+        vm.expectEmit(address(csm));
         emit ICSModule.TopUpQueueRewound(to);
         csm.rewindTopUpQueue(to);
         assertEq(_getTopUpQueueHead(), to);

--- a/test/unit/CSModule.t.sol
+++ b/test/unit/CSModule.t.sol
@@ -990,9 +990,6 @@ contract CSMTopUpQueue is CSMCommon {
         accounting.depositETH{ value: 100 ether }(0);
         uint256 bondBefore = accounting.getBond(0);
 
-        vm.prank(admin);
-        csm.grantRole(csm.REPORT_REGULAR_WITHDRAWN_VALIDATORS_ROLE(), address(this));
-
         WithdrawnValidatorInfo[] memory infos = new WithdrawnValidatorInfo[](1);
         infos[0] = WithdrawnValidatorInfo({
             nodeOperatorId: 0,
@@ -1847,8 +1844,9 @@ contract CSMRemoveKeysChargeFee is CSMCommon {
     }
 
     function test_removeKeys_withNoFee() public assertInvariants {
+        ParametersRegistryMock registry = parametersRegistry;
         vm.prank(admin);
-        module.PARAMETERS_REGISTRY().setKeyRemovalCharge(0, 0);
+        registry.setKeyRemovalCharge(0, 0);
 
         uint256 noId = createNodeOperator(3);
 

--- a/test/unit/CuratedModule.t.sol
+++ b/test/unit/CuratedModule.t.sol
@@ -1710,7 +1710,7 @@ contract CuratedAccessControl is ModuleAccessControl, CuratedCommonNoRoles {}
 
 contract CuratedStakingRouterAccessControl is ModuleStakingRouterAccessControl, CuratedCommonNoRoles {
     function test_stakingRouterRole_onWithdrawalCredentialsChanged_noDepositable() public override {
-        vm.skip(true);
+        vm.skip(true, "Legacy no-depositable withdrawal-credentials path is not applicable for Curated module");
     }
 
     function test_stakingRouterRole_onWithdrawalCredentialsChanged_withDepositable() public {

--- a/test/unit/MerkleGateFactory.t.sol
+++ b/test/unit/MerkleGateFactory.t.sol
@@ -34,9 +34,10 @@ contract MerkleGateFactoryTest is Test, Utilities {
         CSMMock csm = new CSMMock();
         address impl = address(new VettedGate(address(csm)));
         MerkleGateFactory factory = new MerkleGateFactory(impl);
+        address expectedInstance = vm.computeCreateAddress(address(factory), vm.getNonce(address(factory)));
 
-        vm.expectEmit(false, true, true, true, address(factory));
-        emit IMerkleGateFactory.MerkleGateCreated(address(0), admin, curveId);
+        vm.expectEmit(address(factory));
+        emit IMerkleGateFactory.MerkleGateCreated(expectedInstance, admin, curveId);
 
         address instance = factory.create(curveId, root, cid, admin);
         IVettedGate gate = IVettedGate(instance);
@@ -61,9 +62,10 @@ contract MerkleGateFactoryTest is Test, Utilities {
 
         address impl = address(new CuratedGate(address(module)));
         MerkleGateFactory factory = new MerkleGateFactory(impl);
+        address expectedInstance = vm.computeCreateAddress(address(factory), vm.getNonce(address(factory)));
 
-        vm.expectEmit(false, true, true, true, address(factory));
-        emit IMerkleGateFactory.MerkleGateCreated(address(0), admin, curveId);
+        vm.expectEmit(address(factory));
+        emit IMerkleGateFactory.MerkleGateCreated(expectedInstance, admin, curveId);
 
         address instance = factory.create(curveId, root, cid, admin);
         ICuratedGate gate = ICuratedGate(instance);
@@ -94,10 +96,11 @@ contract MerkleGateFactoryTest is Test, Utilities {
         assertEq(factory.GATE_IMPL(), impl);
 
         address secondImpl = address(new VettedGate(address(new CSMMock())));
+        address expectedInstance = vm.computeCreateAddress(address(factory), vm.getNonce(address(factory)));
 
         // The factory should always use its immutable implementation.
-        vm.expectEmit(false, true, true, true, address(factory));
-        emit IMerkleGateFactory.MerkleGateCreated(address(0), admin, curveId);
+        vm.expectEmit(address(factory));
+        emit IMerkleGateFactory.MerkleGateCreated(expectedInstance, admin, curveId);
 
         address instance = factory.create(curveId, root, cid, admin);
         OssifiableProxy proxy = OssifiableProxy(payable(instance));


### PR DESCRIPTION
## Description

- Fix deployment-time staking module wiring and module-type handling across deploy and vote simulation scripts.
- Update staking-router-related interfaces, fixtures, and devnet config defaults, including meta-registry weight and leeway handling.
- Add and adjust staking router fork/integration coverage across common, curated, `csm`, and `csm0x02` test suites.
- Skip newly introduced staking router tests in flows where execution is not yet supported.

## Checklist

- [x] Appropriate PR labels applied
- [ ] Test coverage maintained (`just coverage`)
  - [ ] No need to add/update tests
  - [x] Tests are added/updated
- [x] Documentation maintained
  - [x] No need to update
  - [ ] Updated
