### PR TITLE
utilize upgradeToAndCall

### DIFF
--- a/script/csm/DeployBase.s.sol
+++ b/script/csm/DeployBase.s.sol
@@ -191,7 +191,32 @@ abstract contract DeployBase is Script {
 
         {
             ParametersRegistry parametersRegistryImpl = new ParametersRegistry(config.queueLowestPriority);
-            parametersRegistry = ParametersRegistry(_deployProxy(config.proxyAdmin, address(parametersRegistryImpl)));
+            IParametersRegistry.InitializationData memory parametersRegistryData = IParametersRegistry
+                .InitializationData({
+                    defaultKeyRemovalCharge: config.defaultKeyRemovalCharge,
+                    defaultGeneralDelayedPenaltyAdditionalFine: config.defaultGeneralDelayedPenaltyAdditionalFine,
+                    defaultKeysLimit: config.defaultKeysLimit,
+                    defaultRewardShare: config.defaultRewardShareBP,
+                    defaultPerformanceLeeway: config.defaultAvgPerfLeewayBP,
+                    defaultStrikesLifetime: config.defaultStrikesLifetimeFrames,
+                    defaultStrikesThreshold: config.defaultStrikesThreshold,
+                    defaultQueuePriority: config.defaultQueuePriority,
+                    defaultQueueMaxDeposits: config.defaultQueueMaxDeposits,
+                    defaultBadPerformancePenalty: config.defaultBadPerformancePenalty,
+                    defaultAttestationsWeight: config.defaultAttestationsWeight,
+                    defaultBlocksWeight: config.defaultBlocksWeight,
+                    defaultSyncWeight: config.defaultSyncWeight,
+                    defaultAllowedExitDelay: config.defaultAllowedExitDelay,
+                    defaultExitDelayFee: config.defaultExitDelayFee,
+                    defaultMaxElWithdrawalRequestFee: config.defaultMaxElWithdrawalRequestFee
+                });
+            parametersRegistry = ParametersRegistry(
+                _deployProxy(
+                    config.proxyAdmin,
+                    address(parametersRegistryImpl),
+                    abi.encodeCall(ParametersRegistry.initialize, (deployer, parametersRegistryData))
+                )
+            );
 
             Dummy dummyImpl = new Dummy();
 
@@ -206,7 +231,13 @@ abstract contract DeployBase is Script {
                 accounting: address(accounting),
                 oracle: address(oracle)
             });
-            feeDistributor = FeeDistributor(_deployProxy(config.proxyAdmin, address(feeDistributorImpl)));
+            feeDistributor = FeeDistributor(
+                _deployProxy(
+                    config.proxyAdmin,
+                    address(feeDistributorImpl),
+                    abi.encodeCall(FeeDistributor.initialize, (deployer, config.aragonAgent))
+                )
+            );
 
             // prettier-ignore
             verifier = new Verifier({
@@ -234,28 +265,6 @@ abstract contract DeployBase is Script {
                 admin: deployer
             });
 
-            parametersRegistry.initialize({
-                admin: deployer,
-                data: IParametersRegistry.InitializationData({
-                    defaultKeyRemovalCharge: config.defaultKeyRemovalCharge,
-                    defaultGeneralDelayedPenaltyAdditionalFine: config.defaultGeneralDelayedPenaltyAdditionalFine,
-                    defaultKeysLimit: config.defaultKeysLimit,
-                    defaultRewardShare: config.defaultRewardShareBP,
-                    defaultPerformanceLeeway: config.defaultAvgPerfLeewayBP,
-                    defaultStrikesLifetime: config.defaultStrikesLifetimeFrames,
-                    defaultStrikesThreshold: config.defaultStrikesThreshold,
-                    defaultQueuePriority: config.defaultQueuePriority,
-                    defaultQueueMaxDeposits: config.defaultQueueMaxDeposits,
-                    defaultBadPerformancePenalty: config.defaultBadPerformancePenalty,
-                    defaultAttestationsWeight: config.defaultAttestationsWeight,
-                    defaultBlocksWeight: config.defaultBlocksWeight,
-                    defaultSyncWeight: config.defaultSyncWeight,
-                    defaultAllowedExitDelay: config.defaultAllowedExitDelay,
-                    defaultExitDelayFee: config.defaultExitDelayFee,
-                    defaultMaxElWithdrawalRequestFee: config.defaultMaxElWithdrawalRequestFee
-                })
-            });
-
             Accounting accountingImpl = new Accounting({
                 lidoLocator: config.lidoLocatorAddress,
                 module: address(csm),
@@ -264,39 +273,34 @@ abstract contract DeployBase is Script {
                 maxBondLockPeriod: config.maxBondLockPeriod
             });
 
+            IBondCurve.BondCurveIntervalInput[] memory defaultBondCurve = CommonScriptUtils
+                .arraysToBondCurveIntervalsInputs(config.defaultBondCurve);
             {
                 OssifiableProxy accountingProxy = OssifiableProxy(payable(address(accounting)));
-                accountingProxy.proxy__upgradeTo(address(accountingImpl));
+                accountingProxy.proxy__upgradeToAndCall(
+                    address(accountingImpl),
+                    abi.encodeCall(
+                        Accounting.initialize,
+                        (defaultBondCurve, deployer, config.bondLockPeriod, config.chargePenaltyRecipient)
+                    )
+                );
                 accountingProxy.proxy__changeAdmin(config.proxyAdmin);
             }
 
-            IBondCurve.BondCurveIntervalInput[] memory defaultBondCurve = CommonScriptUtils
-                .arraysToBondCurveIntervalsInputs(config.defaultBondCurve);
-            accounting.initialize({
-                bondCurve: defaultBondCurve,
-                admin: deployer,
-                bondLockPeriod: config.bondLockPeriod,
-                _chargePenaltyRecipient: config.chargePenaltyRecipient
-            });
-
             accounting.grantRole(accounting.MANAGE_BOND_CURVES_ROLE(), address(deployer));
 
-            IBondCurve.BondCurveIntervalInput[] memory legacyEaBondCurve = CommonScriptUtils
-                .arraysToBondCurveIntervalsInputs(config.legacyEaBondCurve);
-            accounting.addBondCurve(legacyEaBondCurve);
+            accounting.addBondCurve(CommonScriptUtils.arraysToBondCurveIntervalsInputs(config.legacyEaBondCurve));
 
             if (config.extraBondCurves.length > 0) {
                 for (uint256 i = 0; i < config.extraBondCurves.length; i++) {
-                    IBondCurve.BondCurveIntervalInput[] memory extraBondCurve = CommonScriptUtils
-                        .arraysToBondCurveIntervalsInputs(config.extraBondCurves[i]);
-                    accounting.addBondCurve(extraBondCurve);
+                    accounting.addBondCurve(
+                        CommonScriptUtils.arraysToBondCurveIntervalsInputs(config.extraBondCurves[i])
+                    );
                 }
             }
 
-            IBondCurve.BondCurveIntervalInput[] memory identifiedCommunityStakersGateBondCurve = CommonScriptUtils
-                .arraysToBondCurveIntervalsInputs(config.identifiedCommunityStakersGateBondCurve);
             uint256 identifiedCommunityStakersGateBondCurveId = accounting.addBondCurve(
-                identifiedCommunityStakersGateBondCurve
+                CommonScriptUtils.arraysToBondCurveIntervalsInputs(config.identifiedCommunityStakersGateBondCurve)
             );
             accounting.revokeRole(accounting.MANAGE_BOND_CURVES_ROLE(), address(deployer));
 
@@ -312,11 +316,12 @@ abstract contract DeployBase is Script {
 
             {
                 OssifiableProxy csmProxy = OssifiableProxy(payable(address(csm)));
-                csmProxy.proxy__upgradeTo(address(csmImpl));
+                csmProxy.proxy__upgradeToAndCall(
+                    address(csmImpl),
+                    abi.encodeCall(CSModule.initialize, (deployer, config.topUpQueueLimit))
+                );
                 csmProxy.proxy__changeAdmin(config.proxyAdmin);
             }
-
-            csm.initialize({ admin: deployer, topUpQueueLimit: config.topUpQueueLimit });
 
             ValidatorStrikes strikesImpl = new ValidatorStrikes({ module: address(csm), oracle: address(oracle) });
 
@@ -411,8 +416,6 @@ abstract contract DeployBase is Script {
                 config.identifiedCommunityStakersGateMaxElWithdrawalRequestFee
             );
 
-            feeDistributor.initialize({ admin: address(deployer), _rebateRecipient: config.aragonAgent });
-
             hashConsensus = new HashConsensus({
                 slotsPerEpoch: config.slotsPerEpoch,
                 secondsPerSlot: config.secondsPerSlot,
@@ -438,15 +441,12 @@ abstract contract DeployBase is Script {
 
             {
                 OssifiableProxy oracleProxy = OssifiableProxy(payable(address(oracle)));
-                oracleProxy.proxy__upgradeTo(address(oracleImpl));
+                oracleProxy.proxy__upgradeToAndCall(
+                    address(oracleImpl),
+                    abi.encodeCall(FeeOracle.initialize, (deployer, address(hashConsensus), config.consensusVersion))
+                );
                 oracleProxy.proxy__changeAdmin(config.proxyAdmin);
             }
-
-            oracle.initialize({
-                admin: address(deployer),
-                consensusContract: address(hashConsensus),
-                consensusVersion: config.consensusVersion
-            });
 
             if (config.gateSealFactory != address(0)) {
                 address[] memory sealables = new address[](6);
@@ -564,9 +564,13 @@ abstract contract DeployBase is Script {
     }
 
     function _deployProxy(address admin, address implementation) internal returns (address) {
+        return _deployProxy(admin, implementation, new bytes(0));
+    }
+
+    function _deployProxy(address admin, address implementation, bytes memory initCalldata) internal returns (address) {
         OssifiableProxy proxy = new OssifiableProxy({
             implementation_: implementation,
-            data_: new bytes(0),
+            data_: initCalldata,
             admin_: admin
         });
 

--- a/script/csm0x02/DeployCSM0x02Base.s.sol
+++ b/script/csm0x02/DeployCSM0x02Base.s.sol
@@ -165,7 +165,32 @@ abstract contract DeployCSM0x02Base is Script {
 
         {
             ParametersRegistry parametersRegistryImpl = new ParametersRegistry(config.queueLowestPriority);
-            parametersRegistry = ParametersRegistry(_deployProxy(config.proxyAdmin, address(parametersRegistryImpl)));
+            IParametersRegistry.InitializationData memory parametersRegistryData = IParametersRegistry
+                .InitializationData({
+                    defaultKeyRemovalCharge: config.defaultKeyRemovalCharge,
+                    defaultGeneralDelayedPenaltyAdditionalFine: config.defaultGeneralDelayedPenaltyAdditionalFine,
+                    defaultKeysLimit: config.defaultKeysLimit,
+                    defaultRewardShare: config.defaultRewardShareBP,
+                    defaultPerformanceLeeway: config.defaultAvgPerfLeewayBP,
+                    defaultStrikesLifetime: config.defaultStrikesLifetimeFrames,
+                    defaultStrikesThreshold: config.defaultStrikesThreshold,
+                    defaultQueuePriority: config.defaultQueuePriority,
+                    defaultQueueMaxDeposits: config.defaultQueueMaxDeposits,
+                    defaultBadPerformancePenalty: config.defaultBadPerformancePenalty,
+                    defaultAttestationsWeight: config.defaultAttestationsWeight,
+                    defaultBlocksWeight: config.defaultBlocksWeight,
+                    defaultSyncWeight: config.defaultSyncWeight,
+                    defaultAllowedExitDelay: config.defaultAllowedExitDelay,
+                    defaultExitDelayFee: config.defaultExitDelayFee,
+                    defaultMaxElWithdrawalRequestFee: config.defaultMaxElWithdrawalRequestFee
+                });
+            parametersRegistry = ParametersRegistry(
+                _deployProxy(
+                    config.proxyAdmin,
+                    address(parametersRegistryImpl),
+                    abi.encodeCall(ParametersRegistry.initialize, (deployer, parametersRegistryData))
+                )
+            );
 
             Dummy dummyImpl = new Dummy();
 
@@ -180,7 +205,13 @@ abstract contract DeployCSM0x02Base is Script {
                 accounting: address(accounting),
                 oracle: address(oracle)
             });
-            feeDistributor = FeeDistributor(_deployProxy(config.proxyAdmin, address(feeDistributorImpl)));
+            feeDistributor = FeeDistributor(
+                _deployProxy(
+                    config.proxyAdmin,
+                    address(feeDistributorImpl),
+                    abi.encodeCall(FeeDistributor.initialize, (deployer, config.aragonAgent))
+                )
+            );
 
             // prettier-ignore
             verifier = new Verifier({
@@ -208,28 +239,6 @@ abstract contract DeployCSM0x02Base is Script {
                 admin: deployer
             });
 
-            parametersRegistry.initialize({
-                admin: deployer,
-                data: IParametersRegistry.InitializationData({
-                    defaultKeyRemovalCharge: config.defaultKeyRemovalCharge,
-                    defaultGeneralDelayedPenaltyAdditionalFine: config.defaultGeneralDelayedPenaltyAdditionalFine,
-                    defaultKeysLimit: config.defaultKeysLimit,
-                    defaultRewardShare: config.defaultRewardShareBP,
-                    defaultPerformanceLeeway: config.defaultAvgPerfLeewayBP,
-                    defaultStrikesLifetime: config.defaultStrikesLifetimeFrames,
-                    defaultStrikesThreshold: config.defaultStrikesThreshold,
-                    defaultQueuePriority: config.defaultQueuePriority,
-                    defaultQueueMaxDeposits: config.defaultQueueMaxDeposits,
-                    defaultBadPerformancePenalty: config.defaultBadPerformancePenalty,
-                    defaultAttestationsWeight: config.defaultAttestationsWeight,
-                    defaultBlocksWeight: config.defaultBlocksWeight,
-                    defaultSyncWeight: config.defaultSyncWeight,
-                    defaultAllowedExitDelay: config.defaultAllowedExitDelay,
-                    defaultExitDelayFee: config.defaultExitDelayFee,
-                    defaultMaxElWithdrawalRequestFee: config.defaultMaxElWithdrawalRequestFee
-                })
-            });
-
             Accounting accountingImpl = new Accounting({
                 lidoLocator: config.lidoLocatorAddress,
                 module: address(csm),
@@ -238,20 +247,19 @@ abstract contract DeployCSM0x02Base is Script {
                 maxBondLockPeriod: config.maxBondLockPeriod
             });
 
-            {
-                OssifiableProxy accountingProxy = OssifiableProxy(payable(address(accounting)));
-                accountingProxy.proxy__upgradeTo(address(accountingImpl));
-                accountingProxy.proxy__changeAdmin(config.proxyAdmin);
-            }
-
             IBondCurve.BondCurveIntervalInput[] memory defaultBondCurve = CommonScriptUtils
                 .arraysToBondCurveIntervalsInputs(config.defaultBondCurve);
-            accounting.initialize({
-                bondCurve: defaultBondCurve,
-                admin: deployer,
-                bondLockPeriod: config.bondLockPeriod,
-                _chargePenaltyRecipient: config.chargePenaltyRecipient
-            });
+            {
+                OssifiableProxy accountingProxy = OssifiableProxy(payable(address(accounting)));
+                accountingProxy.proxy__upgradeToAndCall(
+                    address(accountingImpl),
+                    abi.encodeCall(
+                        Accounting.initialize,
+                        (defaultBondCurve, deployer, config.bondLockPeriod, config.chargePenaltyRecipient)
+                    )
+                );
+                accountingProxy.proxy__changeAdmin(config.proxyAdmin);
+            }
 
             accounting.grantRole(accounting.MANAGE_BOND_CURVES_ROLE(), address(deployer));
 
@@ -276,11 +284,12 @@ abstract contract DeployCSM0x02Base is Script {
 
             {
                 OssifiableProxy csmProxy = OssifiableProxy(payable(address(csm)));
-                csmProxy.proxy__upgradeTo(address(csmImpl));
+                csmProxy.proxy__upgradeToAndCall(
+                    address(csmImpl),
+                    abi.encodeCall(CSModule.initialize, (deployer, config.topUpQueueLimit))
+                );
                 csmProxy.proxy__changeAdmin(config.proxyAdmin);
             }
-
-            csm.initialize({ admin: deployer, topUpQueueLimit: config.topUpQueueLimit });
 
             ValidatorStrikes strikesImpl = new ValidatorStrikes({ module: address(csm), oracle: address(oracle) });
 
@@ -299,8 +308,6 @@ abstract contract DeployCSM0x02Base is Script {
             strikes.initialize(deployer, address(ejector));
 
             permissionlessGate = new PermissionlessGate(address(csm), deployer);
-
-            feeDistributor.initialize({ admin: address(deployer), _rebateRecipient: config.aragonAgent });
 
             hashConsensus = new HashConsensus({
                 slotsPerEpoch: config.slotsPerEpoch,
@@ -327,15 +334,12 @@ abstract contract DeployCSM0x02Base is Script {
 
             {
                 OssifiableProxy oracleProxy = OssifiableProxy(payable(address(oracle)));
-                oracleProxy.proxy__upgradeTo(address(oracleImpl));
+                oracleProxy.proxy__upgradeToAndCall(
+                    address(oracleImpl),
+                    abi.encodeCall(FeeOracle.initialize, (deployer, address(hashConsensus), config.consensusVersion))
+                );
                 oracleProxy.proxy__changeAdmin(config.proxyAdmin);
             }
-
-            oracle.initialize({
-                admin: address(deployer),
-                consensusContract: address(hashConsensus),
-                consensusVersion: config.consensusVersion
-            });
 
             if (config.gateSealFactory != address(0)) {
                 address[] memory sealables = new address[](5);
@@ -443,9 +447,13 @@ abstract contract DeployCSM0x02Base is Script {
     }
 
     function _deployProxy(address admin, address implementation) internal returns (address) {
+        return _deployProxy(admin, implementation, new bytes(0));
+    }
+
+    function _deployProxy(address admin, address implementation, bytes memory initCalldata) internal returns (address) {
         OssifiableProxy proxy = new OssifiableProxy({
             implementation_: implementation,
-            data_: new bytes(0),
+            data_: initCalldata,
             admin_: admin
         });
 

--- a/script/curated/DeployBase.s.sol
+++ b/script/curated/DeployBase.s.sol
@@ -195,7 +195,32 @@ abstract contract DeployBase is Script {
 
         {
             ParametersRegistry parametersRegistryImpl = new ParametersRegistry(config.queueLowestPriority);
-            parametersRegistry = ParametersRegistry(_deployProxy(config.proxyAdmin, address(parametersRegistryImpl)));
+            IParametersRegistry.InitializationData memory parametersRegistryData = IParametersRegistry
+                .InitializationData({
+                    defaultKeyRemovalCharge: config.defaultKeyRemovalCharge,
+                    defaultGeneralDelayedPenaltyAdditionalFine: config.defaultGeneralDelayedPenaltyAdditionalFine,
+                    defaultKeysLimit: config.defaultKeysLimit,
+                    defaultRewardShare: config.defaultRewardShareBP,
+                    defaultPerformanceLeeway: config.defaultAvgPerfLeewayBP,
+                    defaultStrikesLifetime: config.defaultStrikesLifetimeFrames,
+                    defaultStrikesThreshold: config.defaultStrikesThreshold,
+                    defaultQueuePriority: config.defaultQueuePriority,
+                    defaultQueueMaxDeposits: config.defaultQueueMaxDeposits,
+                    defaultBadPerformancePenalty: config.defaultBadPerformancePenalty,
+                    defaultAttestationsWeight: config.defaultAttestationsWeight,
+                    defaultBlocksWeight: config.defaultBlocksWeight,
+                    defaultSyncWeight: config.defaultSyncWeight,
+                    defaultAllowedExitDelay: config.defaultAllowedExitDelay,
+                    defaultExitDelayFee: config.defaultExitDelayFee,
+                    defaultMaxElWithdrawalRequestFee: config.defaultMaxElWithdrawalRequestFee
+                });
+            parametersRegistry = ParametersRegistry(
+                _deployProxy(
+                    config.proxyAdmin,
+                    address(parametersRegistryImpl),
+                    abi.encodeCall(ParametersRegistry.initialize, (deployer, parametersRegistryData))
+                )
+            );
 
             Dummy dummyImpl = new Dummy();
 
@@ -210,7 +235,13 @@ abstract contract DeployBase is Script {
                 accounting: address(accounting),
                 oracle: address(oracle)
             });
-            feeDistributor = FeeDistributor(_deployProxy(config.proxyAdmin, address(feeDistributorImpl)));
+            feeDistributor = FeeDistributor(
+                _deployProxy(
+                    config.proxyAdmin,
+                    address(feeDistributorImpl),
+                    abi.encodeCall(FeeDistributor.initialize, (deployer, config.aragonAgent))
+                )
+            );
 
             // prettier-ignore
             verifier = new Verifier({
@@ -238,28 +269,6 @@ abstract contract DeployBase is Script {
                 admin: deployer
             });
 
-            parametersRegistry.initialize({
-                admin: deployer,
-                data: IParametersRegistry.InitializationData({
-                    defaultKeyRemovalCharge: config.defaultKeyRemovalCharge,
-                    defaultGeneralDelayedPenaltyAdditionalFine: config.defaultGeneralDelayedPenaltyAdditionalFine,
-                    defaultKeysLimit: config.defaultKeysLimit,
-                    defaultRewardShare: config.defaultRewardShareBP,
-                    defaultPerformanceLeeway: config.defaultAvgPerfLeewayBP,
-                    defaultStrikesLifetime: config.defaultStrikesLifetimeFrames,
-                    defaultStrikesThreshold: config.defaultStrikesThreshold,
-                    defaultQueuePriority: config.defaultQueuePriority,
-                    defaultQueueMaxDeposits: config.defaultQueueMaxDeposits,
-                    defaultBadPerformancePenalty: config.defaultBadPerformancePenalty,
-                    defaultAttestationsWeight: config.defaultAttestationsWeight,
-                    defaultBlocksWeight: config.defaultBlocksWeight,
-                    defaultSyncWeight: config.defaultSyncWeight,
-                    defaultAllowedExitDelay: config.defaultAllowedExitDelay,
-                    defaultExitDelayFee: config.defaultExitDelayFee,
-                    defaultMaxElWithdrawalRequestFee: config.defaultMaxElWithdrawalRequestFee
-                })
-            });
-
             Accounting accountingImpl = new Accounting({
                 lidoLocator: config.lidoLocatorAddress,
                 module: address(curatedModule),
@@ -268,20 +277,19 @@ abstract contract DeployBase is Script {
                 maxBondLockPeriod: config.maxBondLockPeriod
             });
 
-            {
-                OssifiableProxy accountingProxy = OssifiableProxy(payable(address(accounting)));
-                accountingProxy.proxy__upgradeTo(address(accountingImpl));
-                accountingProxy.proxy__changeAdmin(config.proxyAdmin);
-            }
-
             IBondCurve.BondCurveIntervalInput[] memory defaultBondCurve = CommonScriptUtils
                 .arraysToBondCurveIntervalsInputs(config.defaultBondCurve);
-            accounting.initialize({
-                bondCurve: defaultBondCurve,
-                admin: deployer,
-                bondLockPeriod: config.bondLockPeriod,
-                _chargePenaltyRecipient: config.chargePenaltyRecipient
-            });
+            {
+                OssifiableProxy accountingProxy = OssifiableProxy(payable(address(accounting)));
+                accountingProxy.proxy__upgradeToAndCall(
+                    address(accountingImpl),
+                    abi.encodeCall(
+                        Accounting.initialize,
+                        (defaultBondCurve, deployer, config.bondLockPeriod, config.chargePenaltyRecipient)
+                    )
+                );
+                accountingProxy.proxy__changeAdmin(config.proxyAdmin);
+            }
 
             accounting.grantRole(accounting.MANAGE_BOND_CURVES_ROLE(), address(deployer));
 
@@ -347,20 +355,23 @@ abstract contract DeployBase is Script {
 
             {
                 OssifiableProxy moduleProxy = OssifiableProxy(payable(address(curatedModule)));
-                moduleProxy.proxy__upgradeTo(address(curatedModuleImpl));
+                moduleProxy.proxy__upgradeToAndCall(
+                    address(curatedModuleImpl),
+                    abi.encodeCall(CuratedModule.initialize, (deployer))
+                );
                 moduleProxy.proxy__changeAdmin(config.proxyAdmin);
             }
-
-            curatedModule.initialize({ admin: deployer });
 
             MetaRegistry metaRegistryImpl = new MetaRegistry(address(curatedModule));
 
             {
                 OssifiableProxy metaRegistryProxy = OssifiableProxy(payable(address(metaRegistry)));
-                metaRegistryProxy.proxy__upgradeTo(address(metaRegistryImpl));
+                metaRegistryProxy.proxy__upgradeToAndCall(
+                    address(metaRegistryImpl),
+                    abi.encodeCall(MetaRegistry.initialize, (deployer))
+                );
                 metaRegistryProxy.proxy__changeAdmin(config.proxyAdmin);
             }
-            metaRegistry.initialize({ admin: deployer });
 
             ValidatorStrikes strikesImpl = new ValidatorStrikes({
                 module: address(curatedModule),
@@ -387,8 +398,6 @@ abstract contract DeployBase is Script {
 
             curatedGateInstances = _deployCuratedGates(curatedCurveIds, address(curatedGateFactory));
 
-            feeDistributor.initialize({ admin: address(deployer), _rebateRecipient: config.aragonAgent });
-
             hashConsensus = new HashConsensus({
                 slotsPerEpoch: config.slotsPerEpoch,
                 secondsPerSlot: config.secondsPerSlot,
@@ -414,15 +423,12 @@ abstract contract DeployBase is Script {
 
             {
                 OssifiableProxy oracleProxy = OssifiableProxy(payable(address(oracle)));
-                oracleProxy.proxy__upgradeTo(address(oracleImpl));
+                oracleProxy.proxy__upgradeToAndCall(
+                    address(oracleImpl),
+                    abi.encodeCall(FeeOracle.initialize, (deployer, address(hashConsensus), config.consensusVersion))
+                );
                 oracleProxy.proxy__changeAdmin(config.proxyAdmin);
             }
-
-            oracle.initialize({
-                admin: address(deployer),
-                consensusContract: address(hashConsensus),
-                consensusVersion: config.consensusVersion
-            });
 
             if (config.gateSealFactory != address(0)) {
                 uint256 baseSealables = 5;
@@ -596,9 +602,13 @@ abstract contract DeployBase is Script {
     }
 
     function _deployProxy(address admin, address implementation) internal returns (address) {
+        return _deployProxy(admin, implementation, new bytes(0));
+    }
+
+    function _deployProxy(address admin, address implementation, bytes memory initCalldata) internal returns (address) {
         OssifiableProxy proxy = new OssifiableProxy({
             implementation_: implementation,
-            data_: new bytes(0),
+            data_: initCalldata,
             admin_: admin
         });
 

--- a/script/fork-helpers/SimulateVote.s.sol
+++ b/script/fork-helpers/SimulateVote.s.sol
@@ -10,6 +10,7 @@ import { Accounting } from "../../src/Accounting.sol";
 import { Ejector } from "../../src/Ejector.sol";
 import { FeeDistributor } from "../../src/FeeDistributor.sol";
 import { ParametersRegistry } from "../../src/ParametersRegistry.sol";
+import { FeeOracle } from "../../src/FeeOracle.sol";
 import { ValidatorStrikes } from "../../src/ValidatorStrikes.sol";
 import { Verifier } from "../../src/Verifier.sol";
 import { VettedGate } from "../../src/VettedGate.sol";
@@ -31,6 +32,9 @@ contract SimulateVote is Script, ForkHelpersCommon {
 
     error WrongModuleType();
 
+    /// @dev Simulation helper only.
+    ///      In a real governance vote, all steps below are expected to be executed atomically
+    ///      in a single transaction via a temporary vote executor contract.
     function addModule() external {
         _setUp();
         if (moduleType != ModuleType.Community && moduleType != ModuleType.Community0x02) {
@@ -85,6 +89,9 @@ contract SimulateVote is Script, ForkHelpersCommon {
         vm.stopBroadcast();
     }
 
+    /// @dev Simulation helper only.
+    ///      In a real governance vote, all steps below are expected to be executed atomically
+    ///      in a single transaction via a temporary vote executor contract.
     function addCuratedModule() external {
         initializeFromDeployment();
         if (moduleType != ModuleType.Curated) revert WrongModuleType();
@@ -133,6 +140,9 @@ contract SimulateVote is Script, ForkHelpersCommon {
         vm.stopBroadcast();
     }
 
+    /// @dev Simulation helper only.
+    ///      In a real governance vote, all steps below are expected to be executed atomically
+    ///      in a single transaction via a temporary vote executor contract.
     function upgrade() external {
         _setUp();
         if (moduleType != ModuleType.Community) revert WrongModuleType();
@@ -153,29 +163,32 @@ contract SimulateVote is Script, ForkHelpersCommon {
         {
             OssifiableProxy moduleProxy = OssifiableProxy(payable(deploymentConfig.csm));
             vm.startBroadcast(_prepareProxyAdmin(address(moduleProxy)));
-            // 1. Upgrade CSModule implementation
-            moduleProxy.proxy__upgradeTo(deploymentConfig.csmImpl);
-            // 2. Finalize CSModule v3 upgrade
-            CSModule(deploymentConfig.csm).finalizeUpgradeV3();
+            // 1-2. Upgrade and finalize CSModule v3 in a single tx
+            moduleProxy.proxy__upgradeToAndCall(
+                deploymentConfig.csmImpl,
+                abi.encodeCall(CSModule.finalizeUpgradeV3, ())
+            );
             vm.stopBroadcast();
         }
 
         {
             OssifiableProxy parametersRegistryProxy = OssifiableProxy(payable(deploymentConfig.parametersRegistry));
             vm.startBroadcast(_prepareProxyAdmin(address(parametersRegistryProxy)));
-            // 3. Upgrade ParametersRegistry implementation
-            parametersRegistryProxy.proxy__upgradeTo(deploymentConfig.parametersRegistryImpl);
-            // 4. Finalize ParametersRegistry v3 upgrade
-            ParametersRegistry(deploymentConfig.parametersRegistry).finalizeUpgradeV3();
+            // 3-4. Upgrade and finalize ParametersRegistry v3 in a single tx
+            parametersRegistryProxy.proxy__upgradeToAndCall(
+                deploymentConfig.parametersRegistryImpl,
+                abi.encodeCall(ParametersRegistry.finalizeUpgradeV3, ())
+            );
             vm.stopBroadcast();
         }
         {
             OssifiableProxy oracleProxy = OssifiableProxy(payable(deploymentConfig.oracle));
             vm.startBroadcast(_prepareProxyAdmin(address(oracleProxy)));
-            // 4. Upgrade FeeOracle implementation
-            oracleProxy.proxy__upgradeTo(deploymentConfig.oracleImpl);
-            // 5. Finalize FeeOracle v3 upgrade
-            oracle.finalizeUpgradeV3(deployParams.consensusVersion);
+            // 4-5. Upgrade and finalize FeeOracle v3 in a single tx
+            oracleProxy.proxy__upgradeToAndCall(
+                deploymentConfig.oracleImpl,
+                abi.encodeCall(FeeOracle.finalizeUpgradeV3, (deployParams.consensusVersion))
+            );
             vm.stopBroadcast();
         }
 
@@ -190,20 +203,22 @@ contract SimulateVote is Script, ForkHelpersCommon {
         {
             OssifiableProxy accountingProxy = OssifiableProxy(payable(deploymentConfig.accounting));
             vm.startBroadcast(_prepareProxyAdmin(address(accountingProxy)));
-            // 7. Upgrade Accounting implementation
-            accountingProxy.proxy__upgradeTo(deploymentConfig.accountingImpl);
-            // 8. Finalize Accounting v3 upgrade
-            Accounting(deploymentConfig.accounting).finalizeUpgradeV3();
+            // 7-8. Upgrade and finalize Accounting v3 in a single tx
+            accountingProxy.proxy__upgradeToAndCall(
+                deploymentConfig.accountingImpl,
+                abi.encodeCall(Accounting.finalizeUpgradeV3, ())
+            );
             vm.stopBroadcast();
         }
 
         {
             OssifiableProxy feeDistributorProxy = OssifiableProxy(payable(deploymentConfig.feeDistributor));
             vm.startBroadcast(_prepareProxyAdmin(address(feeDistributorProxy)));
-            // 9. Upgrade FeeDistributor implementation
-            feeDistributorProxy.proxy__upgradeTo(deploymentConfig.feeDistributorImpl);
-            // 10. Finalize FeeDistributor v3 upgrade
-            FeeDistributor(deploymentConfig.feeDistributor).finalizeUpgradeV3();
+            // 9-10. Upgrade and finalize FeeDistributor v3 in a single tx
+            feeDistributorProxy.proxy__upgradeToAndCall(
+                deploymentConfig.feeDistributorImpl,
+                abi.encodeCall(FeeDistributor.finalizeUpgradeV3, ())
+            );
             vm.stopBroadcast();
         }
 


### PR DESCRIPTION
## Description

- Updated CSM, CSM0x02, and curated deploy scripts to pass init calldata on proxy deployment for atomic deploy-plus-initialize flows.
- Replaced split `proxy__upgradeTo` plus `initialize` paths with `proxy__upgradeToAndCall` for Accounting, module contracts, MetaRegistry (curated), and FeeOracle where applicable.
- Added overloaded `_deployProxy` helpers that accept init calldata while preserving the zero-calldata default path.
- Reworked `SimulateVote.upgrade()` to perform upgrade-plus-finalize calls atomically for CSModule, FeeOracle, Accounting, and FeeDistributor.
- Added simulation notes that real governance executes these steps in a single transaction via a temporary vote executor contract.

## Checklist

- [x] Appropriate PR labels applied
- [ ] Test coverage maintained (`just coverage`)
  - [x] No need to add/update tests
  - [ ] Tests are added/updated
- [x] Documentation maintained
  - [x] No need to update
  - [ ] Updated
