### PR TITLE
test: guard CSM upgrade against shrinking queue priority range

### DIFF
--- a/test/fork/vote-upgrade/V3Upgrade.t.sol
+++ b/test/fork/vote-upgrade/V3Upgrade.t.sol
@@ -146,6 +146,16 @@ contract VoteChangesTest is V3UpgradeTestBase {
         assertEq(totalNodeOperatorsBefore, totalNodeOperatorsAfter);
     }
 
+    function test_csmQueuePriorityRange() public {
+        vm.selectFork(forkIdBeforeUpgrade);
+        uint256 queueLowestPriorityBefore = module.QUEUE_LOWEST_PRIORITY();
+
+        vm.selectFork(forkIdAfterUpgrade);
+        uint256 queueLowestPriorityAfter = module.QUEUE_LOWEST_PRIORITY();
+
+        assertGe(queueLowestPriorityAfter, queueLowestPriorityBefore, "queue priority range shrunk");
+    }
+
     function test_csmStorageSlotsBeforeUpgrade() public {
         vm.selectFork(forkIdBeforeUpgrade);
         bytes32 slot3 = vm.load(address(module), bytes32(uint256(3)));
@@ -215,7 +225,7 @@ contract VoteChangesTest is V3UpgradeTestBase {
         beforeValue = parametersRegistry.QUEUE_LOWEST_PRIORITY();
         vm.selectFork(forkIdAfterUpgrade);
         afterValue = parametersRegistry.QUEUE_LOWEST_PRIORITY();
-        assertEq(beforeValue, afterValue, "queueLowestPriority");
+        assertGe(afterValue, beforeValue, "queueLowestPriority");
 
         vm.selectFork(forkIdBeforeUpgrade);
         beforeValue = parametersRegistry.defaultKeyRemovalCharge();


### PR DESCRIPTION
## Description

Guard CSM upgrade against shrinking queue priority range.

## Checklist

- [x] Appropriate PR labels applied
- [x] Test coverage maintained (`just coverage`)
  - [ ] No need to add/update tests
  - [x] Tests are added/updated
- [x] Documentation maintained
  - [x] No need to update
  - [ ] Updated
