### PR TITLE
chore: Squeeze bytecode further

### DIFF
--- a/src/CSModule.sol
+++ b/src/CSModule.sol
@@ -113,7 +113,7 @@ contract CSModule is ICSModule, BaseModule {
         uint256 depositsLeft = depositsCount;
         uint256 loadedKeysCount = 0;
 
-        bool topUpQueueEnabled = _topUpQueue().enabled;
+        bool topUpQueueEnabled = _topUpQueueEnabled();
         DepositQueueLib.Queue storage depositQueue;
         // NOTE: The highest priority to start iterations with. Priorities are ordered like 0, 1, 2, ...
         uint256 priority = 0;
@@ -288,8 +288,7 @@ contract CSModule is ICSModule, BaseModule {
         if (limit == 0) {
             revert ZeroTopUpQueueLimit();
         }
-        uint8 currentLimit = _topUpQueue().limit;
-        if (limit == currentLimit) {
+        if (limit == _topUpQueue().limit) {
             revert SameTopUpQueueLimit();
         }
         _topUpQueue().limit = limit.toUint8();
@@ -320,9 +319,8 @@ contract CSModule is ICSModule, BaseModule {
         // The Node Operator is charged for the every removed key. It's motivated by the fact that the DAO should cleanup
         // the queue from the empty batches related to the Node Operator. It's possible to have multiple batches with only one
         // key in it, so it means the DAO should be able to cover removal costs for as much batches as keys removed in this case.
-        uint256 curveId = _getBondCurveId(nodeOperatorId);
-        uint256 amountToCharge = PARAMETERS_REGISTRY.getKeyRemovalCharge(
-            curveId
+        uint256 amountToCharge = _parametersRegistry().getKeyRemovalCharge(
+            _getBondCurveId(nodeOperatorId)
         ) * keysCount;
 
         if (amountToCharge != 0) {
@@ -409,7 +407,7 @@ contract CSModule is ICSModule, BaseModule {
         totalExitedValidators = _totalExitedValidators;
         totalDepositedValidators = _totalDepositedValidators;
         depositableValidatorsCount = _depositableValidatorsCount;
-        if (_topUpQueue().enabled) {
+        if (_topUpQueueEnabled()) {
             depositableValidatorsCount = Math.min(
                 depositableValidatorsCount,
                 _topUpQueue().capacity()
@@ -477,7 +475,7 @@ contract CSModule is ICSModule, BaseModule {
         DepositQueueOps.enqueueNodeOperatorKeys({
             nodeOperators: _nodeOperators,
             depositQueues: _depositQueueByPriority,
-            parametersRegistry: PARAMETERS_REGISTRY,
+            parametersRegistry: _parametersRegistry(),
             accounting: _accounting(),
             queueLowestPriority: _queueLowestPriority(),
             nodeOperatorId: nodeOperatorId
@@ -495,7 +493,7 @@ contract CSModule is ICSModule, BaseModule {
     }
 
     function _onlyEnabledTopUpQueue() internal view {
-        if (!_topUpQueue().enabled) {
+        if (!_topUpQueueEnabled()) {
             revert TopUpQueueDisabled();
         }
     }
@@ -503,6 +501,10 @@ contract CSModule is ICSModule, BaseModule {
     function _topUpQueue() internal view returns (TopUpQueueLib.Queue storage) {
         CSModuleStorage storage $ = _storage();
         return $.topUpQueue;
+    }
+
+    function _topUpQueueEnabled() internal view returns (bool enabled) {
+        enabled = _topUpQueue().enabled;
     }
 
     /// @dev This function is used to get the queue lowest priority from immutables to save bytecode.

--- a/src/abstract/BaseModule.sol
+++ b/src/abstract/BaseModule.sol
@@ -163,7 +163,7 @@ abstract contract BaseModule is
         NodeOperatorManagementProperties calldata managementProperties,
         address referrer
     ) external whenResumed returns (uint256 nodeOperatorId) {
-        _checkRole(CREATE_NODE_OPERATOR_ROLE);
+        _checkCreateNodeOperatorRole();
         nodeOperatorId = _nodeOperatorsCount;
         OperatorTracker.recordCreator(nodeOperatorId);
         NodeOperatorOps.createNodeOperator({
@@ -194,7 +194,7 @@ abstract contract BaseModule is
 
         if (
             msg.value <
-            accounting.getRequiredBondForNextKeys(nodeOperatorId, keysCount)
+            _getRequiredBondForNextKeys(accounting, nodeOperatorId, keysCount)
         ) {
             revert InvalidAmount();
         }
@@ -224,7 +224,8 @@ abstract contract BaseModule is
 
         IAccounting accounting = _accounting();
 
-        uint256 amount = accounting.getRequiredBondForNextKeys(
+        uint256 amount = _getRequiredBondForNextKeys(
+            accounting,
             nodeOperatorId,
             keysCount
         );
@@ -454,7 +455,7 @@ abstract contract BaseModule is
         uint256 amount,
         string calldata details
     ) external {
-        _checkRole(REPORT_GENERAL_DELAYED_PENALTY_ROLE);
+        _checkReportGeneralDelayedPenaltyRole();
         _onlyExistingNodeOperator(nodeOperatorId);
         GeneralPenalty.reportGeneralDelayedPenalty(
             nodeOperatorId,
@@ -469,7 +470,7 @@ abstract contract BaseModule is
         uint256 nodeOperatorId,
         uint256 amount
     ) external {
-        _checkRole(REPORT_GENERAL_DELAYED_PENALTY_ROLE);
+        _checkReportGeneralDelayedPenaltyRole();
         _onlyExistingNodeOperator(nodeOperatorId);
         GeneralPenalty.cancelGeneralDelayedPenalty(nodeOperatorId, amount);
     }
@@ -520,7 +521,7 @@ abstract contract BaseModule is
         uint256 nodeOperatorId,
         uint256 keyIndex
     ) external {
-        _checkRole(VERIFIER_ROLE);
+        _checkVerifierRole();
         _onlyExistingNodeOperator(nodeOperatorId);
         NodeOperator storage no = _nodeOperators[nodeOperatorId];
         if (keyIndex >= no.totalDepositedKeys) {
@@ -543,7 +544,7 @@ abstract contract BaseModule is
         uint256 keyIndex,
         uint256 amount
     ) external {
-        _checkRole(VERIFIER_ROLE);
+        _checkVerifierRole();
         _onlyExistingNodeOperator(nodeOperatorId);
 
         NodeOperatorOps.increaseKeyAddedBalance({
@@ -710,7 +711,7 @@ abstract contract BaseModule is
         uint256 nodeOperatorId,
         uint256 startIndex,
         uint256 keysCount
-    ) external view returns (bytes memory) {
+    ) external view returns (bytes memory keys) {
         _onlyValidIndexRange(nodeOperatorId, startIndex, keysCount);
 
         return SigningKeys.loadKeys(nodeOperatorId, startIndex, keysCount);
@@ -793,7 +794,7 @@ abstract contract BaseModule is
     ) external view returns (uint256) {
         _onlyExistingNodeOperator(nodeOperatorId);
         return
-            PARAMETERS_REGISTRY.getAllowedExitDelay(
+            _parametersRegistry().getAllowedExitDelay(
                 _getBondCurveId(nodeOperatorId)
             );
     }
@@ -896,8 +897,9 @@ abstract contract BaseModule is
         NodeOperator storage no = _nodeOperators[nodeOperatorId];
         uint256 totalAddedKeys = no.totalAddedKeys;
 
-        uint256 curveId = _getBondCurveId(nodeOperatorId);
-        uint256 keysLimit = PARAMETERS_REGISTRY.getKeysLimit(curveId);
+        uint256 keysLimit = _parametersRegistry().getKeysLimit(
+            _getBondCurveId(nodeOperatorId)
+        );
 
         unchecked {
             if (
@@ -1038,7 +1040,7 @@ abstract contract BaseModule is
             _onlyNodeOperatorManager(nodeOperatorId, msg.sender);
         } else {
             // We're trying to add keys via gate, check if we can do it.
-            _checkRole(CREATE_NODE_OPERATOR_ROLE);
+            _checkCreateNodeOperatorRole();
             if (OperatorTracker.getCreator(nodeOperatorId) != msg.sender) {
                 revert CannotAddKeys();
             }
@@ -1086,8 +1088,31 @@ abstract contract BaseModule is
         return _accounting().getBondCurveId(nodeOperatorId);
     }
 
+    function _getRequiredBondForNextKeys(
+        IAccounting accounting,
+        uint256 nodeOperatorId,
+        uint256 keysCount
+    ) internal view returns (uint256 amount) {
+        amount = accounting.getRequiredBondForNextKeys(
+            nodeOperatorId,
+            keysCount
+        );
+    }
+
     function _checkStakingRouterRole() internal view {
         _checkRole(STAKING_ROUTER_ROLE);
+    }
+
+    function _checkReportGeneralDelayedPenaltyRole() internal view {
+        _checkRole(REPORT_GENERAL_DELAYED_PENALTY_ROLE);
+    }
+
+    function _checkVerifierRole() internal view {
+        _checkRole(VERIFIER_ROLE);
+    }
+
+    function _checkCreateNodeOperatorRole() internal view {
+        _checkRole(CREATE_NODE_OPERATOR_ROLE);
     }
 
     /// @dev This function is used to get the accounting contract from immutables to save bytecode.
@@ -1098,6 +1123,11 @@ abstract contract BaseModule is
     /// @dev This function is used to get the exit penalties contract from immutables to save bytecode.
     function _exitPenalties() internal view returns (IExitPenalties) {
         return EXIT_PENALTIES;
+    }
+
+    /// @dev This function is used to get the parameters registry contract from immutables to save bytecode.
+    function _parametersRegistry() internal view returns (IParametersRegistry) {
+        return PARAMETERS_REGISTRY;
     }
 
     function _onlyRecoverer() internal view override {


### PR DESCRIPTION
## Description
Before:
```
╭----------------------------+------------------+-------------------+--------------------+---------------------╮
| Contract                   | Runtime Size (B) | Initcode Size (B) | Runtime Margin (B) | Initcode Margin (B) |
+==============================================================================================================+
| CSModule                   | 24,481           | 25,618            | 95                 | 23,534              |
|----------------------------+------------------+-------------------+--------------------+---------------------|
| CuratedModule              | 23,734           | 24,721            | 842                | 24,431              |
╰----------------------------+------------------+-------------------+--------------------+---------------------╯
```

After:
```
╭----------------------------+------------------+-------------------+--------------------+---------------------╮
| Contract                   | Runtime Size (B) | Initcode Size (B) | Runtime Margin (B) | Initcode Margin (B) |
+==============================================================================================================+
| CSModule                   | 24,281           | 25,397            | 295                | 23,755              |
|----------------------------+------------------+-------------------+--------------------+---------------------|
| CuratedModule              | 23,616           | 24,596            | 960                | 24,556              |
╰----------------------------+------------------+-------------------+--------------------+---------------------╯
```

## Checklist

- [x] Appropriate PR labels applied
- [x] Test coverage maintained (`just coverage`)
  - [x] No need to add/update tests
- [x] Documentation maintained
  - [x] No need to update
