### PR TITLE
review round #7

### DIFF
--- a/src/Accounting.sol
+++ b/src/Accounting.sol
@@ -240,8 +240,6 @@ contract Accounting is
         MODULE.updateDepositableValidatorsCount(nodeOperatorId);
     }
 
-    // TODO continue review from this line
-
     /// @inheritdoc IAccounting
     function claimRewardsWstETH(
         uint256 nodeOperatorId,
@@ -285,6 +283,7 @@ contract Accounting is
     }
 
     /// @inheritdoc IAccounting
+    // TODO make this method compensating from bond instead of direct transfer
     function compensateLockedBondETH(uint256 nodeOperatorId) external payable onlyModule {
         (bool success, ) = LIDO_LOCATOR.elRewardsVault().call{ value: msg.value }("");
         if (!success) revert ElRewardsVaultReceiveFailed();
@@ -304,9 +303,9 @@ contract Accounting is
     }
 
     /// @inheritdoc IAccounting
-    function penalize(uint256 nodeOperatorId, uint256 amount) external onlyModule returns (bool fullyBurned) {
+    function penalize(uint256 nodeOperatorId, uint256 amount) external onlyModule returns (bool penaltyCovered) {
         uint256 notBurnedAmount = BondCore._burn(nodeOperatorId, amount);
-        fullyBurned = notBurnedAmount == 0;
+        penaltyCovered = notBurnedAmount == 0;
     }
 
     /// @inheritdoc IAccounting
@@ -445,7 +444,7 @@ contract Accounting is
         }
         claimableShares = _getClaimableBondShares(nodeOperatorId);
         if (hasSplits && claimableShares != 0 && !isPaused()) {
-            (SplitTransfer[] memory transfers, uint256 sharesToSplit) = FeeSplits.getFeeSplitTransfers(
+            (SplitTransfer[] memory transfers, uint256 splittableShares) = FeeSplits.getFeeSplitTransfers(
                 nodeOperatorId,
                 claimableShares
             );
@@ -457,10 +456,10 @@ contract Accounting is
                     transferredShares += shares;
                 }
             }
-            // NOTE: `sharesToSplit` is the whole split operation base. It includes
+            // NOTE: `splittableShares` is the whole split operation base. It includes
             //       the Node Operator's retained shares (split remainder), so we
             //       must decrease pending by the base, not by transferred shares sum.
-            FeeSplits._decreasePendingSharesToSplit(nodeOperatorId, sharesToSplit);
+            FeeSplits._decreasePendingSharesToSplit(nodeOperatorId, splittableShares);
             BondCore._unsafeReduceBond(nodeOperatorId, transferredShares);
             // NOTE: It is safe to use unchecked here since `transferredShares` is always <= `claimableShares`
             unchecked {

--- a/src/abstract/BondCore.sol
+++ b/src/abstract/BondCore.sol
@@ -189,15 +189,15 @@ abstract contract BondCore is IBondCore {
     /// @param amount Bond amount to charge in ETH (stETH)
     /// @param recipient Address to send charged shares
     function _charge(uint256 nodeOperatorId, uint256 amount, address recipient) internal {
-        uint256 toChargeShares = _sharesByEth(amount);
-        uint256 chargedShares = _reduceBond(nodeOperatorId, toChargeShares);
+        uint256 sharesToCharge = _sharesByEth(amount);
+        uint256 effectiveSharesToCharge = _reduceBond(nodeOperatorId, sharesToCharge);
 
         // If no bond already or the amount to charge is zero
-        if (chargedShares == 0) return;
+        if (effectiveSharesToCharge == 0) return;
 
-        uint256 chargedEth = LIDO.transferShares(recipient, chargedShares);
+        uint256 chargedEth = LIDO.transferShares(recipient, effectiveSharesToCharge);
 
-        emit BondCharged(nodeOperatorId, _ethByShares(toChargeShares), chargedEth);
+        emit BondCharged(nodeOperatorId, _ethByShares(sharesToCharge), chargedEth);
     }
 
     /// @dev Unsafe reduce bond shares (stETH) (possible underflow). Safety checks should be done outside

--- a/src/abstract/BondLock.sol
+++ b/src/abstract/BondLock.sol
@@ -73,13 +73,15 @@ abstract contract BondLock is IBondLock, Initializable {
 
     /// @dev Lock bond amount for the given Node Operator until the period.
     function _lock(uint256 nodeOperatorId, uint256 amount) internal {
-        BondLockStorage storage $ = _getBondLockStorage();
         if (amount == 0) revert InvalidBondLockAmount();
+
+        BondLockStorage storage $ = _getBondLockStorage();
         BondLockData memory lock = $.bondLock[nodeOperatorId];
-        if (lock.until > block.timestamp) amount += lock.amount;
+        uint256 currentLockUntil = lock.until;
+        if (currentLockUntil > block.timestamp) amount += lock.amount;
         uint256 until = block.timestamp + $.bondLockPeriod;
-        if (lock.until > until) until = lock.until;
-        _changeBondLock({ nodeOperatorId: nodeOperatorId, amount: amount, until: until });
+        if (currentLockUntil > until) until = currentLockUntil;
+        _changeBondLock(nodeOperatorId, amount, until);
     }
 
     /// @dev Unlock the locked bond amount for the given Node Operator without changing the lock period

--- a/src/abstract/FeeSplits.sol
+++ b/src/abstract/FeeSplits.sol
@@ -42,19 +42,19 @@ abstract contract FeeSplits is IFeeSplits {
     function getFeeSplitTransfers(
         uint256 nodeOperatorId,
         uint256 claimableShares
-    ) public view returns (SplitTransfer[] memory transfers, uint256 sharesToSplit) {
+    ) public view returns (SplitTransfer[] memory transfers, uint256 splittableShares) {
         FeeSplitsStorage storage $ = _getFeeSplitsStorage();
         uint256 pending = $.pendingSharesToSplit[nodeOperatorId];
-        if (pending == 0) return (new SplitTransfer[](0), 0);
-        sharesToSplit = claimableShares > pending ? pending : claimableShares;
-        if (sharesToSplit == 0) return (new SplitTransfer[](0), 0);
+        if (pending == 0 || claimableShares == 0) return (transfers, splittableShares);
+
+        splittableShares = claimableShares > pending ? pending : claimableShares;
 
         FeeSplit[] storage splits = $.feeSplits[nodeOperatorId];
         transfers = new SplitTransfer[](splits.length);
         for (uint256 i; i < splits.length; ++i) {
             FeeSplit storage feeSplit = splits[i];
-            // NOTE: Due to rounding error, final operator's share might contain some dust.
-            uint256 amount = (sharesToSplit * feeSplit.share) / MAX_BP;
+            // NOTE: Due to rounding error, shares left for the node operator might contain some dust.
+            uint256 amount = (splittableShares * feeSplit.share) / MAX_BP;
             transfers[i] = SplitTransfer({ recipient: feeSplit.recipient, shares: amount });
         }
     }

--- a/src/interfaces/IAccounting.sol
+++ b/src/interfaces/IAccounting.sol
@@ -316,8 +316,8 @@ interface IAccounting is IBondCore, IBondCurve, IBondLock, IFeeSplits, IAssetRec
     ///      Method call can result in the remaining bond being lower than the locked bond.
     /// @param nodeOperatorId ID of the Node Operator
     /// @param amount Amount to penalize in ETH (stETH)
-    /// @return fullyBurned True if the bond was fully burned, false otherwise
-    function penalize(uint256 nodeOperatorId, uint256 amount) external returns (bool fullyBurned);
+    /// @return penaltyCovered True if the penalty was fully covered by bond burn, false otherwise
+    function penalize(uint256 nodeOperatorId, uint256 amount) external returns (bool penaltyCovered);
 
     /// @notice Charge fee from bond by transferring stETH shares of the given Node Operator to the charge recipient
     /// @dev Charge confiscation has a priority over the locked bond.
@@ -326,8 +326,7 @@ interface IAccounting is IBondCore, IBondCurve, IBondLock, IFeeSplits, IAssetRec
     /// @param amount Amount to charge in ETH (stETH)
     function chargeFee(uint256 nodeOperatorId, uint256 amount) external;
 
-    /// @notice Pull fees (if proof provided) from FeeDistributor to the Node Operator's bond and split pending according to configured fee splits.
-    /// @dev Permissionless method. Can be called before penalty application to ensure that rewards are also penalized and split.
+    /// @notice Pull fees (if proof provided) from FeeDistributor to the Node Operator's bond and split according to configured fee splits.
     /// @param nodeOperatorId ID of the Node Operator
     /// @param cumulativeFeeShares Cumulative fee stETH shares for the Node Operator
     /// @param rewardsProof Merkle proof of the rewards

--- a/src/interfaces/IBondCore.sol
+++ b/src/interfaces/IBondCore.sol
@@ -16,7 +16,7 @@ interface IBondCore {
     event BondClaimedStETH(uint256 indexed nodeOperatorId, address to, uint256 amount);
     event BondClaimedWstETH(uint256 indexed nodeOperatorId, address to, uint256 amount);
     event BondBurned(uint256 indexed nodeOperatorId, uint256 amountToBurn, uint256 burnedAmount);
-    event BondCharged(uint256 indexed nodeOperatorId, uint256 toChargeAmount, uint256 chargedAmount);
+    event BondCharged(uint256 indexed nodeOperatorId, uint256 amountToCharge, uint256 chargedAmount);
     event BondDebtIncreased(uint256 indexed nodeOperatorId, uint256 amount);
     event BondDebtCovered(uint256 indexed nodeOperatorId, uint256 amount);
 

--- a/src/interfaces/IFeeSplits.sol
+++ b/src/interfaces/IFeeSplits.sol
@@ -39,10 +39,10 @@ interface IFeeSplits {
     /// @param nodeOperatorId ID of the Node Operator
     /// @param claimableShares Max shares that can be used as split operation base
     /// @return transfers Shares amounts to transfer to each split recipient
-    /// @return sharesToSplit Actual split operation base used for calculations
-    /// @dev The returned `sharesToSplit` includes the retained remainder that stays on the Node Operator bond
+    /// @return splittableShares Actual splittable shares used for calculations
+    /// @dev The returned `splittableShares` includes the retained remainder that stays on the Node Operator bond
     function getFeeSplitTransfers(
         uint256 nodeOperatorId,
         uint256 claimableShares
-    ) external view returns (SplitTransfer[] memory transfers, uint256 sharesToSplit);
+    ) external view returns (SplitTransfer[] memory transfers, uint256 splittableShares);
 }

--- a/src/lib/WithdrawnValidatorLib.sol
+++ b/src/lib/WithdrawnValidatorLib.sol
@@ -101,7 +101,6 @@ library WithdrawnValidatorLib {
 
         // Confiscate penalties first to prioritize compensations for the stETH holders.
         if (penaltySum > 0) {
-            // We still call `penalize` even if there's no bond left, for the lock to be created.
             penaltyCovered = accounting.penalize(validatorInfo.nodeOperatorId, penaltySum);
         }
 


### PR DESCRIPTION
## Description

- Clarifies naming across accounting, bond, and fee-split paths to better reflect intent (`penaltyCovered`, `splittableShares`, `amountToCharge`, and related docs).
- Refactors `BondLock` and fee split calculation flow for readability with early exits and cached values while preserving behavior.
- Removes stale review comments and aligns interface NatSpec with the current implementation semantics.

## Checklist

- [x] Appropriate PR labels applied
- [x] Test coverage maintained (`just coverage`)
  - [x] No need to add/update tests
  - [ ] Tests are added/updated
- [x] Documentation maintained
  - [x] No need to update
  - [ ] Updated
