### PR TITLE
feat: Add deposit info up to date tracker

### DIFF
--- a/src/Accounting.sol
+++ b/src/Accounting.sol
@@ -142,6 +142,7 @@ contract Accounting is
         BondCurveIntervalInput[] calldata bondCurve
     ) external onlyRole(MANAGE_BOND_CURVES_ROLE) {
         BondCurve._updateBondCurve(curveId, bondCurve);
+        MODULE.requestFullDepositInfoUpdate();
     }
 
     /// @inheritdoc IAccounting

--- a/src/CSModule.sol
+++ b/src/CSModule.sol
@@ -65,10 +65,9 @@ contract CSModule is ICSModule, BaseModule {
     ///      If the version 3 contract is deployed from scratch, the `initialize` method should be used instead.
     ///      To prevent possible frontrun this method should strictly be called in the same TX as the upgrade transaction and should not be called separately.
     function finalizeUpgradeV3() external reinitializer(INITIALIZED_VERSION) {
-        // Clean `__freeSlot1` and `__freeSlot2` since the storage slots are no longer needed in version 3.
+        // Clean `__freeSlot1` since the storage slot is no longer needed in version 3.
         assembly ("memory-safe") {
             sstore(__freeSlot1.slot, 0x00)
-            sstore(__freeSlot2.slot, 0x00)
         }
         // NOTE: Don't call `_initTopUpQueue` because it is disabled by default and existing CSM deployment can only support 0x01 validators mode.
 
@@ -80,6 +79,7 @@ contract CSModule is ICSModule, BaseModule {
             }
         }
         _totalWithdrawnValidators = totalWithdrawnValidators;
+        _upToDateOperatorDepositInfoCount = _nodeOperatorsCount;
     }
 
     /// @inheritdoc IStakingModule
@@ -94,6 +94,7 @@ contract CSModule is ICSModule, BaseModule {
         bytes calldata /* depositCalldata */
     ) external returns (bytes memory publicKeys, bytes memory signatures) {
         _checkStakingRouterRole();
+        _requireDepositInfoUpToDate();
 
         (publicKeys, signatures) = SigningKeys.initKeysSigsBuf(depositsCount);
         if (depositsCount == 0) return (publicKeys, signatures);
@@ -213,6 +214,9 @@ contract CSModule is ICSModule, BaseModule {
         _onlyEnabledTopUpQueue();
         _checkStakingRouterRole();
 
+        // We do not call `_requireDepositInfoUpToDate()` here since top-ups in CSM strictly follow the order of the deposit queue
+        // and the depositable keys count update is not required for the correct top-up queue processing.
+
         // Cap top-ups so we don't over-allocate to keys that lost balance due to CL penalties.
         uint256[] memory cappedTopUpLimits = NodeOperatorOps.capTopUpLimitsByKeyBalance(
             _keyAddedBalances,
@@ -269,11 +273,6 @@ contract CSModule is ICSModule, BaseModule {
         _topUpQueue().rewind(to.toUint32());
         emit TopUpQueueRewound(to);
         _incrementModuleNonce();
-    }
-
-    /// @inheritdoc IBaseModule
-    function onNodeOperatorBondCurveChange(uint256 nodeOperatorId) external override(IBaseModule) {
-        _updateDepositableValidatorsCount({ nodeOperatorId: nodeOperatorId, incrementNonceIfUpdated: true });
     }
 
     /// @inheritdoc ICSModule

--- a/src/CuratedModule.sol
+++ b/src/CuratedModule.sol
@@ -6,7 +6,7 @@ pragma solidity 0.8.33;
 import { ICuratedModule } from "./interfaces/ICuratedModule.sol";
 import { IMetaRegistry } from "./interfaces/IMetaRegistry.sol";
 import { IStakingModule, IStakingModuleV2 } from "./interfaces/IStakingModule.sol";
-import { IBaseModule, NodeOperator } from "./interfaces/IBaseModule.sol";
+import { NodeOperator } from "./interfaces/IBaseModule.sol";
 
 import { BaseModule } from "./abstract/BaseModule.sol";
 
@@ -59,6 +59,7 @@ contract CuratedModule is ICuratedModule, BaseModule {
         bytes calldata /* depositCalldata */
     ) external returns (bytes memory publicKeys, bytes memory signatures) {
         _checkStakingRouterRole();
+        _requireDepositInfoUpToDate();
 
         (uint256 allocated, uint256[] memory operatorIds, uint256[] memory allocations) = CuratedDepositAllocator
             .allocateInitialDeposits(_nodeOperators, _nodeOperatorsCount, depositsCount);
@@ -122,6 +123,7 @@ contract CuratedModule is ICuratedModule, BaseModule {
         uint256[] calldata topUpLimits
     ) external returns (uint256[] memory allocations) {
         _checkStakingRouterRole();
+        _requireDepositInfoUpToDate();
 
         if (maxDepositAmount == 0) return new uint256[](0);
         if (
@@ -172,13 +174,6 @@ contract CuratedModule is ICuratedModule, BaseModule {
         NOAddresses.changeNodeOperatorAddresses(_nodeOperators, nodeOperatorId, newManagerAddress, newRewardAddress);
     }
 
-    /// @inheritdoc IBaseModule
-    /// @dev This one is called in `Accounting.setBondCurve`.
-    function onNodeOperatorBondCurveChange(uint256 nodeOperatorId) external override(IBaseModule) {
-        _metaRegistry().refreshOperatorWeight(nodeOperatorId);
-        _updateDepositableValidatorsCount({ nodeOperatorId: nodeOperatorId, incrementNonceIfUpdated: true });
-    }
-
     /// @inheritdoc ICuratedModule
     function notifyNodeOperatorWeightChange(uint256 nodeOperatorId, uint256 newWeight) external {
         if (msg.sender != address(_metaRegistry())) revert SenderIsNotMetaRegistry();
@@ -199,6 +194,7 @@ contract CuratedModule is ICuratedModule, BaseModule {
     function getOperatorWeights(
         uint256[] calldata operatorIds
     ) external view returns (uint256[] memory operatorWeights) {
+        _requireDepositInfoUpToDate();
         return _metaRegistry().getOperatorWeights(operatorIds);
     }
 
@@ -211,6 +207,7 @@ contract CuratedModule is ICuratedModule, BaseModule {
     function getDepositsAllocation(
         uint256 maxDepositAmount
     ) external view returns (uint256 allocated, uint256[] memory operatorIds, uint256[] memory allocations) {
+        _requireDepositInfoUpToDate();
         uint256 operatorsCount = _nodeOperatorsCount;
         if (maxDepositAmount == 0 || operatorsCount == 0) return (0, new uint256[](0), new uint256[](0));
 
@@ -226,6 +223,11 @@ contract CuratedModule is ICuratedModule, BaseModule {
             allocationAmount: maxDepositAmount,
             operatorIds: allOperatorIds
         });
+    }
+
+    function _updateDepositInfo(uint256 nodeOperatorId) internal override {
+        _metaRegistry().refreshOperatorWeight(nodeOperatorId);
+        _updateDepositableValidatorsCount({ nodeOperatorId: nodeOperatorId, incrementNonceIfUpdated: true });
     }
 
     function _applyDepositableValidatorsCount(
@@ -316,6 +318,12 @@ contract CuratedModule is ICuratedModule, BaseModule {
 
     function _metaRegistry() internal view returns (IMetaRegistry) {
         return META_REGISTRY;
+    }
+
+    function _canRequestDepositInfoUpdate() internal view override {
+        if (msg.sender != address(_accounting()) && msg.sender != address(_metaRegistry())) {
+            revert SenderIsNotEligible();
+        }
     }
 
     function _storage() internal pure returns (CuratedModuleStorage storage $) {

--- a/src/MetaRegistry.sol
+++ b/src/MetaRegistry.sol
@@ -137,6 +137,7 @@ contract MetaRegistry is IMetaRegistry, Initializable, AccessControlEnumerableUp
 
         $.bondCurveWeight[curveId] = weight;
         emit BondCurveWeightSet(curveId, weight);
+        MODULE.requestFullDepositInfoUpdate();
     }
 
     /// @inheritdoc IMetaRegistry

--- a/src/abstract/BaseModule.sol
+++ b/src/abstract/BaseModule.sol
@@ -96,6 +96,11 @@ abstract contract BaseModule is
         unchecked {
             ++_nodeOperatorsCount;
         }
+
+        // If all operators have up-to-date deposit info, then the new operator also has it, so we can just increase the counter.
+        if (nodeOperatorId == _upToDateOperatorDepositInfoCount) {
+            ++_upToDateOperatorDepositInfoCount;
+        }
         _incrementModuleNonce();
     }
 
@@ -364,6 +369,38 @@ abstract contract BaseModule is
         _exitPenalties().processTriggeredExit(nodeOperatorId, publicKey, elWithdrawalRequestFeePaid, exitType);
     }
 
+    /// @inheritdoc IBaseModule
+    function onNodeOperatorBondCurveChange(uint256 nodeOperatorId) external {
+        _updateDepositInfo(nodeOperatorId);
+    }
+
+    /// @inheritdoc IBaseModule
+    function requestFullDepositInfoUpdate() external {
+        _canRequestDepositInfoUpdate();
+        _upToDateOperatorDepositInfoCount = 0;
+        _incrementModuleNonce();
+    }
+
+    /// @inheritdoc IBaseModule
+    function batchDepositInfoUpdate(uint256 maxCount) external returns (uint256 operatorsLeft) {
+        if (maxCount == 0) revert InvalidInput();
+
+        uint256 operatorsCount = _nodeOperatorsCount;
+        uint256 noId = _upToDateOperatorDepositInfoCount;
+        if (noId == operatorsCount) return 0;
+
+        uint256 limit = noId + maxCount > operatorsCount ? operatorsCount : noId + maxCount;
+
+        for (; noId < limit; ++noId) {
+            _updateDepositInfo(noId);
+        }
+
+        _upToDateOperatorDepositInfoCount = limit;
+        operatorsLeft = operatorsCount - limit;
+
+        if (operatorsLeft == 0) emit NodeOperatorDepositInfoFullyUpdated();
+    }
+
     /// @inheritdoc IStakingModule
     /// @dev This method is not used in the module since rewards are distributed by a performance oracle,
     ///      hence it does nothing
@@ -551,6 +588,11 @@ abstract contract BaseModule is
         return _keyAddedBalances[KeyPointerLib.keyPointer(nodeOperatorId, keyIndex)];
     }
 
+    /// @inheritdoc IBaseModule
+    function getNodeOperatorDepositInfoToUpdateCount() external view returns (uint256 count) {
+        count = _nodeOperatorsCount - _upToDateOperatorDepositInfoCount;
+    }
+
     // solhint-disable-next-line func-name-mixedcase
     function __BaseModule_init(address admin) internal {
         if (admin == address(0)) revert ZeroAdminAddress();
@@ -560,6 +602,10 @@ abstract contract BaseModule is
 
         // Module is on pause initially and should be resumed during the vote
         _pauseFor(PausableUntil.PAUSE_INFINITELY);
+    }
+
+    function _updateDepositInfo(uint256 nodeOperatorId) internal virtual {
+        _updateDepositableValidatorsCount({ nodeOperatorId: nodeOperatorId, incrementNonceIfUpdated: true });
     }
 
     function _reportWithdrawnValidators(WithdrawnValidatorInfo[] calldata validatorInfos, bool slashed) internal {
@@ -736,6 +782,17 @@ abstract contract BaseModule is
     /// @dev This function is used to get the parameters registry contract from immutables to save bytecode.
     function _parametersRegistry() internal view returns (IParametersRegistry) {
         return PARAMETERS_REGISTRY;
+    }
+
+    function _requireDepositInfoUpToDate() internal view {
+        if (_upToDateOperatorDepositInfoCount != _nodeOperatorsCount) revert DepositInfoIsNotUpToDate();
+    }
+
+    /// @dev Default implementation of the guard for requesting deposit info update.
+    function _canRequestDepositInfoUpdate() internal view virtual {
+        if (msg.sender != address(_accounting())) {
+            revert SenderIsNotEligible();
+        }
     }
 
     function _onlyRecoverer() internal view override {

--- a/src/abstract/ModuleLinearStorage.sol
+++ b/src/abstract/ModuleLinearStorage.sol
@@ -12,7 +12,7 @@ abstract contract ModuleLinearStorage {
     mapping(uint256 priority => DepositQueueLib.Queue queue) internal _depositQueueByPriority;
 
     bytes32 internal __freeSlot1;
-    bytes32 internal __freeSlot2;
+    uint256 internal _upToDateOperatorDepositInfoCount;
     /// @dev Total number of withdrawn validators reported for the module.
     uint256 internal _totalWithdrawnValidators;
     mapping(uint256 noKeyIndexPacked => uint256) internal _keyAddedBalances;

--- a/src/interfaces/IBaseModule.sol
+++ b/src/interfaces/IBaseModule.sol
@@ -95,6 +95,7 @@ interface IBaseModule is IStakingModule, IAccessControlEnumerable, INOAddresses,
     event GeneralDelayedPenaltyCancelled(uint256 indexed nodeOperatorId, uint256 amount);
     event GeneralDelayedPenaltyCompensated(uint256 indexed nodeOperatorId, uint256 amount);
     event GeneralDelayedPenaltySettled(uint256 indexed nodeOperatorId);
+    event NodeOperatorDepositInfoFullyUpdated();
 
     error CannotAddKeys();
     error NodeOperatorDoesNotExist();
@@ -123,6 +124,7 @@ interface IBaseModule is IStakingModule, IAccessControlEnumerable, INOAddresses,
     error ZeroModuleType();
     error ZeroPenaltyType();
     error NothingCompensated();
+    error DepositInfoIsNotUpToDate();
 
     function STAKING_ROUTER_ROLE() external view returns (bytes32);
 
@@ -292,6 +294,20 @@ interface IBaseModule is IStakingModule, IAccessControlEnumerable, INOAddresses,
     /// @notice Notify the module about a node operator bond curve change.
     /// @param nodeOperatorId ID of the Node Operator
     function onNodeOperatorBondCurveChange(uint256 nodeOperatorId) external;
+
+    /// @notice Request a full update of deposit info for all node operators.
+    ///         Should be called after external changes that can affect deposit info such as bond curve change or parameters update.
+    function requestFullDepositInfoUpdate() external;
+
+    /// @notice Request a batch update of deposit info for node operators.
+    ///         If `requestFullDepositInfoUpdate` was called before, the update will start from the first operator.
+    ///         Otherwise, it will continue from the next operator after the last updated one.
+    /// @param maxCount Maximum number of operators to update in this batch
+    /// @return operatorsLeft Number of operators left to update
+    function batchDepositInfoUpdate(uint256 maxCount) external returns (uint256 operatorsLeft);
+
+    /// @notice Get the number of Node Operators with outdated deposit info that requires update.
+    function getNodeOperatorDepositInfoToUpdateCount() external view returns (uint256 count);
 
     /// @notice Get Node Operator info
     /// @param nodeOperatorId ID of the Node Operator

--- a/test/fork/deployment/PostDeploymentCSM.t.sol
+++ b/test/fork/deployment/PostDeploymentCSM.t.sol
@@ -37,13 +37,12 @@ contract DeploymentBaseTest is Test, Utilities, DeploymentFixtures {
 contract ModuleDeploymentTest is DeploymentBaseTest {
     function test_state_onlyFull() public view {
         assertEq(module.getInitializedVersion(), 3);
+        assertEq(module.getNodeOperatorDepositInfoToUpdateCount(), 0);
     }
 
     function test_unusedStorageSlots_onlyFull() public {
         bytes32 slot1 = vm.load(address(module), bytes32(uint256(1)));
-        bytes32 slot2 = vm.load(address(module), bytes32(uint256(2)));
         assertEq(slot1, bytes32(0), "assert __freeSlot1 is empty");
-        assertEq(slot2, bytes32(0), "assert __freeSlot2 is empty");
     }
 
     function test_roles_onlyFull() public view {

--- a/test/fork/vote-upgrade/V3Upgrade.t.sol
+++ b/test/fork/vote-upgrade/V3Upgrade.t.sol
@@ -155,6 +155,8 @@ contract VoteChangesTest is V3UpgradeTestBase {
         assertEq(totalDepositedValidatorsBefore, totalDepositedValidatorsAfter);
         assertEq(depositableValidatorsCountBefore, depositableValidatorsCountAfter);
         assertEq(totalNodeOperatorsBefore, totalNodeOperatorsAfter);
+
+        assertEq(module.getNodeOperatorDepositInfoToUpdateCount(), 0);
     }
 
     function test_csmQueuePriorityRange() public {

--- a/test/helpers/Fixtures.sol
+++ b/test/helpers/Fixtures.sol
@@ -1088,9 +1088,7 @@ contract CuratedIntegrationHelpers is ForkIntegrationHelpersBase {
         if (r.getBondCurveWeight(curveId) == 0) {
             r.setBondCurveWeight(curveId, 1);
             CuratedModule cm = CuratedModule(address(module));
-            for (uint256 i = 0; i < cm.getNodeOperatorsCount(); ++i) {
-                r.refreshOperatorWeight(i);
-            }
+            cm.batchDepositInfoUpdate(cm.getNodeOperatorsCount());
         }
     }
 

--- a/test/helpers/InvariantAsserts.sol
+++ b/test/helpers/InvariantAsserts.sol
@@ -143,10 +143,8 @@ contract InvariantAsserts is Test {
         if (skipInvariants()) return;
 
         bytes32 slot1 = vm.load(address(module), bytes32(uint256(1)));
-        bytes32 slot2 = vm.load(address(module), bytes32(uint256(2)));
 
         assertEq(slot1, bytes32(0), "assert __freeSlot1 is empty");
-        assertEq(slot2, bytes32(0), "assert __freeSlot2 is empty");
     }
 
     function assertAccountingTotalBondShares(uint256 nodeOperatorsCount, IStETH steth, Accounting accounting) public {

--- a/test/helpers/mocks/CuratedMock.sol
+++ b/test/helpers/mocks/CuratedMock.sol
@@ -19,4 +19,6 @@ contract CuratedMock is CSMMock {
     }
 
     function notifyNodeOperatorWeightChange(uint256, uint256) external {}
+
+    function requestFullDepositInfoUpdate() external {}
 }

--- a/test/unit/Accounting/BondCalculations.t.sol
+++ b/test/unit/Accounting/BondCalculations.t.sol
@@ -37,6 +37,10 @@ contract BondCurveTest is BaseTest {
 
         uint256 toUpdate = 0;
 
+        vm.expectCall(
+            address(accounting.MODULE()),
+            abi.encodeWithSelector(IBaseModule.requestFullDepositInfoUpdate.selector)
+        );
         vm.prank(admin);
         accounting.updateBondCurve(toUpdate, curvePoints);
 

--- a/test/unit/Accounting/_Base.t.sol
+++ b/test/unit/Accounting/_Base.t.sol
@@ -111,6 +111,14 @@ contract AccountingFixtures is Test, Fixtures, Utilities, InvariantAsserts {
         );
     }
 
+    function mock_requestFullDepositInfoUpdate() internal {
+        vm.mockCall(
+            address(stakingModule),
+            abi.encodeWithSelector(IBaseModule.requestFullDepositInfoUpdate.selector),
+            ""
+        );
+    }
+
     function addBond(uint256 nodeOperatorId, uint256 amount) internal {
         vm.deal(address(stakingModule), amount);
         vm.prank(address(stakingModule));
@@ -135,6 +143,7 @@ contract BaseTest is AccountingFixtures {
         stakingModule = new Stub();
         mock_updateDepositableValidatorsCount();
         mock_onNodeOperatorBondCurveChange(0);
+        mock_requestFullDepositInfoUpdate();
 
         IBondCurve.BondCurveIntervalInput[] memory curve = new IBondCurve.BondCurveIntervalInput[](1);
         curve[0] = IBondCurve.BondCurveIntervalInput({ minKeysCount: 1, trend: 2 ether });

--- a/test/unit/CSModule.t.sol
+++ b/test/unit/CSModule.t.sol
@@ -551,6 +551,16 @@ contract CSMObtainDepositData is ModuleObtainDepositData, CSMCommon {
         module.obtainDepositData(2, "");
     }
 
+    function test_obtainDepositData_RevertWhen_DepositInfoIsNotUpToDate() public assertInvariants {
+        uint256 noId = createNodeOperator(1);
+
+        vm.prank(address(accounting));
+        module.requestFullDepositInfoUpdate();
+
+        vm.expectRevert(IBaseModule.DepositInfoIsNotUpToDate.selector);
+        module.obtainDepositData(1, "");
+    }
+
     function testFuzz_obtainDepositData_OneOperator_enqueuedCount(
         uint256 batchCount,
         uint256 random
@@ -1990,6 +2000,28 @@ contract CSMMisc is ModuleMisc, CSMCommon {
         uint256 noId = createNodeOperator(3);
         csm.updateOperatorBalances(randomBytes(48), randomBytes(48));
     }
+
+    function test_requestFullDepositInfoUpdate_fromAccounting() public {
+        createNodeOperator(1);
+
+        uint256 nonceBefore = module.getNonce();
+
+        vm.prank(address(accounting));
+        module.requestFullDepositInfoUpdate();
+
+        uint256 nonceAfter = module.getNonce();
+
+        assertEq(module.getNodeOperatorDepositInfoToUpdateCount(), 1);
+        assertEq(nonceAfter, nonceBefore + 1);
+    }
+
+    function test_requestFullDepositInfoUpdate_revertWhen_SenderIsNotEligible() public {
+        createNodeOperator(1);
+
+        vm.expectRevert(IBaseModule.SenderIsNotEligible.selector);
+        vm.prank(nextAddress());
+        module.requestFullDepositInfoUpdate();
+    }
 }
 
 contract CSMExitDeadlineThreshold is ModuleExitDeadlineThreshold, CSMCommon {}
@@ -2001,3 +2033,5 @@ contract CSMReportValidatorExitDelay is ModuleReportValidatorExitDelay, CSMCommo
 contract CSMOnValidatorExitTriggered is ModuleOnValidatorExitTriggered, CSMCommon {}
 
 contract CSMCreateNodeOperators is ModuleCreateNodeOperators, CSMCommon {}
+
+contract CSMBatchDepositInfoUpdate is ModuleBatchDepositInfoUpdate, CSMCommon {}

--- a/test/unit/CuratedModule.t.sol
+++ b/test/unit/CuratedModule.t.sol
@@ -469,7 +469,7 @@ contract CuratedObtainDepositData is ModuleObtainDepositData, CuratedCommon {
         assertEq(no1.totalDepositedKeys, 2);
     }
 
-    function test_obtainDepositData_RevertWhen_NotEnoughCapacity() public {
+    function test_obtainDepositData_NotEnoughCapacity() public {
         uint256 noId = createNodeOperator(1);
 
         bytes memory expectedKeys = module.getSigningKeys(noId, 0, 1);
@@ -481,7 +481,7 @@ contract CuratedObtainDepositData is ModuleObtainDepositData, CuratedCommon {
         assertEq(pubkeys, expectedKeys);
     }
 
-    function test_obtainDepositData_RevertWhen_WeightedCapacityTooLow() public assertInvariants {
+    function test_obtainDepositData_WeightedCapacityTooLow() public assertInvariants {
         uint256 zeroWeightId = createNodeOperator(2);
         uint256 weightedId = createNodeOperator(1);
 
@@ -567,6 +567,16 @@ contract CuratedObtainDepositData is ModuleObtainDepositData, CuratedCommon {
         assertEq(no0.totalDepositedKeys, 2);
         assertEq(no1.totalDepositedKeys, 1);
         assertEq(pubkeys, expectedKeys);
+    }
+
+    function test_obtainDepositData_revertWhen_DepositInfoIsNotUpToDate() public assertInvariants {
+        createNodeOperator(1);
+
+        vm.prank(address(accounting));
+        module.requestFullDepositInfoUpdate();
+
+        vm.expectRevert(IBaseModule.DepositInfoIsNotUpToDate.selector);
+        module.obtainDepositData(1, "");
     }
 }
 
@@ -1010,6 +1020,26 @@ contract CuratedTopUpObtainDepositData is CuratedCommon {
         }
     }
 
+    function test_topUpObtainDepositData_revertWhen_DepositInfoIsNotUpToDate() public assertInvariants {
+        uint256 noId = createNodeOperator(2);
+        module.obtainDepositData(2, "");
+
+        vm.prank(address(accounting));
+        module.requestFullDepositInfoUpdate();
+
+        bytes memory key0 = module.getSigningKeys(noId, 0, 1);
+        bytes memory key1 = module.getSigningKeys(noId, 1, 1);
+
+        vm.expectRevert(IBaseModule.DepositInfoIsNotUpToDate.selector);
+        cm.allocateDeposits(
+            10 ether,
+            BytesArr(key0, key1),
+            UintArr(0, 1),
+            UintArr(noId, noId),
+            UintArr(3 ether, 3 ether)
+        );
+    }
+
     function test_getDepositsAllocation_matchesObtainDepositData() public assertInvariants {
         uint256 firstId = createNodeOperator(1);
         uint256 secondId = createNodeOperator(1);
@@ -1039,6 +1069,18 @@ contract CuratedTopUpObtainDepositData is CuratedCommon {
         assertEq(ids[1], secondId);
         assertEq(allocs[0], keyAllocations[0]);
         assertEq(allocs[1], keyAllocations[1]);
+    }
+
+    function test_getDepositsAllocation_revertWhen_DepositInfoIsNotUpToDate() public assertInvariants {
+        uint256 firstId = createNodeOperator(1);
+        uint256 secondId = createNodeOperator(1);
+        module.obtainDepositData(2, "");
+
+        vm.prank(address(accounting));
+        module.requestFullDepositInfoUpdate();
+
+        vm.expectRevert(IBaseModule.DepositInfoIsNotUpToDate.selector);
+        cm.getDepositsAllocation(2 ether);
     }
 
     function test_getDepositsAllocation_matchesObtainDepositData_twoSteps() public assertInvariants {
@@ -1536,6 +1578,25 @@ contract CuratedGetOperatorsWeights is CuratedCommon {
         uint256[] memory weights = cm.getOperatorWeights(operatorIds);
         assertEq(weights, expectedWeights);
     }
+
+    function test_getOperatorWeights_revertWhen_DepositInfoIsNotUpToDate() public assertInvariants {
+        createNodeOperator(1);
+        createNodeOperator(1);
+
+        uint256[] memory operatorIds = UintArr(0, 1);
+        uint256[] memory expectedWeights = UintArr(42, 7);
+        vm.mockCall(
+            address(metaRegistry),
+            abi.encodeWithSelector(IMetaRegistry.getOperatorWeights.selector, operatorIds),
+            abi.encode(expectedWeights)
+        );
+
+        vm.prank(address(accounting));
+        module.requestFullDepositInfoUpdate();
+
+        vm.expectRevert(IBaseModule.DepositInfoIsNotUpToDate.selector);
+        cm.getOperatorWeights(operatorIds);
+    }
 }
 
 contract CuratedProposeNodeOperatorManagerAddressChange is
@@ -1712,6 +1773,42 @@ contract CuratedMisc is ModuleMisc, CuratedCommon {
 
         uint256 depositableAfter = module.getNodeOperator(noId).depositableValidatorsCount;
         assertEq(depositableAfter, 0);
+    }
+
+    function test_requestFullDepositInfoUpdate_fromAccounting() public {
+        createNodeOperator(1);
+
+        uint256 nonceBefore = module.getNonce();
+
+        vm.prank(address(accounting));
+        module.requestFullDepositInfoUpdate();
+
+        uint256 nonceAfter = module.getNonce();
+
+        assertEq(module.getNodeOperatorDepositInfoToUpdateCount(), 1);
+        assertEq(nonceAfter, nonceBefore + 1);
+    }
+
+    function test_requestFullDepositInfoUpdate_fromMetaRegistry() public {
+        createNodeOperator(1);
+
+        uint256 nonceBefore = module.getNonce();
+
+        vm.prank(address(metaRegistry));
+        module.requestFullDepositInfoUpdate();
+
+        uint256 nonceAfter = module.getNonce();
+
+        assertEq(module.getNodeOperatorDepositInfoToUpdateCount(), 1);
+        assertEq(nonceAfter, nonceBefore + 1);
+    }
+
+    function test_requestFullDepositInfoUpdate_revertWhen_SenderIsNotEligible() public {
+        createNodeOperator(1);
+
+        vm.expectRevert(IBaseModule.SenderIsNotEligible.selector);
+        vm.prank(nextAddress());
+        module.requestFullDepositInfoUpdate();
     }
 }
 
@@ -2037,3 +2134,5 @@ contract CuratedHooks is CuratedCommon {
         cm.notifyNodeOperatorWeightChange(0, 0);
     }
 }
+
+contract CuratedBatchDepositInfoUpdate is ModuleBatchDepositInfoUpdate, CuratedCommon {}

--- a/test/unit/MetaRegistry.t.sol
+++ b/test/unit/MetaRegistry.t.sol
@@ -11,6 +11,7 @@ import { MetaRegistry } from "src/MetaRegistry.sol";
 import { IMetaRegistry, OperatorMetadata } from "src/interfaces/IMetaRegistry.sol";
 import { NodeOperatorManagementProperties } from "src/interfaces/IBaseModule.sol";
 import { ICuratedModule } from "src/interfaces/ICuratedModule.sol";
+import { IBaseModule } from "src/interfaces/IBaseModule.sol";
 import { IStakingRouter } from "src/interfaces/IStakingRouter.sol";
 import { ExternalOperatorLib } from "src/lib/ExternalOperatorLib.sol";
 
@@ -969,6 +970,9 @@ contract MetaRegistryTestBondCurve is MetaRegistryTestGroupsBase {
     function test_getBondCurveWeight_ReturnsValue() public {
         assertEq(registry.getBondCurveWeight(0), 0);
 
+        vm.expectCall(address(module), abi.encodeWithSelector(IBaseModule.requestFullDepositInfoUpdate.selector));
+        vm.expectEmit(address(registry));
+        emit IMetaRegistry.BondCurveWeightSet(0, 123);
         vm.prank(bondCurveWeightManager);
         registry.setBondCurveWeight(0, 123);
 

--- a/test/unit/ModuleAbstract/Core.t.sol
+++ b/test/unit/ModuleAbstract/Core.t.sol
@@ -198,10 +198,6 @@ contract MyModule is BaseModule {
         revert NotImplementedInTest();
     }
 
-    function onNodeOperatorBondCurveChange(uint256 nodeOperatorId) external {
-        revert NotImplementedInTest();
-    }
-
     function helper_grantRole(bytes32 role, address who) external {
         _grantRole(role, who);
     }

--- a/test/unit/ModuleAbstract/Deposits.t.sol
+++ b/test/unit/ModuleAbstract/Deposits.t.sol
@@ -795,3 +795,59 @@ abstract contract ModuleNodeOperatorStateAfterUpdateCurve is ModuleFixtures {
         );
     }
 }
+
+abstract contract ModuleBatchDepositInfoUpdate is ModuleFixtures {
+    function test_batchDepositInfoUpdate() public assertInvariants {
+        createNodeOperator(1);
+        createNodeOperator(1);
+        createNodeOperator(1);
+
+        vm.prank(address(accounting));
+        module.requestFullDepositInfoUpdate();
+
+        vm.expectEmit(address(module));
+        emit IBaseModule.NodeOperatorDepositInfoFullyUpdated();
+        uint256 left = module.batchDepositInfoUpdate(3);
+
+        assertEq(left, 0);
+    }
+
+    function test_batchDepositInfoUpdate_revertWhen_InvalidInput() public assertInvariants {
+        createNodeOperator(1);
+        createNodeOperator(1);
+        createNodeOperator(1);
+
+        vm.prank(address(accounting));
+        module.requestFullDepositInfoUpdate();
+
+        vm.expectRevert(IBaseModule.InvalidInput.selector);
+        module.batchDepositInfoUpdate(0);
+    }
+
+    function test_batchDepositInfoUpdate_nothingToUpdate() public assertInvariants {
+        createNodeOperator(1);
+        createNodeOperator(1);
+        createNodeOperator(1);
+
+        uint256 left = module.batchDepositInfoUpdate(3);
+
+        assertEq(left, 0);
+    }
+
+    function test_batchDepositInfoUpdate_partialUpdate() public assertInvariants {
+        createNodeOperator(1);
+        createNodeOperator(1);
+        createNodeOperator(1);
+
+        vm.prank(address(accounting));
+        module.requestFullDepositInfoUpdate();
+
+        vm.recordLogs();
+        uint256 left = module.batchDepositInfoUpdate(2);
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+
+        assertEq(logs.length, 0);
+
+        assertEq(left, 1);
+    }
+}

--- a/test/unit/ModuleAbstract/NodeOperators.t.sol
+++ b/test/unit/ModuleAbstract/NodeOperators.t.sol
@@ -27,6 +27,26 @@ abstract contract ModuleCreateNodeOperator is ModuleFixtures {
         assertEq(module.getNodeOperatorsCount(), 1);
         assertEq(module.getNonce(), nonce + 1);
         assertEq(nodeOperatorId, 0);
+        assertEq(module.getNodeOperatorDepositInfoToUpdateCount(), 0);
+    }
+
+    function test_createNodeOperator_whenDepositInfoUpdateIsRequested() public assertInvariants {
+        createNodeOperator(1);
+        vm.prank(address(accounting));
+        module.requestFullDepositInfoUpdate();
+        assertEq(module.getNodeOperatorDepositInfoToUpdateCount(), 1);
+
+        module.createNodeOperator(
+            nodeOperator,
+            NodeOperatorManagementProperties({
+                managerAddress: address(0),
+                rewardAddress: address(0),
+                extendedManagerPermissions: false
+            }),
+            address(0)
+        );
+
+        assertEq(module.getNodeOperatorDepositInfoToUpdateCount(), 2);
     }
 
     function test_createNodeOperator_withCustomAddresses() public assertInvariants {


### PR DESCRIPTION
## Description

Add a deposit info up-to-date tracker. Deposit info might become stale in cases such as bond curve value updates and bond curve weight changes. In all of these cases, we need to walk through all operators and trigger the deposit info update for them.

## Checklist

- [x] Appropriate PR labels applied
- [x] Test coverage maintained (`just coverage`)
  - [x] Tests are added/updated
- [x] Documentation maintained
  - [x] Updated
