### PR TITLE
introduce lazy loading for Ejector's staking module id

### DIFF
--- a/script/csm/DeployBase.s.sol
+++ b/script/csm/DeployBase.s.sol
@@ -32,7 +32,6 @@ import { GIndex } from "../../src/lib/GIndex.sol";
 import { Slot } from "../../src/lib/Types.sol";
 import { MerkleGateFactory } from "../../src/MerkleGateFactory.sol";
 import { ExitPenalties } from "../../src/ExitPenalties.sol";
-import { IStakingRouter } from "../../src/interfaces/IStakingRouter.sol";
 
 struct DeployParams {
     // Lido addresses
@@ -69,7 +68,6 @@ struct DeployParams {
     address setResetBondCurveAddress;
     address chargePenaltyRecipient;
     // Module
-    uint256 stakingModuleId;
     bytes32 moduleType;
     address generalDelayedPenaltyReporter;
     uint8 topUpQueueLimit;
@@ -335,7 +333,7 @@ abstract contract DeployBase is Script {
                 exitPenaltiesProxy.proxy__changeAdmin(config.proxyAdmin);
             }
 
-            ejector = new Ejector(address(csm), address(strikes), config.stakingModuleId, deployer);
+            ejector = new Ejector(address(csm), address(strikes), deployer);
 
             strikes.initialize(deployer, address(ejector));
 
@@ -610,9 +608,5 @@ abstract contract DeployBase is Script {
         ejector.grantRole(ejector.DEFAULT_ADMIN_ROLE(), config.secondAdminAddress);
         verifier.grantRole(verifier.DEFAULT_ADMIN_ROLE(), config.secondAdminAddress);
         strikes.grantRole(strikes.DEFAULT_ADMIN_ROLE(), config.secondAdminAddress);
-    }
-
-    function _nextStakingModuleId(address locatorAddress) internal view returns (uint256) {
-        return IStakingRouter(ILidoLocator(locatorAddress).stakingRouter()).getStakingModulesCount() + 1;
     }
 }

--- a/script/csm/DeployCSMImplementationsBase.s.sol
+++ b/script/csm/DeployCSMImplementationsBase.s.sol
@@ -81,9 +81,7 @@ abstract contract DeployCSMImplementationsBase is DeployBase {
 
             ExitPenalties exitPenaltiesImpl = new ExitPenalties(address(csm), address(strikes));
 
-            uint256 stakingModuleId = Ejector(address(ejector)).STAKING_MODULE_ID();
-
-            ejector = new Ejector(address(csm), address(strikes), stakingModuleId, deployer);
+            ejector = new Ejector(address(csm), address(strikes), deployer);
 
             permissionlessGate = new PermissionlessGate(address(csm), deployer);
 
@@ -143,7 +141,6 @@ abstract contract DeployCSMImplementationsBase is DeployBase {
             verifierV3.grantRole(verifierV3.DEFAULT_ADMIN_ROLE(), config.aragonAgent);
             verifierV3.revokeRole(verifierV3.DEFAULT_ADMIN_ROLE(), deployer);
 
-            config.stakingModuleId = stakingModuleId;
             config.identifiedCommunityStakersGateCurveId = vettedGate.curveId();
             config.identifiedCommunityStakersGateTreeRoot = vettedGate.treeRoot();
             config.identifiedCommunityStakersGateTreeCid = vettedGate.treeCid();

--- a/script/csm/DeployHoodi.s.sol
+++ b/script/csm/DeployHoodi.s.sol
@@ -61,7 +61,6 @@ contract DeployHoodi is DeployBase {
         config.setResetBondCurveAddress = 0x4AF43Ee34a6fcD1fEcA1e1F832124C763561dA53; // Dev team EOA
         config.chargePenaltyRecipient = 0x0534aA41907c9631fae990960bCC72d75fA7cfeD; // locator.treasury()
         // Module
-        config.stakingModuleId = _nextStakingModuleId(config.lidoLocatorAddress);
         config.moduleType = "community-onchain-v1"; // Just a unique type name to be used by the off-chain tooling
         config.generalDelayedPenaltyReporter = 0x4AF43Ee34a6fcD1fEcA1e1F832124C763561dA53; // Dev team EOA
 

--- a/script/csm/DeployLocalDevNet.s.sol
+++ b/script/csm/DeployLocalDevNet.s.sol
@@ -51,7 +51,6 @@ contract DeployLocalDevNet is DeployBase {
         config.setResetBondCurveAddress = vm.envAddress("CSM_FIRST_ADMIN_ADDRESS"); // Dev team EOA
         config.chargePenaltyRecipient = vm.envAddress("CSM_FIRST_ADMIN_ADDRESS"); // Dev team EOA
         // Module
-        config.stakingModuleId = vm.envUint("CSM_STAKING_MODULE_ID");
         config.moduleType = "community-onchain-v1"; // Just a unique type name to be used by the off-chain tooling
         config.generalDelayedPenaltyReporter = vm.envAddress("CSM_FIRST_ADMIN_ADDRESS"); // Dev team EOA
 

--- a/script/csm/DeployMainnet.s.sol
+++ b/script/csm/DeployMainnet.s.sol
@@ -59,7 +59,6 @@ contract DeployMainnet is DeployBase {
         config.chargePenaltyRecipient = 0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c; // locator.treasury()
 
         // Module
-        config.stakingModuleId = _nextStakingModuleId(config.lidoLocatorAddress);
         config.moduleType = "community-onchain-v1"; // Just a unique type name to be used by the off-chain tooling
         config.generalDelayedPenaltyReporter = 0xC52fC3081123073078698F1EAc2f1Dc7Bd71880f; // CSM Committee MS
 

--- a/script/csm0x02/DeployCSM0x02Base.s.sol
+++ b/script/csm0x02/DeployCSM0x02Base.s.sol
@@ -30,7 +30,6 @@ import { CommonScriptUtils } from "../utils/Common.sol";
 import { GIndex } from "../../src/lib/GIndex.sol";
 import { Slot } from "../../src/lib/Types.sol";
 import { ExitPenalties } from "../../src/ExitPenalties.sol";
-import { IStakingRouter } from "../../src/interfaces/IStakingRouter.sol";
 
 struct DeployCSM0x02Params {
     // Lido addresses
@@ -66,7 +65,6 @@ struct DeployCSM0x02Params {
     address setResetBondCurveAddress;
     address chargePenaltyRecipient;
     // Module
-    uint256 stakingModuleId;
     bytes32 moduleType;
     address generalDelayedPenaltyReporter;
     uint8 topUpQueueLimit;
@@ -303,7 +301,7 @@ abstract contract DeployCSM0x02Base is Script {
                 exitPenaltiesProxy.proxy__changeAdmin(config.proxyAdmin);
             }
 
-            ejector = new Ejector(address(csm), address(strikes), config.stakingModuleId, deployer);
+            ejector = new Ejector(address(csm), address(strikes), deployer);
 
             strikes.initialize(deployer, address(ejector));
 
@@ -492,9 +490,5 @@ abstract contract DeployCSM0x02Base is Script {
         ejector.grantRole(ejector.DEFAULT_ADMIN_ROLE(), config.secondAdminAddress);
         verifier.grantRole(verifier.DEFAULT_ADMIN_ROLE(), config.secondAdminAddress);
         strikes.grantRole(strikes.DEFAULT_ADMIN_ROLE(), config.secondAdminAddress);
-    }
-
-    function _nextStakingModuleId(address locatorAddress) internal view returns (uint256) {
-        return IStakingRouter(ILidoLocator(locatorAddress).stakingRouter()).getStakingModulesCount() + 1;
     }
 }

--- a/script/csm0x02/DeployCSM0x02Hoodi.s.sol
+++ b/script/csm0x02/DeployCSM0x02Hoodi.s.sol
@@ -59,7 +59,6 @@ contract DeployCSM0x02Hoodi is DeployCSM0x02Base {
         config.setResetBondCurveAddress = 0x4AF43Ee34a6fcD1fEcA1e1F832124C763561dA53; // Dev team EOA
         config.chargePenaltyRecipient = 0x0534aA41907c9631fae990960bCC72d75fA7cfeD; // locator.treasury()
         // Module
-        config.stakingModuleId = _nextStakingModuleId(config.lidoLocatorAddress);
         config.moduleType = "community-onchain-v1"; // Just a unique type name to be used by the off-chain tooling
         config.generalDelayedPenaltyReporter = 0x4AF43Ee34a6fcD1fEcA1e1F832124C763561dA53; // Dev team EOA
 

--- a/script/csm0x02/DeployCSM0x02LocalDevNet.s.sol
+++ b/script/csm0x02/DeployCSM0x02LocalDevNet.s.sol
@@ -49,7 +49,6 @@ contract DeployCSM0x02LocalDevNet is DeployCSM0x02Base {
         config.setResetBondCurveAddress = vm.envAddress("CSM_FIRST_ADMIN_ADDRESS"); // Dev team EOA
         config.chargePenaltyRecipient = vm.envAddress("CSM_FIRST_ADMIN_ADDRESS"); // Dev team EOA
         // Module
-        config.stakingModuleId = vm.envUint("CSM_STAKING_MODULE_ID");
         config.moduleType = "community-onchain-v1"; // Just a unique type name to be used by the off-chain tooling
         config.generalDelayedPenaltyReporter = vm.envAddress("CSM_FIRST_ADMIN_ADDRESS"); // Dev team EOA
 

--- a/script/csm0x02/DeployCSM0x02Mainnet.s.sol
+++ b/script/csm0x02/DeployCSM0x02Mainnet.s.sol
@@ -57,7 +57,6 @@ contract DeployCSM0x02Mainnet is DeployCSM0x02Base {
         config.chargePenaltyRecipient = 0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c; // locator.treasury()
 
         // Module
-        config.stakingModuleId = _nextStakingModuleId(config.lidoLocatorAddress);
         config.moduleType = "community-onchain-v1"; // Just a unique type name to be used by the off-chain tooling
         config.generalDelayedPenaltyReporter = 0xC52fC3081123073078698F1EAc2f1Dc7Bd71880f; // CSM Committee MS
 

--- a/script/curated/DeployBase.s.sol
+++ b/script/curated/DeployBase.s.sol
@@ -26,7 +26,6 @@ import { BaseOracle } from "../../src/lib/base-oracle/BaseOracle.sol";
 import { IVerifier } from "../../src/interfaces/IVerifier.sol";
 import { IParametersRegistry } from "../../src/interfaces/IParametersRegistry.sol";
 import { IBondCurve } from "../../src/interfaces/IBondCurve.sol";
-import { IStakingRouter } from "../../src/interfaces/IStakingRouter.sol";
 
 import { JsonObj, Json } from "../utils/Json.sol";
 import { Dummy } from "../utils/Dummy.sol";
@@ -92,7 +91,6 @@ struct CuratedDeployParams {
     uint256 bondLockPeriod;
     address chargePenaltyRecipient;
     // Module
-    uint256 stakingModuleId;
     bytes32 moduleType;
     address generalDelayedPenaltyReporter;
     // ParametersRegistry
@@ -388,7 +386,7 @@ abstract contract DeployBase is Script {
                 exitPenaltiesProxy.proxy__changeAdmin(config.proxyAdmin);
             }
 
-            ejector = new Ejector(address(curatedModule), address(strikes), config.stakingModuleId, deployer);
+            ejector = new Ejector(address(curatedModule), address(strikes), deployer);
 
             strikes.initialize(deployer, address(ejector));
 
@@ -651,9 +649,5 @@ abstract contract DeployBase is Script {
         ejector.grantRole(ejector.DEFAULT_ADMIN_ROLE(), config.secondAdminAddress);
         verifier.grantRole(verifier.DEFAULT_ADMIN_ROLE(), config.secondAdminAddress);
         strikes.grantRole(strikes.DEFAULT_ADMIN_ROLE(), config.secondAdminAddress);
-    }
-
-    function _nextStakingModuleId(address locatorAddress) internal view returns (uint256) {
-        return IStakingRouter(ILidoLocator(locatorAddress).stakingRouter()).getStakingModulesCount() + 1;
     }
 }

--- a/script/curated/DeployHoodi.s.sol
+++ b/script/curated/DeployHoodi.s.sol
@@ -57,7 +57,6 @@ contract DeployHoodi is DeployBase {
         config.bondLockPeriod = 8 weeks;
         config.chargePenaltyRecipient = 0x0534aA41907c9631fae990960bCC72d75fA7cfeD; // locator.treasury()
         // Module
-        config.stakingModuleId = _nextStakingModuleId(config.lidoLocatorAddress);
         config.moduleType = "curated-onchain-v1"; // Just a unique type name to be used by the off-chain tooling
         config.generalDelayedPenaltyReporter = 0x4AF43Ee34a6fcD1fEcA1e1F832124C763561dA53; // Dev team EOA
 

--- a/script/curated/DeployLocalDevNet.s.sol
+++ b/script/curated/DeployLocalDevNet.s.sol
@@ -45,7 +45,6 @@ contract DeployLocalDevNet is DeployBase {
         config.bondLockPeriod = 1 days;
         config.chargePenaltyRecipient = vm.envAddress("CSM_FIRST_ADMIN_ADDRESS"); // Dev team EOA
         // Module
-        config.stakingModuleId = vm.envUint("CSM_STAKING_MODULE_ID");
         config.moduleType = "curated-onchain-v1"; // Just a unique type name to be used by the off-chain tooling
         config.generalDelayedPenaltyReporter = vm.envAddress("CSM_FIRST_ADMIN_ADDRESS"); // Dev team EOA
 

--- a/script/curated/DeployMainnet.s.sol
+++ b/script/curated/DeployMainnet.s.sol
@@ -56,7 +56,6 @@ contract DeployMainnet is DeployBase {
         config.chargePenaltyRecipient = 0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c; // locator.treasury()
 
         // Module
-        config.stakingModuleId = _nextStakingModuleId(config.lidoLocatorAddress);
         config.moduleType = "curated-onchain-v1"; // TODO reconsider
         config.generalDelayedPenaltyReporter = 0xC52fC3081123073078698F1EAc2f1Dc7Bd71880f; // TODO reconsider
 

--- a/src/Ejector.sol
+++ b/src/Ejector.sol
@@ -13,26 +13,26 @@ import { TransientUintUintMap, TransientUintUintMapLib } from "./lib/TransientUi
 
 import { IEjector } from "./interfaces/IEjector.sol";
 import { IBaseModule } from "./interfaces/IBaseModule.sol";
+import { IStakingRouter } from "./interfaces/IStakingRouter.sol";
 import { ITriggerableWithdrawalsGateway, ValidatorData } from "./interfaces/ITriggerableWithdrawalsGateway.sol";
 
 contract Ejector is IEjector, ExitTypes, AccessControlEnumerable, PausableWithRoles, AssetRecoverer {
-    uint256 public immutable STAKING_MODULE_ID;
     IBaseModule public immutable MODULE;
     address public immutable STRIKES;
+    uint256 public stakingModuleId;
 
     modifier onlyStrikes() {
         _onlyStrikes();
         _;
     }
 
-    constructor(address module, address strikes, uint256 stakingModuleId, address admin) {
+    constructor(address module, address strikes, address admin) {
         if (module == address(0)) revert ZeroModuleAddress();
         if (strikes == address(0)) revert ZeroStrikesAddress();
         if (admin == address(0)) revert ZeroAdminAddress();
 
         STRIKES = strikes;
         MODULE = IBaseModule(module);
-        STAKING_MODULE_ID = stakingModuleId;
 
         _grantRole(DEFAULT_ADMIN_ROLE, admin);
     }
@@ -50,6 +50,7 @@ contract Ejector is IEjector, ExitTypes, AccessControlEnumerable, PausableWithRo
         // Default to sender if no refund recipient is specified
         refundRecipient = _msgSenderIfEmpty(refundRecipient);
 
+        uint256 moduleId = _getOrCacheStakingModuleId();
         uint256 totalDepositedKeys = MODULE.getNodeOperator(nodeOperatorId).totalDepositedKeys;
         ValidatorData[] memory exitsData = new ValidatorData[](keyIndices.length);
         TransientUintUintMap seen = TransientUintUintMapLib.create();
@@ -68,11 +69,7 @@ contract Ejector is IEjector, ExitTypes, AccessControlEnumerable, PausableWithRo
             // there are no active keys available
             if (MODULE.isValidatorWithdrawn(nodeOperatorId, keyIndex)) revert AlreadyWithdrawn();
             bytes memory pubkey = MODULE.getSigningKeys(nodeOperatorId, keyIndex, 1);
-            exitsData[i] = ValidatorData({
-                stakingModuleId: STAKING_MODULE_ID,
-                nodeOperatorId: nodeOperatorId,
-                pubkey: pubkey
-            });
+            exitsData[i] = ValidatorData({ stakingModuleId: moduleId, nodeOperatorId: nodeOperatorId, pubkey: pubkey });
             emit VoluntaryEjectionRequested({
                 nodeOperatorId: nodeOperatorId,
                 pubkey: pubkey,
@@ -104,13 +101,10 @@ contract Ejector is IEjector, ExitTypes, AccessControlEnumerable, PausableWithRo
         // active keys available
         if (MODULE.isValidatorWithdrawn(nodeOperatorId, keyIndex)) revert AlreadyWithdrawn();
 
+        uint256 moduleId = _getOrCacheStakingModuleId();
         ValidatorData[] memory exitsData = new ValidatorData[](1);
         bytes memory pubkey = MODULE.getSigningKeys(nodeOperatorId, keyIndex, 1);
-        exitsData[0] = ValidatorData({
-            stakingModuleId: STAKING_MODULE_ID,
-            nodeOperatorId: nodeOperatorId,
-            pubkey: pubkey
-        });
+        exitsData[0] = ValidatorData({ stakingModuleId: moduleId, nodeOperatorId: nodeOperatorId, pubkey: pubkey });
         emit BadPerformerEjectionRequested({
             nodeOperatorId: nodeOperatorId,
             pubkey: pubkey,
@@ -128,6 +122,25 @@ contract Ejector is IEjector, ExitTypes, AccessControlEnumerable, PausableWithRo
     /// @inheritdoc IEjector
     function triggerableWithdrawalsGateway() public view returns (ITriggerableWithdrawalsGateway) {
         return ITriggerableWithdrawalsGateway(MODULE.LIDO_LOCATOR().triggerableWithdrawalsGateway());
+    }
+
+    function _getOrCacheStakingModuleId() internal returns (uint256 moduleId) {
+        moduleId = stakingModuleId;
+        if (moduleId != 0) return moduleId;
+
+        IStakingRouter stakingRouter = IStakingRouter(MODULE.LIDO_LOCATOR().stakingRouter());
+        uint256[] memory stakingModuleIds = stakingRouter.getStakingModuleIds();
+        for (uint256 i = stakingModuleIds.length; i > 0; i--) {
+            uint256 id = stakingModuleIds[i - 1];
+            IStakingRouter.StakingModule memory moduleInfo = stakingRouter.getStakingModule(id);
+            if (moduleInfo.stakingModuleAddress == address(MODULE)) {
+                stakingModuleId = id;
+                emit StakingModuleIdCached(id);
+                return id;
+            }
+        }
+
+        revert StakingModuleIdNotFound();
     }
 
     function _msgSenderIfEmpty(address input) internal view returns (address) {

--- a/src/interfaces/IEjector.sol
+++ b/src/interfaces/IEjector.sol
@@ -19,12 +19,14 @@ interface IEjector is IExitTypes {
     error NothingToEject();
     error DuplicateKeyIndex();
     error ZeroRefundRecipient();
+    error StakingModuleIdNotFound();
 
     event VoluntaryEjectionRequested(uint256 indexed nodeOperatorId, bytes pubkey, address refundRecipient);
 
     event BadPerformerEjectionRequested(uint256 indexed nodeOperatorId, bytes pubkey, address refundRecipient);
+    event StakingModuleIdCached(uint256 stakingModuleId);
 
-    function STAKING_MODULE_ID() external view returns (uint256);
+    function stakingModuleId() external view returns (uint256);
 
     function MODULE() external view returns (IBaseModule);
 

--- a/test/fork/deployment/PostDeploymentCommon.t.sol
+++ b/test/fork/deployment/PostDeploymentCommon.t.sol
@@ -449,7 +449,7 @@ contract EjectorDeploymentTest is DeploymentBaseTest {
 
     function test_immutables() public view {
         assertEq(address(ejector.MODULE()), address(module));
-        assertEq(ejector.STAKING_MODULE_ID(), deployParams.stakingModuleId);
+        assertEq(ejector.stakingModuleId(), 0);
         assertEq(address(ejector.STRIKES()), address(strikes));
     }
 

--- a/test/fork/integration/common/Ejection.t.sol
+++ b/test/fork/integration/common/Ejection.t.sol
@@ -4,6 +4,7 @@
 pragma solidity 0.8.33;
 
 import { IStakingModule } from "../../../../src/interfaces/IStakingModule.sol";
+import { IStakingRouter } from "../../../../src/interfaces/IStakingRouter.sol";
 import { IWithdrawalVault } from "../../../../src/interfaces/IWithdrawalVault.sol";
 import { IEjector } from "../../../../src/interfaces/IEjector.sol";
 import { ModuleTypeBase, CSMIntegrationBase, CSM0x02IntegrationBase, CuratedIntegrationBase } from "./ModuleTypeBase.sol";
@@ -89,6 +90,10 @@ abstract contract EjectionTestBase is ModuleTypeBase {
         vm.stopSnapshotGas();
 
         vm.assertEq(operatorOwner.balance, initialBalance - expectedFee * KEYS_COUNT);
+        uint256 moduleId = findModule();
+        assertEq(ejector.stakingModuleId(), moduleId);
+        IStakingRouter.StakingModule memory moduleInfo = stakingRouter.getStakingModule(moduleId);
+        assertEq(moduleInfo.stakingModuleAddress, address(module));
     }
 }
 

--- a/test/fork/integration/common/StakingRouter.t.sol
+++ b/test/fork/integration/common/StakingRouter.t.sol
@@ -5,6 +5,7 @@ pragma solidity 0.8.33;
 
 import { NodeOperator } from "src/interfaces/IBaseModule.sol";
 import { IStakingRouter } from "src/interfaces/IStakingRouter.sol";
+import { IWithdrawalVault } from "src/interfaces/IWithdrawalVault.sol";
 
 import { ExitPenaltyInfo } from "../../../../src/interfaces/IExitPenalties.sol";
 import { ModuleTypeBase, CSMIntegrationBase, CSM0x02IntegrationBase, CuratedIntegrationBase } from "./ModuleTypeBase.sol";
@@ -60,8 +61,28 @@ abstract contract StakingRouterIntegrationTestBase is ModuleTypeBase {
         assertTrue(moduleInfo.stakingModuleAddress == address(module));
     }
 
-    function test_validStakingModuleId() public view {
-        IStakingRouter.StakingModule memory moduleInfo = stakingRouter.getStakingModule(ejector.STAKING_MODULE_ID());
+    function test_stakingModuleIdIsUnsetOrMatchesModule() public {
+        uint256 ejectorModuleId = ejector.stakingModuleId();
+        if (ejectorModuleId == 0) {
+            (uint256 noId, uint256 keyIndex) = integrationHelpers.getDepositedNodeOperatorWithSequentialActiveKeys(
+                nextAddress(),
+                1
+            );
+            address owner = module.getNodeOperatorOwner(noId);
+
+            uint256[] memory keyIndices = new uint256[](1);
+            keyIndices[0] = keyIndex;
+
+            uint256 withdrawalRequestFee = IWithdrawalVault(locator.withdrawalVault()).getWithdrawalRequestFee();
+            vm.deal(owner, withdrawalRequestFee);
+            vm.prank(owner);
+            ejector.voluntaryEject{ value: withdrawalRequestFee }(noId, keyIndices, address(this));
+
+            ejectorModuleId = ejector.stakingModuleId();
+        }
+
+        assertEq(ejectorModuleId, moduleId);
+        IStakingRouter.StakingModule memory moduleInfo = stakingRouter.getStakingModule(ejectorModuleId);
         assertEq(moduleInfo.stakingModuleAddress, address(module));
     }
 

--- a/test/helpers/Fixtures.sol
+++ b/test/helpers/Fixtures.sol
@@ -113,7 +113,6 @@ contract DeploymentHelpers is Test {
         address secondAdminAddress;
         address chargePenaltyRecipient;
         address setResetBondCurveAddress;
-        uint256 stakingModuleId;
         bytes32 moduleType;
         uint256 queueLowestPriority;
         uint256 defaultDepositAllocationWeight;
@@ -449,7 +448,6 @@ contract DeploymentHelpers is Test {
         dst.chargePenaltyRecipient = src.chargePenaltyRecipient;
 
         // Module
-        dst.stakingModuleId = src.stakingModuleId;
         dst.moduleType = src.moduleType;
         dst.generalDelayedPenaltyReporter = src.generalDelayedPenaltyReporter;
 
@@ -531,7 +529,6 @@ contract DeploymentHelpers is Test {
         params.resealManager = decoded.resealManager;
         params.secondAdminAddress = decoded.secondAdminAddress;
         params.chargePenaltyRecipient = decoded.chargePenaltyRecipient;
-        params.stakingModuleId = decoded.stakingModuleId;
         params.moduleType = decoded.moduleType;
         params.queueLowestPriority = decoded.queueLowestPriority;
         params.bondLockPeriod = decoded.bondLockPeriod;
@@ -570,7 +567,6 @@ contract DeploymentHelpers is Test {
         params.secondAdminAddress = decoded.secondAdminAddress;
         params.chargePenaltyRecipient = decoded.chargePenaltyRecipient;
         params.setResetBondCurveAddress = decoded.setResetBondCurveAddress;
-        params.stakingModuleId = decoded.stakingModuleId;
         params.moduleType = decoded.moduleType;
         params.queueLowestPriority = decoded.queueLowestPriority;
         params.bondLockPeriod = decoded.bondLockPeriod;
@@ -609,7 +605,6 @@ contract DeploymentHelpers is Test {
         params.secondAdminAddress = decoded.secondAdminAddress;
         params.chargePenaltyRecipient = decoded.chargePenaltyRecipient;
         params.setResetBondCurveAddress = decoded.setResetBondCurveAddress;
-        params.stakingModuleId = decoded.stakingModuleId;
         params.moduleType = decoded.moduleType;
         params.queueLowestPriority = decoded.queueLowestPriority;
         params.bondLockPeriod = decoded.bondLockPeriod;

--- a/test/helpers/mocks/StakingRouterMock.sol
+++ b/test/helpers/mocks/StakingRouterMock.sol
@@ -57,6 +57,10 @@ contract StakingRouterMock {
         return module;
     }
 
+    function getStakingModuleIds() external view returns (uint256[] memory stakingModuleIds) {
+        return _moduleIds;
+    }
+
     function getStakingModulesCount() public view returns (uint256) {
         return _moduleIds.length;
     }

--- a/test/unit/Ejector.t.sol
+++ b/test/unit/Ejector.t.sol
@@ -11,6 +11,7 @@ import { NodeOperatorManagementProperties } from "src/interfaces/IBaseModule.sol
 import { IAccounting } from "src/interfaces/IAccounting.sol";
 import { Utilities } from "../helpers/Utilities.sol";
 import { CSMMock } from "../helpers/mocks/CSMMock.sol";
+import { StakingRouterMock } from "../helpers/mocks/StakingRouterMock.sol";
 import { TWGMock } from "../helpers/mocks/TWGMock.sol";
 import { Fixtures } from "../helpers/Fixtures.sol";
 import { ValidatorStrikesMock } from "../helpers/mocks/ValidatorStrikesMock.sol";
@@ -19,6 +20,7 @@ contract EjectorTestBase is Test, Utilities, Fixtures {
     Ejector internal ejector;
     CSMMock internal csm;
     ValidatorStrikesMock internal strikes;
+    StakingRouterMock internal stakingRouter;
     IAccounting internal accounting;
     TWGMock internal twg;
 
@@ -26,26 +28,29 @@ contract EjectorTestBase is Test, Utilities, Fixtures {
     address internal admin;
     address internal refundRecipient;
     uint256 internal constant NO_ID = 0;
-    uint256 internal constant STAKING_MODULE_ID = 0;
+    uint256 internal constant ROUTER_STAKING_MODULE_ID = 1;
 
     function setUp() public {
         csm = new CSMMock();
         accounting = csm.accounting();
         strikes = new ValidatorStrikesMock();
+        stakingRouter = StakingRouterMock(csm.LIDO_LOCATOR().stakingRouter());
         twg = TWGMock(payable(csm.LIDO_LOCATOR().triggerableWithdrawalsGateway()));
         stranger = nextAddress("STRANGER");
         admin = nextAddress("ADMIN");
         refundRecipient = nextAddress("refundRecipient");
 
-        ejector = new Ejector(address(csm), address(strikes), STAKING_MODULE_ID, admin);
+        stakingRouter.addModule(ROUTER_STAKING_MODULE_ID, address(csm));
+
+        ejector = new Ejector(address(csm), address(strikes), admin);
     }
 }
 
 contract EjectorTestMisc is EjectorTestBase {
     function test_constructor() public {
-        ejector = new Ejector(address(csm), address(strikes), STAKING_MODULE_ID, admin);
+        ejector = new Ejector(address(csm), address(strikes), admin);
         assertEq(address(ejector.MODULE()), address(csm));
-        assertEq(ejector.STAKING_MODULE_ID(), STAKING_MODULE_ID);
+        assertEq(ejector.stakingModuleId(), 0);
         assertEq(ejector.STRIKES(), address(strikes));
         assertEq(ejector.getRoleMemberCount(ejector.DEFAULT_ADMIN_ROLE()), 1);
         assertEq(ejector.getRoleMember(ejector.DEFAULT_ADMIN_ROLE(), 0), admin);
@@ -53,17 +58,17 @@ contract EjectorTestMisc is EjectorTestBase {
 
     function test_constructor_RevertWhen_ZeroModuleAddress() public {
         vm.expectRevert(IEjector.ZeroModuleAddress.selector);
-        new Ejector(address(0), address(strikes), STAKING_MODULE_ID, admin);
+        new Ejector(address(0), address(strikes), admin);
     }
 
     function test_constructor_RevertWhen_ZeroStrikesAddress() public {
         vm.expectRevert(IEjector.ZeroStrikesAddress.selector);
-        new Ejector(address(csm), address(0), STAKING_MODULE_ID, admin);
+        new Ejector(address(csm), address(0), admin);
     }
 
     function test_constructor_RevertWhen_ZeroAdminAddress() public {
         vm.expectRevert(IEjector.ZeroAdminAddress.selector);
-        new Ejector(address(csm), address(strikes), STAKING_MODULE_ID, address(0));
+        new Ejector(address(csm), address(strikes), address(0));
     }
 
     function test_pauseFor() public {
@@ -136,6 +141,8 @@ contract EjectorTestMisc is EjectorTestBase {
 
 contract EjectorTestVoluntaryEject is EjectorTestBase {
     function test_voluntaryEjectByArray_SingleKey() public {
+        assertEq(ejector.stakingModuleId(), 0);
+
         uint256 keyIndex = 0;
         bytes memory pubkey = csm.getSigningKeys(0, 0, 1);
 
@@ -146,7 +153,7 @@ contract EjectorTestVoluntaryEject is EjectorTestBase {
         );
 
         ValidatorData[] memory expectedExitsData = new ValidatorData[](1);
-        expectedExitsData[0] = ValidatorData(0, NO_ID, pubkey);
+        expectedExitsData[0] = ValidatorData(ROUTER_STAKING_MODULE_ID, NO_ID, pubkey);
         uint256 exitType = ejector.VOLUNTARY_EXIT_TYPE_ID();
 
         uint256[] memory indices = new uint256[](1);
@@ -161,12 +168,16 @@ contract EjectorTestVoluntaryEject is EjectorTestBase {
             )
         );
         vm.expectEmit(address(ejector));
+        emit IEjector.StakingModuleIdCached(ROUTER_STAKING_MODULE_ID);
+        vm.expectEmit(address(ejector));
         emit IEjector.VoluntaryEjectionRequested({
             nodeOperatorId: NO_ID,
             pubkey: pubkey,
             refundRecipient: refundRecipient
         });
         ejector.voluntaryEject(NO_ID, indices, refundRecipient);
+
+        assertEq(ejector.stakingModuleId(), ROUTER_STAKING_MODULE_ID);
     }
 
     function test_voluntaryEjectByArray_DefaultRefundRecipient() public {
@@ -180,7 +191,7 @@ contract EjectorTestVoluntaryEject is EjectorTestBase {
         );
 
         ValidatorData[] memory expectedExitsData = new ValidatorData[](1);
-        expectedExitsData[0] = ValidatorData(0, NO_ID, pubkey);
+        expectedExitsData[0] = ValidatorData(ROUTER_STAKING_MODULE_ID, NO_ID, pubkey);
         uint256 exitType = ejector.VOLUNTARY_EXIT_TYPE_ID();
 
         uint256[] memory indices = new uint256[](1);
@@ -217,7 +228,7 @@ contract EjectorTestVoluntaryEject is EjectorTestBase {
         bytes[] memory emittedPubkeys = new bytes[](keysCount);
         for (uint256 i; i < keysCount; ++i) {
             bytes memory pubkey = slice(pubkeys, 48 * i, 48);
-            expectedExitsData[i] = ValidatorData(0, NO_ID, pubkey);
+            expectedExitsData[i] = ValidatorData(ROUTER_STAKING_MODULE_ID, NO_ID, pubkey);
             emittedPubkeys[i] = pubkey;
         }
         uint256 exitType = ejector.VOLUNTARY_EXIT_TYPE_ID();
@@ -265,7 +276,7 @@ contract EjectorTestVoluntaryEject is EjectorTestBase {
         bytes[] memory emittedPubkeys = new bytes[](indices.length);
         for (uint256 i; i < indices.length; ++i) {
             bytes memory pubkey = slice(pubkeys, 48 * indices[i], 48);
-            expectedExitsData[i] = ValidatorData(0, NO_ID, pubkey);
+            expectedExitsData[i] = ValidatorData(ROUTER_STAKING_MODULE_ID, NO_ID, pubkey);
             emittedPubkeys[i] = pubkey;
         }
         uint256 exitType = ejector.VOLUNTARY_EXIT_TYPE_ID();
@@ -476,17 +487,36 @@ contract EjectorTestVoluntaryEject is EjectorTestBase {
         vm.expectRevert(IEjector.AlreadyWithdrawn.selector);
         ejector.voluntaryEject(NO_ID, indices, address(0));
     }
+
+    function test_voluntaryEjectByArray_revertWhen_StakingModuleIdNotFound() public {
+        uint256[] memory indices = new uint256[](1);
+        indices[0] = 0;
+
+        csm.mock_setNodeOperatorsCount(1);
+        csm.mock_setNodeOperatorTotalDepositedKeys(1);
+        csm.mock_setNodeOperatorManagementProperties(
+            NodeOperatorManagementProperties(address(this), address(this), false)
+        );
+
+        address[] memory modules = new address[](0);
+        stakingRouter.setModules(modules);
+
+        vm.expectRevert(IEjector.StakingModuleIdNotFound.selector);
+        ejector.voluntaryEject(NO_ID, indices, refundRecipient);
+    }
 }
 
 contract EjectorTestEjectBadPerformer is EjectorTestBase {
     function test_ejectBadPerformer_HappyPath() public {
+        assertEq(ejector.stakingModuleId(), 0);
+
         uint256 keyIndex = 0;
         bytes memory pubkey = csm.getSigningKeys(0, keyIndex, 1);
 
         csm.mock_setNodeOperatorTotalDepositedKeys(1);
 
         ValidatorData[] memory expectedExitsData = new ValidatorData[](1);
-        expectedExitsData[0] = ValidatorData(0, NO_ID, pubkey);
+        expectedExitsData[0] = ValidatorData(ROUTER_STAKING_MODULE_ID, NO_ID, pubkey);
         uint256 exitType = ejector.STRIKES_EXIT_TYPE_ID();
 
         vm.expectCall(
@@ -500,6 +530,8 @@ contract EjectorTestEjectBadPerformer is EjectorTestBase {
         );
 
         vm.expectEmit(address(ejector));
+        emit IEjector.StakingModuleIdCached(ROUTER_STAKING_MODULE_ID);
+        vm.expectEmit(address(ejector));
         emit IEjector.BadPerformerEjectionRequested({
             nodeOperatorId: NO_ID,
             pubkey: pubkey,
@@ -507,6 +539,8 @@ contract EjectorTestEjectBadPerformer is EjectorTestBase {
         });
         vm.prank(address(strikes));
         ejector.ejectBadPerformer(NO_ID, keyIndex, refundRecipient);
+
+        assertEq(ejector.stakingModuleId(), ROUTER_STAKING_MODULE_ID);
     }
 
     function test_ejectBadPerformer_revertWhen_ZeroRefundRecipient() public {
@@ -516,7 +550,7 @@ contract EjectorTestEjectBadPerformer is EjectorTestBase {
         csm.mock_setNodeOperatorTotalDepositedKeys(1);
 
         ValidatorData[] memory expectedExitsData = new ValidatorData[](1);
-        expectedExitsData[0] = ValidatorData(0, NO_ID, pubkey);
+        expectedExitsData[0] = ValidatorData(ROUTER_STAKING_MODULE_ID, NO_ID, pubkey);
         uint256 exitType = ejector.STRIKES_EXIT_TYPE_ID();
 
         vm.expectRevert(IEjector.ZeroRefundRecipient.selector);
@@ -563,6 +597,17 @@ contract EjectorTestEjectBadPerformer is EjectorTestBase {
         vm.prank(address(strikes));
         vm.expectRevert(IEjector.AlreadyWithdrawn.selector);
         ejector.ejectBadPerformer(NO_ID, keyIndex, refundRecipient);
+    }
+
+    function test_ejectBadPerformer_revertWhen_StakingModuleIdNotFound() public {
+        csm.mock_setNodeOperatorTotalDepositedKeys(1);
+
+        address[] memory modules = new address[](0);
+        stakingRouter.setModules(modules);
+
+        vm.prank(address(strikes));
+        vm.expectRevert(IEjector.StakingModuleIdNotFound.selector);
+        ejector.ejectBadPerformer(NO_ID, 0, refundRecipient);
     }
 
     function test_triggerableWithdrawalsGateway() public view {


### PR DESCRIPTION
## Description

- Remove preconfigured `stakingModuleId` wiring from CSM/CSM0x02/Curated deploy params and instantiate `Ejector` without a module id argument.
- Update `Ejector` to resolve staking module id from `stakingRouter.getStakingModuleIds()` on first ejection, cache it in storage, and emit `StakingModuleIdCached`.
- Unify voluntary ejection to the key-index array flow (`voluntaryEject`) and keep duplicate/withdrawn/deposit checks in the shared path.
- Extend unit and fork tests to cover lazy module id caching, `StakingModuleIdNotFound` revert paths, and deployment expectations with unset initial module id.

## Checklist

- [x] Appropriate PR labels applied
- [x] Test coverage maintained (`just coverage`)
  - [ ] No need to add/update tests
  - [x] Tests are added/updated
- [x] Documentation maintained
  - [x] No need to update
  - [ ] Updated
