### PR TITLE
fix: todos for allocations

### DIFF
--- a/src/CSModule.sol
+++ b/src/CSModule.sol
@@ -324,7 +324,7 @@ contract CSModule is ICSModule, BaseModule {
     /// @dev The function does nothing in CSM, since the information about the operator balances is not used in the
     ///      module. If it becomes needed in the future, the method should be implemented and the oracle should deliver
     ///      the actual balances.
-    function updateOperatorBalances(uint256[] calldata, uint256[] calldata, uint256) external {
+    function updateOperatorBalances(bytes calldata, bytes calldata) external {
         // NOTE: The function does nothing in CSM, see the docstring.
     }
 

--- a/src/CuratedModule.sol
+++ b/src/CuratedModule.sol
@@ -14,6 +14,7 @@ import { NOAddresses } from "./lib/NOAddresses.sol";
 import { SigningKeys } from "./lib/SigningKeys.sol";
 import { TransientUintUintMap, TransientUintUintMapLib } from "./lib/TransientUintUintMapLib.sol";
 import { CuratedDepositAllocator } from "./lib/allocator/CuratedDepositAllocator.sol";
+import { CuratedOperatorBalancesOps } from "./lib/CuratedOperatorBalancesOps.sol";
 import { NodeOperatorOps } from "./lib/NodeOperatorOps.sol";
 
 contract CuratedModule is ICuratedModule, BaseModule {
@@ -90,7 +91,11 @@ contract CuratedModule is ICuratedModule, BaseModule {
             no.depositableValidatorsCount = depositableValidatorsCount;
             emit DepositableSigningKeysCountChanged(operatorId, depositableValidatorsCount);
 
-            _increaseOperatorBalance($, operatorId, allocation * CuratedDepositAllocator.MIN_ACTIVATION_BALANCE);
+            CuratedOperatorBalancesOps.increaseBalance(
+                $.operatorBalances,
+                operatorId,
+                allocation * CuratedDepositAllocator.MIN_ACTIVATION_BALANCE
+            );
         }
         unchecked {
             _depositableValidatorsCount -= uint64(allocated);
@@ -119,14 +124,21 @@ contract CuratedModule is ICuratedModule, BaseModule {
             revert InvalidInput();
         }
 
-        // NOTE: StakingRouter is expected to provide per-key top-up limits capped
-        // by MAX_EFFECTIVE_BALANCE and avoid duplicate (operatorId, keyIndex)
+        // NOTE: StakingRouter is expected to avoid duplicate (operatorId, keyIndex)
         // entries in a single request.
 
         _validateTopUpPublicKeys(pubkeys, keyIndices, operatorIds);
-        allocations = _allocateTopUps(maxDepositAmount, operatorIds, keyIndices, topUpLimits);
 
-        // TODO: Do we need to check for zero allocations here?
+        // Cap top-ups so we don't over-allocate to keys that lost balance due to CL penalties.
+        uint256[] memory cappedTopUpLimits = NodeOperatorOps.capTopUpLimitsByKeyBalance(
+            _keyAddedBalances,
+            operatorIds,
+            keyIndices,
+            topUpLimits
+        );
+
+        allocations = _allocateTopUps(maxDepositAmount, operatorIds, keyIndices, cappedTopUpLimits);
+
         _incrementModuleNonce();
     }
 
@@ -137,21 +149,12 @@ contract CuratedModule is ICuratedModule, BaseModule {
         uint256 /* refSlot */
     ) external {
         _checkStakingRouterRole();
-        // TODO: Move operator balances ops into internal lib
-        uint256 operatorsCount = operatorIds.length;
-        if (operatorsCount != totalBalancesGwei.length) {
-            revert InvalidInput();
-        }
-
-        CuratedModuleStorage storage $ = _storage();
-        uint256 nodeOperatorsCount = _nodeOperatorsCount;
-
-        for (uint256 i; i < operatorsCount; ++i) {
-            uint256 operatorId = operatorIds[i];
-            if (operatorId >= nodeOperatorsCount) revert NodeOperatorDoesNotExist();
-
-            _setOperatorBalance($, operatorId, totalBalancesGwei[i] * 1 gwei);
-        }
+        CuratedOperatorBalancesOps.applyReportedBalances(
+            _storage().operatorBalances,
+            _nodeOperatorsCount,
+            operatorIds,
+            totalBalancesGwei
+        );
         _incrementModuleNonce();
     }
 
@@ -246,13 +249,10 @@ contract CuratedModule is ICuratedModule, BaseModule {
         uint256[] calldata operatorIds
     ) internal view {
         for (uint256 i; i < pubkeys.length; ++i) {
-            // TODO: Move to NodeOperatorOps and unify with CSM
             uint256 operatorId = operatorIds[i];
             uint256 keyIndex = keyIndices[i];
             if (keyIndex >= _nodeOperators[operatorId].totalDepositedKeys) revert SigningKeysInvalidOffset();
-            if (keccak256(pubkeys[i]) != keccak256(SigningKeys.loadKeys(operatorId, keyIndex, 1))) {
-                revert PubkeyMismatch();
-            }
+            SigningKeys.verifySigningKey(operatorId, keyIndex, pubkeys[i]);
         }
     }
 
@@ -260,7 +260,7 @@ contract CuratedModule is ICuratedModule, BaseModule {
         uint256 maxDepositAmount,
         uint256[] calldata operatorIds,
         uint256[] calldata keyIndices,
-        uint256[] calldata topUpLimits
+        uint256[] memory topUpLimits
     ) internal returns (uint256[] memory allocations) {
         uint256[] memory uniqueOperatorIds = _uniqueOperatorIds(operatorIds);
         (, uint256[] memory allocatedOperatorIds, uint256[] memory operatorAllocations) = CuratedDepositAllocator
@@ -272,8 +272,6 @@ contract CuratedModule is ICuratedModule, BaseModule {
                 operatorIds: uniqueOperatorIds
             });
 
-        // TODO: Add capped top-up limits like in CSM
-
         uint256[] memory perOperatorIncrements;
         (allocations, perOperatorIncrements) = NodeOperatorOps.distributeTopUpAllocations({
             operatorIds: operatorIds,
@@ -284,10 +282,11 @@ contract CuratedModule is ICuratedModule, BaseModule {
         });
 
         NodeOperatorOps.increaseKeyAddedBalancesByAllocations(_keyAddedBalances, operatorIds, keyIndices, allocations);
-        _increaseOperatorBalancesByAllocations({
-            uniqueOperatorIds: uniqueOperatorIds,
-            perOperatorIncrements: perOperatorIncrements
-        });
+        CuratedOperatorBalancesOps.increaseByAllocations(
+            _storage().operatorBalances,
+            uniqueOperatorIds,
+            perOperatorIncrements
+        );
     }
 
     /// @dev Deduplicate operator ids for allocation to avoid overweighting by repeated keys.
@@ -309,32 +308,6 @@ contract CuratedModule is ICuratedModule, BaseModule {
                 mstore(uniqueOperatorIds, count)
             }
         }
-    }
-
-    function _increaseOperatorBalancesByAllocations(
-        uint256[] memory uniqueOperatorIds,
-        uint256[] memory perOperatorIncrements
-    ) internal {
-        CuratedModuleStorage storage $ = _storage();
-        for (uint256 i; i < uniqueOperatorIds.length; ++i) {
-            uint256 operatorId = uniqueOperatorIds[i];
-            uint256 increment = perOperatorIncrements[operatorId];
-            if (increment == 0) continue;
-            _increaseOperatorBalance($, operatorId, increment);
-        }
-    }
-
-    function _increaseOperatorBalance(
-        CuratedModuleStorage storage $,
-        uint256 operatorId,
-        uint256 incrementWei
-    ) internal {
-        _setOperatorBalance($, operatorId, $.operatorBalances[operatorId] + incrementWei);
-    }
-
-    function _setOperatorBalance(CuratedModuleStorage storage $, uint256 operatorId, uint256 balanceWei) internal {
-        $.operatorBalances[operatorId] = balanceWei;
-        emit NodeOperatorBalanceUpdated(operatorId, balanceWei);
     }
 
     function _metaRegistry() internal view returns (IMetaRegistry) {

--- a/src/CuratedModule.sol
+++ b/src/CuratedModule.sol
@@ -143,11 +143,7 @@ contract CuratedModule is ICuratedModule, BaseModule {
     }
 
     /// @inheritdoc IStakingModuleV2
-    function updateOperatorBalances(
-        uint256[] calldata operatorIds,
-        uint256[] calldata totalBalancesGwei,
-        uint256 /* refSlot */
-    ) external {
+    function updateOperatorBalances(bytes calldata operatorIds, bytes calldata totalBalancesGwei) external {
         _checkStakingRouterRole();
         CuratedOperatorBalancesOps.applyReportedBalances(
             _storage().operatorBalances,

--- a/src/Verifier.sol
+++ b/src/Verifier.sol
@@ -339,6 +339,7 @@ contract Verifier is IVerifier, AccessControlEnumerable, PausableUntil {
     ) external whenResumed {
         MODULE.increaseKeyAddedBalance(nodeOperatorId, keyIndex, addedBalanceWei);
         // TODO implement
+        revert NotImplemented();
     }
 
     function _reportSingleValidator(WithdrawnValidatorInfo memory info) internal {

--- a/src/interfaces/IStakingModule.sol
+++ b/src/interfaces/IStakingModule.sol
@@ -238,12 +238,9 @@ interface IStakingModuleV2 {
 
     /// @notice Called by StakingRouter to update node operator total balances.
     /// @dev Total balances are denominated in gwei.
-    /// @param operatorIds Node operator IDs to update balances for.
-    /// @param totalBalancesGwei Total balances (validators + pending) aligned with operatorIds.
-    /// @param refSlot Accounting oracle ref slot.
-    function updateOperatorBalances(
-        uint256[] calldata operatorIds,
-        uint256[] calldata totalBalancesGwei,
-        uint256 refSlot
-    ) external;
+    /// @dev Input format matches validator counts updates from StakingRouter:
+    ///      `operatorIds` packs ids as bytes8 entries and `totalBalancesGwei` packs values as bytes16 entries.
+    /// @param operatorIds Bytes packed array of node operator IDs.
+    /// @param totalBalancesGwei Bytes packed array of total balances (validators + pending), in gwei.
+    function updateOperatorBalances(bytes calldata operatorIds, bytes calldata totalBalancesGwei) external;
 }

--- a/src/interfaces/IVerifier.sol
+++ b/src/interfaces/IVerifier.sol
@@ -106,6 +106,7 @@ interface IVerifier {
     error InvalidPivotSlot();
     error InvalidCapellaSlot();
     error HistoricalSummaryDoesNotExist();
+    error NotImplemented();
 
     function PAUSE_ROLE() external view returns (bytes32);
 

--- a/src/lib/CuratedOperatorBalancesOps.sol
+++ b/src/lib/CuratedOperatorBalancesOps.sol
@@ -31,9 +31,9 @@ library CuratedOperatorBalancesOps {
     ) external {
         for (uint256 i; i < uniqueOperatorIds.length; ++i) {
             uint256 operatorId = uniqueOperatorIds[i];
-            uint256 increment = perOperatorIncrements[operatorId];
-            if (increment == 0) continue;
-            _setBalance(operatorBalances, operatorId, operatorBalances[operatorId] + increment);
+            uint256 incrementWei = perOperatorIncrements[operatorId];
+            if (incrementWei == 0) continue;
+            _setBalance(operatorBalances, operatorId, operatorBalances[operatorId] + incrementWei);
         }
     }
 

--- a/src/lib/CuratedOperatorBalancesOps.sol
+++ b/src/lib/CuratedOperatorBalancesOps.sol
@@ -1,0 +1,58 @@
+// SPDX-FileCopyrightText: 2026 Lido <info@lido.fi>
+// SPDX-License-Identifier: GPL-3.0
+
+pragma solidity 0.8.33;
+
+import { IBaseModule } from "../interfaces/IBaseModule.sol";
+import { ICuratedModule } from "../interfaces/ICuratedModule.sol";
+
+/// @dev The library is used to reduce CuratedModule bytecode size and keep balance ops centralized.
+library CuratedOperatorBalancesOps {
+    function applyReportedBalances(
+        mapping(uint256 => uint256) storage operatorBalances,
+        uint256 nodeOperatorsCount,
+        uint256[] calldata operatorIds,
+        uint256[] calldata totalBalancesGwei
+    ) external {
+        uint256 operatorsCount = operatorIds.length;
+        if (operatorsCount != totalBalancesGwei.length) {
+            revert IBaseModule.InvalidInput();
+        }
+
+        for (uint256 i; i < operatorsCount; ++i) {
+            uint256 operatorId = operatorIds[i];
+            if (operatorId >= nodeOperatorsCount) revert IBaseModule.NodeOperatorDoesNotExist();
+            _setBalance(operatorBalances, operatorId, totalBalancesGwei[i] * 1 gwei);
+        }
+    }
+
+    function increaseByAllocations(
+        mapping(uint256 => uint256) storage operatorBalances,
+        uint256[] calldata uniqueOperatorIds,
+        uint256[] calldata perOperatorIncrements
+    ) external {
+        for (uint256 i; i < uniqueOperatorIds.length; ++i) {
+            uint256 operatorId = uniqueOperatorIds[i];
+            uint256 increment = perOperatorIncrements[operatorId];
+            if (increment == 0) continue;
+            _setBalance(operatorBalances, operatorId, operatorBalances[operatorId] + increment);
+        }
+    }
+
+    function increaseBalance(
+        mapping(uint256 => uint256) storage operatorBalances,
+        uint256 operatorId,
+        uint256 incrementWei
+    ) external {
+        _setBalance(operatorBalances, operatorId, operatorBalances[operatorId] + incrementWei);
+    }
+
+    function _setBalance(
+        mapping(uint256 => uint256) storage operatorBalances,
+        uint256 operatorId,
+        uint256 balanceWei
+    ) private {
+        operatorBalances[operatorId] = balanceWei;
+        emit ICuratedModule.NodeOperatorBalanceUpdated(operatorId, balanceWei);
+    }
+}

--- a/src/lib/CuratedOperatorBalancesOps.sol
+++ b/src/lib/CuratedOperatorBalancesOps.sol
@@ -5,24 +5,22 @@ pragma solidity 0.8.33;
 
 import { IBaseModule } from "../interfaces/IBaseModule.sol";
 import { ICuratedModule } from "../interfaces/ICuratedModule.sol";
+import { ValidatorCountsReport } from "./ValidatorCountsReport.sol";
 
 /// @dev The library is used to reduce CuratedModule bytecode size and keep balance ops centralized.
 library CuratedOperatorBalancesOps {
     function applyReportedBalances(
         mapping(uint256 => uint256) storage operatorBalances,
         uint256 nodeOperatorsCount,
-        uint256[] calldata operatorIds,
-        uint256[] calldata totalBalancesGwei
+        bytes calldata operatorIds,
+        bytes calldata totalBalancesGwei
     ) external {
-        uint256 operatorsCount = operatorIds.length;
-        if (operatorsCount != totalBalancesGwei.length) {
-            revert IBaseModule.InvalidInput();
-        }
+        uint256 operatorsInReport = ValidatorCountsReport.safeCountOperators(operatorIds, totalBalancesGwei);
 
-        for (uint256 i; i < operatorsCount; ++i) {
-            uint256 operatorId = operatorIds[i];
+        for (uint256 i; i < operatorsInReport; ++i) {
+            (uint256 operatorId, uint256 balanceGwei) = ValidatorCountsReport.next(operatorIds, totalBalancesGwei, i);
             if (operatorId >= nodeOperatorsCount) revert IBaseModule.NodeOperatorDoesNotExist();
-            _setBalance(operatorBalances, operatorId, totalBalancesGwei[i] * 1 gwei);
+            _setBalance(operatorBalances, operatorId, balanceGwei * 1 gwei);
         }
     }
 

--- a/src/lib/SigningKeys.sol
+++ b/src/lib/SigningKeys.sol
@@ -19,6 +19,7 @@ library SigningKeys {
     error InvalidKeysCount();
     error InvalidLength();
     error EmptyKey();
+    error InvalidSigningKey();
 
     /// @dev store operator keys to storage
     /// @param nodeOperatorId operator id
@@ -185,6 +186,12 @@ library SigningKeys {
                 i := add(i, 1)
             }
         }
+    }
+
+    /// @dev Verify that the key matches the key stored for a specific operator/index.
+    function verifySigningKey(uint256 nodeOperatorId, uint256 keyIndex, bytes calldata key) internal view {
+        if (keccak256(key) == keccak256(loadKeys(nodeOperatorId, keyIndex, 1))) return;
+        revert InvalidSigningKey();
     }
 
     function initKeysSigsBuf(uint256 count) internal pure returns (bytes memory, bytes memory) {

--- a/src/lib/TopUpQueueOps.sol
+++ b/src/lib/TopUpQueueOps.sol
@@ -60,7 +60,7 @@ library TopUpQueueOps {
                 revert ICSModule.InvalidTopUpOrder();
             }
 
-            _verifyModuleKey(item.noId(), item.keyIndex(), pubkeys[i]);
+            SigningKeys.verifySigningKey(item.noId(), item.keyIndex(), pubkeys[i]);
 
             if (maxDepositAmount > 0) {
                 allocations[i] = Math.min(data.topUpLimits[i], maxDepositAmount);
@@ -70,12 +70,5 @@ library TopUpQueueOps {
                 topUpQueue.dequeue();
             } else if (i < keyCount - 1) revert ICSModule.UnexpectedExtraKey();
         }
-    }
-
-    function _verifyModuleKey(uint256 nodeOperatorId, uint256 keyIndex, bytes memory key) private view {
-        if (key.length != SigningKeys.PUBKEY_LENGTH) revert IBaseModule.InvalidInput();
-        bytes memory keyFromStorage = SigningKeys.loadKeys(nodeOperatorId, keyIndex, 1);
-
-        if (keccak256(key) != keccak256(keyFromStorage)) revert ICSModule.InvalidSigningKey();
     }
 }

--- a/src/lib/allocator/CuratedDepositAllocator.sol
+++ b/src/lib/allocator/CuratedDepositAllocator.sol
@@ -36,7 +36,6 @@ library CuratedDepositAllocator {
     // so this is the smallest effective-balance step; EIP‑7251 keeps that increment.
     uint256 internal constant TOP_UP_STEP = 1 ether;
 
-    // TODO: Rename to `allocateInitialDeposits`
     /// @notice Allocate new validator deposits across curated operators.
     /// @dev Input preparation and iteration behavior:
     ///      - Only operators with capacity > 0 and non-zero allocation weight are included.

--- a/test/helpers/Utilities.sol
+++ b/test/helpers/Utilities.sol
@@ -90,6 +90,18 @@ contract Utilities is CommonBase {
         return bytes.concat(bytes16(uint128(value)));
     }
 
+    function _encodeNodeOperatorIds(uint256[] memory noIds) internal pure returns (bytes memory encoded) {
+        for (uint256 i; i < noIds.length; ++i) {
+            encoded = bytes.concat(encoded, _encodeNodeOperatorId(noIds[i]));
+        }
+    }
+
+    function _encodeUint128Values(uint256[] memory values) internal pure returns (bytes memory encoded) {
+        for (uint256 i; i < values.length; ++i) {
+            encoded = bytes.concat(encoded, _encodeUint128Value(values[i]));
+        }
+    }
+
     function randomBytes(uint256 length) public returns (bytes memory b) {
         b = new bytes(length);
 

--- a/test/unit/CSModule.t.sol
+++ b/test/unit/CSModule.t.sol
@@ -14,6 +14,7 @@ import { CSModule } from "src/CSModule.sol";
 import { IBondCurve } from "src/interfaces/IBondCurve.sol";
 import { IBaseModule, WithdrawnValidatorInfo } from "src/interfaces/IBaseModule.sol";
 import { IDepositQueueLib } from "src/lib/DepositQueueLib.sol";
+import { SigningKeys } from "src/lib/SigningKeys.sol";
 import { ITopUpQueueLib } from "src/lib/TopUpQueueLib.sol";
 import { ICSModule } from "src/interfaces/ICSModule.sol";
 import { WithdrawnValidatorLib } from "src/lib/WithdrawnValidatorLib.sol";
@@ -1001,7 +1002,7 @@ contract CSMTopUpQueue is CSMCommon {
             topUpLimits: UintArr(4)
         });
 
-        vm.expectRevert(ICSModule.InvalidSigningKey.selector);
+        vm.expectRevert(SigningKeys.InvalidSigningKey.selector);
         csm.allocateDeposits({
             maxDepositAmount: 3,
             pubkeys: pubkeys,
@@ -1049,7 +1050,7 @@ contract CSMTopUpQueue is CSMCommon {
         csm.obtainDepositData(1, "");
 
         bytes[] memory pubkeys = BytesArr(new bytes(47));
-        vm.expectRevert(IBaseModule.InvalidInput.selector);
+        vm.expectRevert(SigningKeys.InvalidSigningKey.selector);
         csm.allocateDeposits({
             maxDepositAmount: 1,
             pubkeys: pubkeys,

--- a/test/unit/CuratedModule.t.sol
+++ b/test/unit/CuratedModule.t.sol
@@ -6,6 +6,7 @@ pragma solidity 0.8.33;
 import { Initializable } from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 
 import { CuratedDepositAllocator } from "src/lib/allocator/CuratedDepositAllocator.sol";
+import { SigningKeys } from "src/lib/SigningKeys.sol";
 import { CuratedModule } from "src/CuratedModule.sol";
 import { IBaseModule, INOAddresses, NodeOperator, NodeOperatorManagementProperties } from "src/interfaces/IBaseModule.sol";
 import { IBondCurve } from "src/interfaces/IBondCurve.sol";
@@ -785,7 +786,7 @@ contract CuratedTopUpObtainDepositData is CuratedCommon {
         assertEq(allocations[0], 2 ether);
     }
 
-    function test_topUpObtainDepositData_capacityCapLeavesRemainder() public assertInvariants {
+    function test_topUpObtainDepositData_capacityAndKeyCapsLeaveRemainder() public assertInvariants {
         uint256 cappedId = createNodeOperator(1);
         uint256 wideId = createNodeOperator(2);
         module.obtainDepositData(3, "");
@@ -806,8 +807,27 @@ contract CuratedTopUpObtainDepositData is CuratedCommon {
         );
 
         assertEq(allocations[0], 48 ether);
-        assertEq(allocations[1], 2100 ether);
-        assertEq(allocations[0] + allocations[1], 2148 ether);
+        assertEq(allocations[1], 2016 ether);
+        assertEq(allocations[0] + allocations[1], 2064 ether);
+    }
+
+    function test_topUpObtainDepositData_keyCapBoundsSingleKeyAllocation() public assertInvariants {
+        uint256 noId = createNodeOperator(2);
+        module.obtainDepositData(2, "");
+
+        bytes memory key = module.getSigningKeys(noId, 0, 1);
+        uint256[] memory allocations = cm.allocateDeposits(
+            5000 ether,
+            BytesArr(key),
+            UintArr(0),
+            UintArr(noId),
+            UintArr(5000 ether)
+        );
+
+        assertEq(
+            allocations[0],
+            WithdrawnValidatorLib.MAX_EFFECTIVE_BALANCE - WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE
+        );
     }
 
     function test_topUpObtainDepositData_globalBaselineHeavilyOmitted() public assertInvariants {
@@ -1340,7 +1360,7 @@ contract CuratedTopUpObtainDepositData is CuratedCommon {
         bytes memory wrongKey = module.getSigningKeys(noId, 0, 1);
         wrongKey[0] = bytes1(uint8(wrongKey[0]) ^ 0x01);
 
-        vm.expectRevert(IBaseModule.PubkeyMismatch.selector);
+        vm.expectRevert(SigningKeys.InvalidSigningKey.selector);
         cm.allocateDeposits(1 ether, BytesArr(wrongKey), UintArr(0), UintArr(noId), UintArr(1 ether));
     }
 

--- a/test/unit/CuratedModule.t.sol
+++ b/test/unit/CuratedModule.t.sol
@@ -7,6 +7,7 @@ import { Initializable } from "@openzeppelin/contracts-upgradeable/proxy/utils/I
 
 import { CuratedDepositAllocator } from "src/lib/allocator/CuratedDepositAllocator.sol";
 import { SigningKeys } from "src/lib/SigningKeys.sol";
+import { ValidatorCountsReport } from "src/lib/ValidatorCountsReport.sol";
 import { CuratedModule } from "src/CuratedModule.sol";
 import { IBaseModule, INOAddresses, NodeOperator, NodeOperatorManagementProperties } from "src/interfaces/IBaseModule.sol";
 import { IBondCurve } from "src/interfaces/IBondCurve.sol";
@@ -642,7 +643,10 @@ contract CuratedTopUpObtainDepositData is CuratedCommon {
         uint256 secondId = createNodeOperator(1);
         module.obtainDepositData(2, "");
 
-        cm.updateOperatorBalances(UintArr(firstId, secondId), UintArr(2048 ether / 1 gwei, 0), 0);
+        cm.updateOperatorBalances(
+            _encodeNodeOperatorIds(UintArr(firstId, secondId)),
+            _encodeUint128Values(UintArr(2048 ether / 1 gwei, 0))
+        );
 
         bytes memory key = module.getSigningKeys(secondId, 0, 1);
 
@@ -669,7 +673,10 @@ contract CuratedTopUpObtainDepositData is CuratedCommon {
         accounting.setBondCurve(secondId, curveId);
         _mockOperatorWeight(secondId, 3);
 
-        cm.updateOperatorBalances(UintArr(firstId, secondId), UintArr(0, 0), 0);
+        cm.updateOperatorBalances(
+            _encodeNodeOperatorIds(UintArr(firstId, secondId)),
+            _encodeUint128Values(UintArr(0, 0))
+        );
 
         bytes memory key0 = module.getSigningKeys(firstId, 0, 1);
         bytes memory key1 = module.getSigningKeys(firstId, 1, 1);
@@ -686,7 +693,10 @@ contract CuratedTopUpObtainDepositData is CuratedCommon {
         assertEq(allocations[0], 1 ether);
         assertEq(allocations[1], 0);
 
-        cm.updateOperatorBalances(UintArr(firstId, secondId), UintArr(allocations[0] / 1 gwei, 0), 0);
+        cm.updateOperatorBalances(
+            _encodeNodeOperatorIds(UintArr(firstId, secondId)),
+            _encodeUint128Values(UintArr(allocations[0] / 1 gwei, 0))
+        );
 
         uint256[] memory secondAllocations = cm.allocateDeposits(
             7 ether,
@@ -704,7 +714,10 @@ contract CuratedTopUpObtainDepositData is CuratedCommon {
         uint256 noId = createNodeOperator(1);
         module.obtainDepositData(1, "");
 
-        cm.updateOperatorBalances(UintArr(noId), UintArr(2047 ether / 1 gwei), 0);
+        cm.updateOperatorBalances(
+            _encodeNodeOperatorIds(UintArr(noId)),
+            _encodeUint128Values(UintArr(2047 ether / 1 gwei))
+        );
 
         bytes memory key = module.getSigningKeys(noId, 0, 1);
 
@@ -723,7 +736,10 @@ contract CuratedTopUpObtainDepositData is CuratedCommon {
         uint256 noId = createNodeOperator(1);
         module.obtainDepositData(1, "");
 
-        cm.updateOperatorBalances(UintArr(noId), UintArr(2048 ether / 1 gwei), 0);
+        cm.updateOperatorBalances(
+            _encodeNodeOperatorIds(UintArr(noId)),
+            _encodeUint128Values(UintArr(2048 ether / 1 gwei))
+        );
 
         bytes memory key = module.getSigningKeys(noId, 0, 1);
 
@@ -791,7 +807,10 @@ contract CuratedTopUpObtainDepositData is CuratedCommon {
         uint256 wideId = createNodeOperator(2);
         module.obtainDepositData(3, "");
 
-        cm.updateOperatorBalances(UintArr(cappedId, wideId), UintArr(2000 ether / 1 gwei, 0), 0);
+        cm.updateOperatorBalances(
+            _encodeNodeOperatorIds(UintArr(cappedId, wideId)),
+            _encodeUint128Values(UintArr(2000 ether / 1 gwei, 0))
+        );
 
         bytes memory cappedKey = module.getSigningKeys(cappedId, 0, 1);
         bytes memory wideKey = module.getSigningKeys(wideId, 0, 1);
@@ -851,7 +870,10 @@ contract CuratedTopUpObtainDepositData is CuratedCommon {
         accounting.setBondCurve(includedId, curveId);
         _mockOperatorWeight(includedId, 1);
 
-        cm.updateOperatorBalances(UintArr(omittedHeavyId, omittedMidId, includedId), UintArr(0, 0, 0), 0);
+        cm.updateOperatorBalances(
+            _encodeNodeOperatorIds(UintArr(omittedHeavyId, omittedMidId, includedId)),
+            _encodeUint128Values(UintArr(0, 0, 0))
+        );
 
         bytes memory key = module.getSigningKeys(includedId, 0, 1);
         uint256 depositAmount = 111 ether;
@@ -980,7 +1002,10 @@ contract CuratedTopUpObtainDepositData is CuratedCommon {
         uint256 secondId = createNodeOperator(1);
         module.obtainDepositData(2, "");
 
-        cm.updateOperatorBalances(UintArr(firstId, secondId), UintArr(10, 10), 0);
+        cm.updateOperatorBalances(
+            _encodeNodeOperatorIds(UintArr(firstId, secondId)),
+            _encodeUint128Values(UintArr(10, 10))
+        );
 
         (, uint256[] memory ids, uint256[] memory allocs) = cm.getDepositsAllocation(2 ether);
 
@@ -1029,9 +1054,8 @@ contract CuratedTopUpObtainDepositData is CuratedCommon {
             );
 
             cm.updateOperatorBalances(
-                UintArr(firstId, secondId),
-                UintArr(balances[0] / 1 gwei, balances[1] / 1 gwei),
-                0
+                _encodeNodeOperatorIds(UintArr(firstId, secondId)),
+                _encodeUint128Values(UintArr(balances[0] / 1 gwei, balances[1] / 1 gwei))
             );
 
             (, uint256[] memory ids, uint256[] memory allocs) = cm.getDepositsAllocation(3 ether);
@@ -1063,9 +1087,8 @@ contract CuratedTopUpObtainDepositData is CuratedCommon {
             );
 
             cm.updateOperatorBalances(
-                UintArr(firstId, secondId),
-                UintArr(balances[0] / 1 gwei, balances[1] / 1 gwei),
-                0
+                _encodeNodeOperatorIds(UintArr(firstId, secondId)),
+                _encodeUint128Values(UintArr(balances[0] / 1 gwei, balances[1] / 1 gwei))
             );
 
             (, uint256[] memory ids, uint256[] memory allocs) = cm.getDepositsAllocation(3 ether);
@@ -1117,7 +1140,10 @@ contract CuratedTopUpObtainDepositData is CuratedCommon {
         uint256 secondId = createNodeOperator(1);
         module.obtainDepositData(2, "");
 
-        cm.updateOperatorBalances(UintArr(firstId, secondId), UintArr(2048 ether / 1 gwei, 0), 0);
+        cm.updateOperatorBalances(
+            _encodeNodeOperatorIds(UintArr(firstId, secondId)),
+            _encodeUint128Values(UintArr(2048 ether / 1 gwei, 0))
+        );
 
         (, uint256[] memory ids, uint256[] memory allocs) = cm.getDepositsAllocation(4 ether);
 
@@ -1130,7 +1156,10 @@ contract CuratedTopUpObtainDepositData is CuratedCommon {
         uint256 noId = createNodeOperator(1);
         module.obtainDepositData(1, "");
 
-        cm.updateOperatorBalances(UintArr(noId), UintArr(2047 ether / 1 gwei), 0);
+        cm.updateOperatorBalances(
+            _encodeNodeOperatorIds(UintArr(noId)),
+            _encodeUint128Values(UintArr(2047 ether / 1 gwei))
+        );
 
         (, uint256[] memory ids, uint256[] memory allocs) = cm.getDepositsAllocation(10 ether);
 
@@ -1144,7 +1173,10 @@ contract CuratedTopUpObtainDepositData is CuratedCommon {
         uint256 secondId = createNodeOperator(1);
         module.obtainDepositData(2, "");
 
-        cm.updateOperatorBalances(UintArr(firstId, secondId), UintArr(10_000_000_000, 0), 0);
+        cm.updateOperatorBalances(
+            _encodeNodeOperatorIds(UintArr(firstId, secondId)),
+            _encodeUint128Values(UintArr(10_000_000_000, 0))
+        );
 
         (, uint256[] memory ids, uint256[] memory allocs) = cm.getDepositsAllocation(1 ether);
 
@@ -1158,7 +1190,10 @@ contract CuratedTopUpObtainDepositData is CuratedCommon {
         uint256 secondId = createNodeOperator(1);
         module.obtainDepositData(2, "");
 
-        cm.updateOperatorBalances(UintArr(firstId, secondId), UintArr(10, 0), 0);
+        cm.updateOperatorBalances(
+            _encodeNodeOperatorIds(UintArr(firstId, secondId)),
+            _encodeUint128Values(UintArr(10, 0))
+        );
 
         (, uint256[] memory ids, uint256[] memory allocs) = cm.getDepositsAllocation(2 ether);
 
@@ -1173,7 +1208,10 @@ contract CuratedTopUpObtainDepositData is CuratedCommon {
         uint256 secondId = createNodeOperator(1);
         module.obtainDepositData(2, "");
 
-        cm.updateOperatorBalances(UintArr(firstId, secondId), UintArr(10, 10), 0);
+        cm.updateOperatorBalances(
+            _encodeNodeOperatorIds(UintArr(firstId, secondId)),
+            _encodeUint128Values(UintArr(10, 10))
+        );
 
         bytes memory key0 = module.getSigningKeys(firstId, 0, 1);
         bytes memory key1 = module.getSigningKeys(secondId, 0, 1);
@@ -1226,7 +1264,7 @@ contract CuratedTopUpObtainDepositData is CuratedCommon {
         uint256 noId = createNodeOperator(1);
         module.obtainDepositData(1, "");
 
-        cm.updateOperatorBalances(UintArr(noId), UintArr(10), 0);
+        cm.updateOperatorBalances(_encodeNodeOperatorIds(UintArr(noId)), _encodeUint128Values(UintArr(10)));
 
         bytes memory key = module.getSigningKeys(noId, 0, 1);
 
@@ -1246,7 +1284,10 @@ contract CuratedTopUpObtainDepositData is CuratedCommon {
         uint256 weightedId = createNodeOperator(1);
         module.obtainDepositData(2, "");
 
-        cm.updateOperatorBalances(UintArr(zeroWeightId, weightedId), UintArr(10, 10), 0);
+        cm.updateOperatorBalances(
+            _encodeNodeOperatorIds(UintArr(zeroWeightId, weightedId)),
+            _encodeUint128Values(UintArr(10, 10))
+        );
 
         IBondCurve.BondCurveIntervalInput[] memory curve = new IBondCurve.BondCurveIntervalInput[](1);
         curve[0] = IBondCurve.BondCurveIntervalInput({ minKeysCount: 1, trend: BOND_SIZE });
@@ -1275,7 +1316,10 @@ contract CuratedTopUpObtainDepositData is CuratedCommon {
         uint256 secondId = createNodeOperator(1);
         module.obtainDepositData(2, "");
 
-        cm.updateOperatorBalances(UintArr(firstId, secondId), UintArr(10_000_000_000, 0), 0);
+        cm.updateOperatorBalances(
+            _encodeNodeOperatorIds(UintArr(firstId, secondId)),
+            _encodeUint128Values(UintArr(10_000_000_000, 0))
+        );
 
         bytes memory key0 = module.getSigningKeys(firstId, 0, 1);
         bytes memory key1 = module.getSigningKeys(secondId, 0, 1);
@@ -1297,7 +1341,7 @@ contract CuratedTopUpObtainDepositData is CuratedCommon {
         uint256 noId = createNodeOperator(1);
         module.obtainDepositData(1, "");
 
-        cm.updateOperatorBalances(UintArr(noId), UintArr(10), 0);
+        cm.updateOperatorBalances(_encodeNodeOperatorIds(UintArr(noId)), _encodeUint128Values(UintArr(10)));
 
         bytes memory key = module.getSigningKeys(noId, 0, 1);
         uint256 limitWei = 10 ether;
@@ -1394,11 +1438,10 @@ contract CuratedTopUpObtainDepositData is CuratedCommon {
         uint256 secondId = createNodeOperator(1);
         module.obtainDepositData(2, "");
 
-        cm.updateOperatorBalances({
-            operatorIds: UintArr(firstId, secondId),
-            totalBalancesGwei: UintArr(5 ether / 1 gwei, 5 ether / 1 gwei),
-            refSlot: 0
-        });
+        cm.updateOperatorBalances(
+            _encodeNodeOperatorIds(UintArr(firstId, secondId)),
+            _encodeUint128Values(UintArr(5 ether / 1 gwei, 5 ether / 1 gwei))
+        );
 
         // Operator 0 has large external stake; operator 1 has none.
         _mockOperatorWeightAndExternalStake(firstId, 1, 10 ether);
@@ -1431,7 +1474,10 @@ contract CuratedUpdateOperatorBalances is CuratedCommon {
         uint256 secondId = createNodeOperator(1);
 
         uint256 nonce = module.getNonce();
-        cm.updateOperatorBalances(UintArr(firstId, secondId), UintArr(13, 24), 0);
+        cm.updateOperatorBalances(
+            _encodeNodeOperatorIds(UintArr(firstId, secondId)),
+            _encodeUint128Values(UintArr(13, 24))
+        );
 
         assertEq(module.getNonce(), nonce + 1);
         assertEq(cm.getNodeOperatorBalance(firstId), 13 gwei);
@@ -1441,15 +1487,15 @@ contract CuratedUpdateOperatorBalances is CuratedCommon {
     function test_updateOperatorBalances_RevertWhen_LengthMismatch() public {
         createNodeOperator(1);
 
-        vm.expectRevert(IBaseModule.InvalidInput.selector);
-        cm.updateOperatorBalances(UintArr(0), UintArr(1, 2), 0);
+        vm.expectRevert(ValidatorCountsReport.InvalidReportData.selector);
+        cm.updateOperatorBalances(_encodeNodeOperatorIds(UintArr(0)), _encodeUint128Values(UintArr(1, 2)));
     }
 
     function test_updateOperatorBalances_RevertWhen_NodeOperatorDoesNotExist() public {
         createNodeOperator(1);
 
         vm.expectRevert(IBaseModule.NodeOperatorDoesNotExist.selector);
-        cm.updateOperatorBalances(UintArr(1), UintArr(1), 0);
+        cm.updateOperatorBalances(_encodeNodeOperatorIds(UintArr(1)), _encodeUint128Values(UintArr(1)));
     }
 
     function test_updateOperatorBalances_RevertWhen_NotStakingRouter() public {
@@ -1457,7 +1503,7 @@ contract CuratedUpdateOperatorBalances is CuratedCommon {
 
         vm.prank(stranger);
         expectRoleRevert(stranger, role);
-        cm.updateOperatorBalances(UintArr(), UintArr(), 0);
+        cm.updateOperatorBalances(_encodeNodeOperatorIds(UintArr()), _encodeUint128Values(UintArr()));
     }
 }
 


### PR DESCRIPTION
## Description

This PR resolves allocation-related TODOs and consolidates duplicated key/balance logic in curated + CSM top-up flows.

## Changes

- Curated top-up allocations now cap per-key limits by key-added balance before distribution (CSM parity).
- Added `SigningKeys.verifySigningKey(...)` and unified mismatch error handling to `SigningKeys.InvalidSigningKey()`.
- Replaced duplicated pubkey-vs-storage comparisons in `CuratedModule` and `TopUpQueueOps` with direct `SigningKeys` calls.
- Removed `_verifyModuleKey` in `TopUpQueueOps` and inlined key verification.
- Added `CuratedOperatorBalancesOps` and moved operator-balance updates/increments there:
  - reported oracle balances
  - balance increments from initial deposits
  - balance increments from top-up allocations
- Added explicit `revert NotImplemented()` in `Verifier.reportKeyAddedBalance` and declared error in `IVerifier`.
- Removed stale TODO/comments in allocator/module where covered by implemented behavior.
- updated updateOperatorBalances interface

## Checklist

- [x] Appropriate PR labels applied
- [x] Test coverage maintained (`just coverage`)
- [x] Documentation maintained
