### PR TITLE
feat: add syncKeyAddedBalance to module

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -2,6 +2,7 @@
   "plugins": ["prettier-plugin-solidity"],
   "singleQuote": false,
   "trailingComma": "all",
+  "printWidth": 100,
   "overrides": [
     {
       "files": "*.sol",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,7 @@
 - While refactoring keep comments added from existing implementations where applicable.
 - Make sure external functions in contracts and interfaces have proper natspec.
 - Avoid using magic numbers, prefer re-using or defining constants.
+- Inline values used only once where the variable name does not add legibility.
 - When last I looked, the year was 2026.
 
 ## Testing Guidelines
@@ -44,6 +45,7 @@
 - Run: `just test-unit` for fast cycles; `CHAIN`/`RPC_URL` required for fork tests. Example: `export CHAIN=hoodi && export RPC_URL=<https-url>`.
 - Coverage: `just coverage-lcov` produces LCOV output (commit if relevant).
 - After making changes to the source code make sure you've either ran build command or unit tests.
+- Do not assert unchanged state after a reverting call.
 - Deployment test name suffixes are part of the test selection contract used by `just` recipes and encode two axes: phase and flow.
 - Phase semantics:
 - `*_scratch*`: checks for post-deploy, pre-vote state only.

--- a/src/Verifier.sol
+++ b/src/Verifier.sol
@@ -239,14 +239,53 @@ contract Verifier is IVerifier, AccessControlEnumerable, PausableWithRoles {
     }
 
     /// @inheritdoc IVerifier
-    function processIncomingConsolidation(
-        uint256 nodeOperatorId,
-        uint256 keyIndex,
-        uint256 addedBalanceWei
-    ) external whenResumed {
-        MODULE.increaseKeyAddedBalance(nodeOperatorId, keyIndex, addedBalanceWei);
-        // TODO implement
-        revert NotImplemented();
+    function processBalanceProof(ProcessBalanceProofInput calldata data) external whenResumed {
+        if (data.recentBlock.header.slot < FIRST_SUPPORTED_SLOT) {
+            revert UnsupportedSlot(data.recentBlock.header.slot);
+        }
+
+        {
+            bytes32 trustedHeaderRoot = _getParentBlockRoot(data.recentBlock.rootsTimestamp);
+            if (trustedHeaderRoot != data.recentBlock.header.hashTreeRoot()) revert InvalidBlockHeader();
+        }
+
+        uint64 balanceGwei = _processBalanceProof(
+            data.validator,
+            data.balance,
+            data.recentBlock.header.stateRoot,
+            data.recentBlock.header.slot
+        );
+
+        MODULE.syncKeyAddedBalance(data.validator.nodeOperatorId, data.validator.keyIndex, gweiToWei(balanceGwei));
+    }
+
+    /// @inheritdoc IVerifier
+    function processHistoricalBalanceProof(ProcessHistoricalBalanceProofInput calldata data) external whenResumed {
+        if (data.recentBlock.header.slot < FIRST_SUPPORTED_SLOT) revert UnsupportedSlot(data.recentBlock.header.slot);
+        if (data.historicalBlock.header.slot < FIRST_SUPPORTED_SLOT) {
+            revert UnsupportedSlot(data.historicalBlock.header.slot);
+        }
+
+        {
+            bytes32 trustedHeaderRoot = _getParentBlockRoot(data.recentBlock.rootsTimestamp);
+            if (trustedHeaderRoot != data.recentBlock.header.hashTreeRoot()) revert InvalidBlockHeader();
+        }
+
+        SSZ.verifyProof({
+            proof: data.historicalBlock.proof,
+            root: data.recentBlock.header.stateRoot,
+            leaf: data.historicalBlock.header.hashTreeRoot(),
+            gI: _getHistoricalBlockRootGI(data.recentBlock.header.slot, data.historicalBlock.header.slot)
+        });
+
+        uint64 balanceGwei = _processBalanceProof(
+            data.validator,
+            data.balance,
+            data.historicalBlock.header.stateRoot,
+            data.historicalBlock.header.slot
+        );
+
+        MODULE.syncKeyAddedBalance(data.validator.nodeOperatorId, data.validator.keyIndex, gweiToWei(balanceGwei));
     }
 
     function _reportSingleValidator(WithdrawnValidatorInfo memory info) internal {
@@ -317,6 +356,33 @@ contract Verifier is IVerifier, AccessControlEnumerable, PausableWithRoles {
             root: header.stateRoot,
             leaf: withdrawal.object.hashTreeRoot(),
             gI: _getWithdrawalGI(withdrawal.offset, header.slot)
+        });
+    }
+
+    function _processBalanceProof(
+        ValidatorWitness calldata validator,
+        BalanceWitness calldata balance,
+        bytes32 stateRoot,
+        Slot stateSlot
+    ) internal view returns (uint64 balanceGwei) {
+        {
+            bytes memory pubkey = MODULE.getSigningKeys(validator.nodeOperatorId, validator.keyIndex, 1);
+            if (keccak256(pubkey) != keccak256(validator.object.pubkey)) revert InvalidPublicKey();
+        }
+
+        SSZ.verifyProof({
+            proof: validator.proof,
+            root: stateRoot,
+            leaf: validator.object.hashTreeRoot(),
+            gI: _getValidatorGI(validator.index, stateSlot)
+        });
+
+        balanceGwei = _verifyValidatorBalance({
+            validatorIndex: validator.index,
+            balanceNode: balance.node,
+            stateRoot: stateRoot,
+            stateSlot: stateSlot,
+            proof: balance.proof
         });
     }
 

--- a/src/abstract/BaseModule.sol
+++ b/src/abstract/BaseModule.sol
@@ -331,7 +331,8 @@ abstract contract BaseModule is
             currentBalanceWei: currentBalanceWei
         });
 
-        // NOTE: We do not increment nonce here since individual validator balances don't change the distribution.
+        // NOTE: We do not increment nonce here since individual validator balances don't change the distribution
+        // returned by the view functions in both CSModule and CuratedModule.
     }
 
     function reportSlashedWithdrawnValidators(WithdrawnValidatorInfo[] calldata validatorInfos) external {

--- a/src/abstract/BaseModule.sol
+++ b/src/abstract/BaseModule.sol
@@ -319,18 +319,19 @@ abstract contract BaseModule is
     }
 
     /// @inheritdoc IBaseModule
-    function increaseKeyAddedBalance(uint256 nodeOperatorId, uint256 keyIndex, uint256 amount) external {
+    function syncKeyAddedBalance(uint256 nodeOperatorId, uint256 keyIndex, uint256 currentBalanceWei) external {
         _checkVerifierRole();
 
-        NodeOperatorOps.increaseKeyAddedBalance({
+        NodeOperatorOps.syncKeyAddedBalance({
             nodeOperators: _nodeOperators,
             nodeOperatorsCount: _nodeOperatorsCount,
-            isValidatorWithdrawn: _isValidatorWithdrawn,
             keyAddedBalances: _keyAddedBalances,
             nodeOperatorId: nodeOperatorId,
             keyIndex: keyIndex,
-            incrementWei: amount
+            currentBalanceWei: currentBalanceWei
         });
+
+        // NOTE: We do not increment nonce here since individual validator balances don't change the distribution.
     }
 
     function reportSlashedWithdrawnValidators(WithdrawnValidatorInfo[] calldata validatorInfos) external {

--- a/src/abstract/BaseModule.sol
+++ b/src/abstract/BaseModule.sol
@@ -344,8 +344,9 @@ abstract contract BaseModule is
             currentBalanceWei: currentBalanceWei
         });
 
-        // NOTE: We do not increment nonce here since individual validator balances don't change the distribution
-        // returned by the view functions in both CSModule and CuratedModule.
+        // NOTE: We do not increment nonce because individual validator balances don't change the distribution
+        // returned by the module. The distribution from `allocateDeposits` might change but still meets
+        // expectations of StakingRouter.
     }
 
     function reportSlashedWithdrawnValidators(WithdrawnValidatorInfo[] calldata validatorInfos) external {

--- a/src/interfaces/IBaseModule.sol
+++ b/src/interfaces/IBaseModule.sol
@@ -361,12 +361,12 @@ interface IBaseModule is IStakingModule, IAccessControlEnumerable, INOAddresses,
     /// @param keyIndex Index of the key in the Node Operator's keys storage
     function onValidatorSlashed(uint256 nodeOperatorId, uint256 keyIndex) external;
 
-    /// @notice Increase tracked added balance for a particular key
-    /// @dev The method is not expected to be called on 0x01 validator mode module
+    /// @notice Sync tracked added balance for a key based on proven validator balance.
+    ///         Only increases the tracked balance.
     /// @param nodeOperatorId ID of the Node Operator
     /// @param keyIndex Index of the key in the Node Operator's keys storage
-    /// @param amount Amount to add to the tracked added balance (wei)
-    function increaseKeyAddedBalance(uint256 nodeOperatorId, uint256 keyIndex, uint256 amount) external;
+    /// @param currentBalanceWei Proven current validator balance in wei
+    function syncKeyAddedBalance(uint256 nodeOperatorId, uint256 keyIndex, uint256 currentBalanceWei) external;
 
     /// @notice Get tracked added balance for a particular key
     /// @param nodeOperatorId ID of the Node Operator

--- a/src/interfaces/IBaseModule.sol
+++ b/src/interfaces/IBaseModule.sol
@@ -362,6 +362,7 @@ interface IBaseModule is IStakingModule, IAccessControlEnumerable, INOAddresses,
     function onValidatorSlashed(uint256 nodeOperatorId, uint256 keyIndex) external;
 
     /// @notice Sync tracked added balance for a key based on proven validator balance.
+    /// @dev The function only increases the key added value at the moment.
     /// @param nodeOperatorId ID of the Node Operator
     /// @param keyIndex Index of the key in the Node Operator's keys storage
     /// @param currentBalanceWei Proven current validator balance in wei

--- a/src/interfaces/IBaseModule.sol
+++ b/src/interfaces/IBaseModule.sol
@@ -362,7 +362,6 @@ interface IBaseModule is IStakingModule, IAccessControlEnumerable, INOAddresses,
     function onValidatorSlashed(uint256 nodeOperatorId, uint256 keyIndex) external;
 
     /// @notice Sync tracked added balance for a key based on proven validator balance.
-    ///         Only increases the tracked balance.
     /// @param nodeOperatorId ID of the Node Operator
     /// @param keyIndex Index of the key in the Node Operator's keys storage
     /// @param currentBalanceWei Proven current validator balance in wei

--- a/src/interfaces/IVerifier.sol
+++ b/src/interfaces/IVerifier.sol
@@ -70,6 +70,19 @@ interface IVerifier {
         HistoricalHeaderWitness withdrawalBlock;
     }
 
+    struct ProcessBalanceProofInput {
+        RecentHeaderWitness recentBlock;
+        ValidatorWitness validator;
+        BalanceWitness balance;
+    }
+
+    struct ProcessHistoricalBalanceProofInput {
+        RecentHeaderWitness recentBlock;
+        HistoricalHeaderWitness historicalBlock;
+        ValidatorWitness validator;
+        BalanceWitness balance;
+    }
+
     error RootNotFound();
     error InvalidBlockHeader();
     error InvalidChainConfig();
@@ -87,7 +100,6 @@ interface IVerifier {
     error InvalidPivotSlot();
     error InvalidCapellaSlot();
     error HistoricalSummaryDoesNotExist();
-    error NotImplemented();
 
     function BEACON_ROOTS() external view returns (address);
 
@@ -139,6 +151,14 @@ interface IVerifier {
     /// @param data @see ProcessHistoricalWithdrawalInput
     function processHistoricalWithdrawalProof(ProcessHistoricalWithdrawalInput calldata data) external;
 
-    /// @notice Stub method for incoming consolidation request proofs.
-    function processIncomingConsolidation(uint256 nodeOperatorId, uint256 keyIndex, uint256 addedBalanceWei) external;
+    /// @notice Verify a validator's balance proof from a recent beacon block and sync the key added balance.
+    /// @param data The balance proof input containing recent block header, validator witness, and balance witness.
+    function processBalanceProof(ProcessBalanceProofInput calldata data) external;
+
+    /// @notice Verify a validator's balance proof from a historical beacon block and sync the key added balance.
+    ///         A historical proof is needed because the validator's balance may have increased at some point in the past
+    ///         and later decreased (e.g. due to inactivity leak or penalties). A recent proof alone would miss that peak,
+    ///         so a historical proof allows capturing the highest observed balance.
+    /// @param data The balance proof input containing recent + historical block headers, validator witness, and balance witness.
+    function processHistoricalBalanceProof(ProcessHistoricalBalanceProofInput calldata data) external;
 }

--- a/src/lib/NodeOperatorOps.sol
+++ b/src/lib/NodeOperatorOps.sol
@@ -176,15 +176,15 @@ library NodeOperatorOps {
             currentBalanceWei = WithdrawnValidatorLib.MAX_EFFECTIVE_BALANCE;
         }
 
-        uint256 updated;
+        uint256 newKeyAddedBalance;
         unchecked {
-            updated = currentBalanceWei - WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE;
+            newKeyAddedBalance = currentBalanceWei - WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE;
         }
 
         uint256 pointer = KeyPointerLib.keyPointer(nodeOperatorId, keyIndex);
-        if (updated <= keyAddedBalances[pointer]) return;
-        keyAddedBalances[pointer] = updated;
-        emit IBaseModule.KeyAddedBalanceChanged(nodeOperatorId, keyIndex, updated);
+        if (newKeyAddedBalance <= keyAddedBalances[pointer]) return;
+        keyAddedBalances[pointer] = newKeyAddedBalance;
+        emit IBaseModule.KeyAddedBalanceChanged(nodeOperatorId, keyIndex, newKeyAddedBalance);
     }
 
     function increaseKeyAddedBalancesByAllocations(

--- a/src/lib/NodeOperatorOps.sol
+++ b/src/lib/NodeOperatorOps.sol
@@ -148,23 +148,33 @@ library NodeOperatorOps {
         }
     }
 
-    function increaseKeyAddedBalance(
+    function syncKeyAddedBalance(
         mapping(uint256 => NodeOperator) storage nodeOperators,
         uint256 nodeOperatorsCount,
-        mapping(uint256 => bool) storage isValidatorWithdrawn,
         mapping(uint256 => uint256) storage keyAddedBalances,
         uint256 nodeOperatorId,
         uint256 keyIndex,
-        uint256 incrementWei
+        uint256 currentBalanceWei
     ) external {
         _onlyExistingNodeOperator(nodeOperatorId, nodeOperatorsCount);
-        NodeOperator storage no = nodeOperators[nodeOperatorId];
-        if (keyIndex >= no.totalDepositedKeys) revert IBaseModule.SigningKeysInvalidOffset();
+        if (keyIndex >= nodeOperators[nodeOperatorId].totalDepositedKeys) {
+            revert IBaseModule.SigningKeysInvalidOffset();
+        }
+
+        if (currentBalanceWei < WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE) return;
+        if (currentBalanceWei > WithdrawnValidatorLib.MAX_EFFECTIVE_BALANCE) {
+            currentBalanceWei = WithdrawnValidatorLib.MAX_EFFECTIVE_BALANCE;
+        }
+
+        uint256 updated;
+        unchecked {
+            updated = currentBalanceWei - WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE;
+        }
 
         uint256 pointer = KeyPointerLib.keyPointer(nodeOperatorId, keyIndex);
-        if (isValidatorWithdrawn[pointer]) revert IBaseModule.InvalidWithdrawnValidatorInfo();
-
-        _increaseKeyAddedBalance(keyAddedBalances, nodeOperatorId, keyIndex, incrementWei);
+        if (updated <= keyAddedBalances[pointer]) return;
+        keyAddedBalances[pointer] = updated;
+        emit IBaseModule.KeyAddedBalanceChanged(nodeOperatorId, keyIndex, updated);
     }
 
     function increaseKeyAddedBalancesByAllocations(

--- a/test/fixtures/Verifier/balance.mjs
+++ b/test/fixtures/Verifier/balance.mjs
@@ -1,0 +1,146 @@
+// Usage: node balance.mjs [balance_gwei]
+
+"use strict";
+
+import assert from "node:assert";
+import { createHash } from "crypto";
+
+import { ssz } from "@lodestar/types";
+import { createProof, ProofType } from "@chainsafe/persistent-merkle-tree";
+import { encodeParameters } from "web3-eth-abi";
+
+import VerifierBalanceProofTest from "../../../out/Verifier.t.sol/VerifierBalanceProofTest.json" assert { type: "json" };
+
+const SLOTS_PER_EPOCH = 32;
+const MAX_VALIDATORS = 1_000;
+const Fork = ssz.electra;
+
+/**
+ * @param {Object} opts
+ * @param {number} opts.validatorIndex - Index of a validator in the `validators` list.
+ * @param {bigint} opts.balanceGwei - The validator's balance in gwei.
+ * @param {number} opts.epoch - Epoch for the state slot.
+ */
+function main(opts) {
+  assert(opts);
+  assert(opts.validatorIndex < MAX_VALIDATORS);
+
+  const faker = new Faker("seed sEed seEd");
+
+  /** @type {import('@chainsafe/ssz').ContainerType} */
+  const Validator = Fork.BeaconState.getPathInfo(["validators", 0]).type;
+
+  /** @type {import('@lodestar/types/lib/phase0').Validator} */
+  const validator = Validator.defaultView();
+
+  validator.slashed = false;
+  validator.pubkey = new Uint8Array(48).fill(18);
+  validator.effectiveBalance = 32e9;
+  validator.withdrawalCredentials = new Uint8Array([
+    ...new Uint8Array([0x01]),
+    ...new Uint8Array(11),
+    ...hexStrToBytesArr("b3e29c46ee1745724417c0c51eb2351a1c01cf36"),
+  ]);
+
+  const state = Fork.BeaconState.defaultView();
+  state.slot = opts.epoch * SLOTS_PER_EPOCH;
+
+  while (state.validators.length < MAX_VALIDATORS) {
+    state.validators.push(Validator.defaultView());
+  }
+  state.validators.set(opts.validatorIndex, validator);
+
+  while (state.balances.length < MAX_VALIDATORS) {
+    state.balances.push(0);
+  }
+  state.balances.set(opts.validatorIndex, Number(opts.balanceGwei));
+
+  const validatorProof = createProof(state.node, {
+    type: ProofType.single,
+    gindex: state.type.getPathInfo(["validators", opts.validatorIndex]).gindex,
+  });
+
+  const balanceProof = createProof(state.node, {
+    type: ProofType.single,
+    gindex: state.type.getPathInfo(["balances", opts.validatorIndex]).gindex,
+  });
+
+  const recentBlock = Fork.BeaconBlock.defaultView();
+  recentBlock.slot = state.slot;
+  recentBlock.parentRoot = faker.someBytes32();
+  recentBlock.stateRoot = state.hashTreeRoot();
+
+  const fixture = {
+    blockRoot: recentBlock.hashTreeRoot(),
+    data: {
+      recentBlock: {
+        header: {
+          slot: recentBlock.slot,
+          proposerIndex: recentBlock.proposerIndex,
+          parentRoot: recentBlock.parentRoot,
+          stateRoot: recentBlock.stateRoot,
+          bodyRoot: recentBlock.body.hashTreeRoot(),
+        },
+        rootsTimestamp: 42,
+      },
+      validator: {
+        index: opts.validatorIndex,
+        nodeOperatorId: 0,
+        keyIndex: 0,
+        object: {
+          pubkey: validator.pubkey,
+          withdrawalCredentials: validator.withdrawalCredentials,
+          effectiveBalance: validator.effectiveBalance,
+          slashed: validator.slashed,
+          activationEligibilityEpoch: validator.activationEligibilityEpoch,
+          activationEpoch: validator.activationEpoch,
+          exitEpoch: validator.exitEpoch,
+          withdrawableEpoch: validator.withdrawableEpoch,
+        },
+        proof: validatorProof.witnesses,
+      },
+      balance: {
+        node: balanceProof.leaf,
+        proof: balanceProof.witnesses,
+      },
+    },
+  };
+
+  const ffi_interface = VerifierBalanceProofTest.abi.find((e) => e.name == "ffi_interface");
+  assert(ffi_interface);
+
+  const calldata = encodeParameters(ffi_interface.inputs, [fixture]);
+  console.log(calldata);
+}
+
+/**
+ * @param {string} s
+ * @returns {Uint8Array}
+ */
+function hexStrToBytesArr(s) {
+  return Uint8Array.from(s.match(/.{1,2}/g).map((byte) => parseInt(byte, 16)));
+}
+
+class Faker {
+  /**
+   * @param {string|Buffer|Uint8Array} seed
+   */
+  constructor(seed) {
+    this.seed = Buffer.from(seed);
+  }
+
+  /**
+   * @returns {Buffer}
+   */
+  someBytes32() {
+    const hash = createHash("sha256").update(this.seed).digest();
+    this.seed = hash;
+    return hash;
+  }
+}
+
+main({
+  validatorIndex: 17,
+  balanceGwei: BigInt(process.argv[2] || "64000000000"), // default 64 ETH in gwei
+  epoch: 100_500,
+});

--- a/test/fixtures/Verifier/historical_balance.mjs
+++ b/test/fixtures/Verifier/historical_balance.mjs
@@ -1,0 +1,218 @@
+// Usage: node historical_balance.mjs <fork> [balance_gwei]
+
+"use strict";
+
+import assert from "node:assert";
+import { createHash } from "crypto";
+
+import { ssz } from "@lodestar/types";
+import { createProof, ProofType, concatGindices } from "@chainsafe/persistent-merkle-tree";
+import { encodeParameters } from "web3-eth-abi";
+
+import VerifierHistoricalBalanceTest from "../../../out/VerifierHistorical.t.sol/VerifierHistoricalBalanceTest.json" assert { type: "json" };
+
+const SLOTS_PER_HISTORICAL_ROOT = 8192;
+const SLOTS_PER_EPOCH = 32;
+
+const MAX_VALIDATORS = 1_000;
+
+/**
+ * @param {Object} opts
+ * @param {number} opts.validatorIndex
+ * @param {bigint} opts.balanceGwei
+ * @param {string} opts.fork - Fork from 'ssz' library.
+ * @param {number} opts.epoch
+ * @param {number} opts.capellaSlot
+ */
+function main(opts) {
+  assert(opts);
+  assert(opts.validatorIndex < MAX_VALIDATORS);
+  assert(["deneb", "electra"].includes(opts.fork));
+  assert(opts.capellaSlot % SLOTS_PER_HISTORICAL_ROOT === 0);
+
+  const faker = new Faker("seed sEed seEd");
+
+  const LatestFork = ssz.fulu;
+  /** @type {ssz.deneb | ssz.electra} */
+  const HistoricalFork = ssz[opts.fork];
+
+  const historicalState = HistoricalFork.BeaconState.defaultView();
+  historicalState.slot = opts.epoch * SLOTS_PER_EPOCH;
+
+  /** @type {import('@chainsafe/ssz').ContainerType} */
+  const Validator = HistoricalFork.BeaconState.getPathInfo(["validators", 0]).type;
+
+  /** @type {import('@lodestar/types/lib/phase0').Validator} */
+  const validator = Validator.defaultView();
+
+  validator.slashed = false;
+  validator.pubkey = new Uint8Array(48).fill(18);
+  validator.effectiveBalance = 32e9;
+  validator.withdrawalCredentials = new Uint8Array([
+    ...new Uint8Array([0x01]),
+    ...new Uint8Array(11),
+    ...hexStrToBytesArr("b3e29c46ee1745724417c0c51eb2351a1c01cf36"),
+  ]);
+
+  while (historicalState.validators.length < MAX_VALIDATORS) {
+    historicalState.validators.push(Validator.defaultView());
+  }
+  historicalState.validators.set(opts.validatorIndex, validator);
+
+  while (historicalState.balances.length < MAX_VALIDATORS) {
+    historicalState.balances.push(0);
+  }
+  historicalState.balances.set(opts.validatorIndex, Number(opts.balanceGwei));
+
+  const validatorProof = createProof(historicalState.node, {
+    type: ProofType.single,
+    gindex: historicalState.type.getPathInfo(["validators", opts.validatorIndex]).gindex,
+  });
+
+  const balanceProof = createProof(historicalState.node, {
+    type: ProofType.single,
+    gindex: historicalState.type.getPathInfo(["balances", opts.validatorIndex]).gindex,
+  });
+
+  const historicalBlock = HistoricalFork.BeaconBlock.defaultView();
+  historicalBlock.slot = historicalState.slot;
+  historicalBlock.stateRoot = historicalState.hashTreeRoot();
+
+  const summaryIndex = Math.floor(historicalBlock.slot / SLOTS_PER_HISTORICAL_ROOT);
+  const rootIndex = historicalBlock.slot % SLOTS_PER_HISTORICAL_ROOT;
+
+  const recentState = LatestFork.BeaconState.defaultView();
+  recentState.slot = historicalState.slot + 0x421337;
+
+  recentState.historicalSummaries.push(recentState.historicalSummaries.type.defaultView());
+
+  for (let s = opts.capellaSlot; s < recentState.slot; s += SLOTS_PER_HISTORICAL_ROOT) {
+    const summary = LatestFork.HistoricalSummary.defaultView();
+    summary.blockSummaryRoot = faker.someBytes32();
+    summary.stateSummaryRoot = faker.someBytes32();
+
+    // This branch significantly improves performance.
+    if (recentState.historicalSummaries.length == summaryIndex) {
+      const BlockRoots = recentState.blockRoots.type;
+      const blockRoots = BlockRoots.fromJson(
+        new Array(8192).fill(faker.someBytes32().toString("hex")),
+      );
+
+      blockRoots[rootIndex] = historicalBlock.hashTreeRoot();
+
+      summary.blockSummaryRoot = recentState.blockRoots.type.hashTreeRoot(blockRoots);
+      summary.stateSummaryRoot = faker.someBytes32();
+
+      // Patching the state tree.
+      const nav = recentState.type.getPathInfo([
+        "historicalSummaries",
+        recentState.historicalSummaries.length,
+        "blockSummaryRoot",
+      ]);
+      recentState.historicalSummaries.push(summary);
+      recentState.tree.setNode(nav.gindex, BlockRoots.toView(blockRoots).node);
+    } else {
+      recentState.historicalSummaries.push(summary);
+    }
+  }
+
+  const historicalBlockProof = createProof(recentState.node, {
+    type: ProofType.single,
+    gindex: concatGindices([
+      recentState.type.getPathInfo(["historicalSummaries", summaryIndex, "blockSummaryRoot"])
+        .gindex,
+      recentState.blockRoots.type.getPropertyGindex(rootIndex),
+    ]),
+  });
+
+  const recentBlock = LatestFork.BeaconBlock.defaultView();
+  recentBlock.slot = recentState.slot;
+  recentBlock.parentRoot = faker.someBytes32();
+  recentBlock.stateRoot = recentState.hashTreeRoot();
+
+  const fixture = {
+    blockRoot: recentBlock.hashTreeRoot(),
+    data: {
+      recentBlock: {
+        header: {
+          slot: recentBlock.slot,
+          proposerIndex: recentBlock.proposerIndex,
+          parentRoot: recentBlock.parentRoot,
+          stateRoot: recentBlock.stateRoot,
+          bodyRoot: recentBlock.body.hashTreeRoot(),
+        },
+        rootsTimestamp: 42,
+      },
+      historicalBlock: {
+        header: {
+          slot: historicalBlock.slot,
+          proposerIndex: historicalBlock.proposerIndex,
+          parentRoot: historicalBlock.parentRoot,
+          stateRoot: historicalBlock.stateRoot,
+          bodyRoot: historicalBlock.body.hashTreeRoot(),
+        },
+        proof: historicalBlockProof.witnesses,
+      },
+      validator: {
+        index: opts.validatorIndex,
+        nodeOperatorId: 0,
+        keyIndex: 0,
+        object: {
+          pubkey: validator.pubkey,
+          withdrawalCredentials: validator.withdrawalCredentials,
+          effectiveBalance: validator.effectiveBalance,
+          slashed: validator.slashed,
+          activationEligibilityEpoch: validator.activationEligibilityEpoch,
+          activationEpoch: validator.activationEpoch,
+          exitEpoch: validator.exitEpoch,
+          withdrawableEpoch: validator.withdrawableEpoch,
+        },
+        proof: validatorProof.witnesses,
+      },
+      balance: {
+        node: balanceProof.leaf,
+        proof: balanceProof.witnesses,
+      },
+    },
+  };
+
+  const ffi_interface = VerifierHistoricalBalanceTest.abi.find((e) => e.name == "ffi_interface");
+  assert(ffi_interface);
+
+  const calldata = encodeParameters(ffi_interface.inputs, [fixture]);
+  console.log(calldata);
+}
+
+/**
+ * @param {string} s
+ * @returns {Uint8Array}
+ */
+function hexStrToBytesArr(s) {
+  return Uint8Array.from(s.match(/.{1,2}/g).map((byte) => parseInt(byte, 16)));
+}
+
+class Faker {
+  /**
+   * @param {string|Buffer|Uint8Array} seed
+   */
+  constructor(seed) {
+    this.seed = Buffer.from(seed);
+  }
+
+  /**
+   * @returns {Buffer}
+   */
+  someBytes32() {
+    const hash = createHash("sha256").update(this.seed).digest();
+    this.seed = hash;
+    return hash;
+  }
+}
+
+main({
+  validatorIndex: 17,
+  balanceGwei: BigInt(process.argv[3] || "64000000000"),
+  fork: process.argv[2],
+  epoch: 100_500,
+  capellaSlot: 0,
+});

--- a/test/unit/CSModule.t.sol
+++ b/test/unit/CSModule.t.sol
@@ -932,7 +932,7 @@ contract CSMTopUpQueue is CSMCommon {
         csm.obtainDepositData(1, "");
 
         uint256 cap = WithdrawnValidatorLib.MAX_EFFECTIVE_BALANCE - WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE;
-        csm.increaseKeyAddedBalance(0, 0, cap);
+        setKeyAddedBalance(0, 0, cap);
 
         bytes memory key = csm.getSigningKeys(0, 0, 1);
         vm.recordLogs();
@@ -956,7 +956,7 @@ contract CSMTopUpQueue is CSMCommon {
         csm.obtainDepositData(1, "");
 
         uint256 cap = WithdrawnValidatorLib.MAX_EFFECTIVE_BALANCE - WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE;
-        csm.increaseKeyAddedBalance(0, 0, cap - 1 ether);
+        setKeyAddedBalance(0, 0, cap - 1 ether);
 
         bytes memory key = csm.getSigningKeys(0, 0, 1);
         vm.expectEmit(address(csm));
@@ -1871,6 +1871,8 @@ contract CSMCompensateGeneralDelayedPenalty is ModuleCompensateGeneralDelayedPen
 contract CSMReportWithdrawnValidators is ModuleReportWithdrawnValidators, CSMCommon {}
 
 contract CSMKeyAddedBalance is ModuleKeyAddedBalance, CSMCommon {}
+
+contract CSMSyncKeyAddedBalance is ModuleSyncKeyAddedBalance, CSMCommon {}
 
 contract CSMGetStakingModuleSummary is ModuleGetStakingModuleSummary, CSMCommon {}
 

--- a/test/unit/CuratedModule.t.sol
+++ b/test/unit/CuratedModule.t.sol
@@ -1655,6 +1655,8 @@ contract CuratedReportWithdrawnValidators is ModuleReportWithdrawnValidators, Cu
 
 contract CuratedKeyAddedBalance is ModuleKeyAddedBalance, CuratedCommon {}
 
+contract CuratedSyncKeyAddedBalance is ModuleSyncKeyAddedBalance, CuratedCommon {}
+
 contract CuratedTopUpKeyAddedBalance is CuratedCommon {
     function test_topUp_emitsKeyAddedBalanceChanged() public {
         createNodeOperator(1);
@@ -1680,7 +1682,7 @@ contract CuratedTopUpKeyAddedBalance is CuratedCommon {
         cm.obtainDepositData(1, "");
 
         uint256 cap = WithdrawnValidatorLib.MAX_EFFECTIVE_BALANCE - WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE;
-        cm.increaseKeyAddedBalance(0, 0, cap);
+        setKeyAddedBalance(0, 0, cap);
 
         bytes memory key = cm.getSigningKeys(0, 0, 1);
         bytes[] memory pubkeys = BytesArr(key);

--- a/test/unit/ModuleAbstract/KeyAddedBalance.t.sol
+++ b/test/unit/ModuleAbstract/KeyAddedBalance.t.sol
@@ -1,0 +1,107 @@
+// SPDX-FileCopyrightText: 2026 Lido <info@lido.fi>
+// SPDX-License-Identifier: GPL-3.0
+
+pragma solidity 0.8.33;
+
+import { IBaseModule } from "src/interfaces/IBaseModule.sol";
+import { WithdrawnValidatorLib } from "src/lib/WithdrawnValidatorLib.sol";
+
+import { ModuleFixtures } from "./_Base.t.sol";
+
+abstract contract ModuleKeyAddedBalance is ModuleFixtures {
+    function test_getKeyAddedBalance_defaultZero() public {
+        uint256 noId = createNodeOperator();
+        module.obtainDepositData(1, "");
+
+        assertEq(module.getKeyAddedBalance(noId, 0), 0);
+    }
+
+    function test_getKeyAddedBalance_afterSet() public {
+        uint256 noId = createNodeOperator();
+        module.obtainDepositData(1, "");
+
+        setKeyAddedBalance(noId, 0, 3 ether);
+        assertEq(module.getKeyAddedBalance(noId, 0), 3 ether);
+    }
+}
+
+abstract contract ModuleSyncKeyAddedBalance is ModuleFixtures {
+    function test_syncKeyAddedBalance_happyPath() public assertInvariants {
+        uint256 noId = createNodeOperator();
+        module.obtainDepositData(1, "");
+
+        uint256 balanceWei = WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE + 10 ether;
+
+        vm.expectEmit(address(module));
+        emit IBaseModule.KeyAddedBalanceChanged(noId, 0, 10 ether);
+        module.syncKeyAddedBalance(noId, 0, balanceWei);
+
+        assertEq(module.getKeyAddedBalance(noId, 0), 10 ether);
+    }
+
+    function test_syncKeyAddedBalance_increasesWhenHigher() public assertInvariants {
+        uint256 noId = createNodeOperator();
+        module.obtainDepositData(1, "");
+
+        module.syncKeyAddedBalance(noId, 0, WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE + 5 ether);
+        assertEq(module.getKeyAddedBalance(noId, 0), 5 ether);
+
+        vm.expectEmit(address(module));
+        emit IBaseModule.KeyAddedBalanceChanged(noId, 0, 10 ether);
+        module.syncKeyAddedBalance(noId, 0, WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE + 10 ether);
+        assertEq(module.getKeyAddedBalance(noId, 0), 10 ether);
+    }
+
+    function test_syncKeyAddedBalance_doesNotDecrease() public assertInvariants {
+        uint256 noId = createNodeOperator();
+        module.obtainDepositData(1, "");
+
+        module.syncKeyAddedBalance(noId, 0, WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE + 10 ether);
+        assertEq(module.getKeyAddedBalance(noId, 0), 10 ether);
+
+        // Lower value — should not change
+        module.syncKeyAddedBalance(noId, 0, WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE + 5 ether);
+        assertEq(module.getKeyAddedBalance(noId, 0), 10 ether);
+
+        // Equal value — should not change
+        module.syncKeyAddedBalance(noId, 0, WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE + 10 ether);
+        assertEq(module.getKeyAddedBalance(noId, 0), 10 ether);
+    }
+
+    function test_syncKeyAddedBalance_capsAtMax() public assertInvariants {
+        uint256 noId = createNodeOperator();
+        module.obtainDepositData(1, "");
+
+        uint256 cap = WithdrawnValidatorLib.MAX_EFFECTIVE_BALANCE - WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE;
+        module.syncKeyAddedBalance(noId, 0, WithdrawnValidatorLib.MAX_EFFECTIVE_BALANCE + 100 ether);
+        assertEq(module.getKeyAddedBalance(noId, 0), cap);
+    }
+
+    function test_syncKeyAddedBalance_noUpdateWhenBelowMinActivation() public assertInvariants {
+        uint256 noId = createNodeOperator();
+        module.obtainDepositData(1, "");
+
+        module.syncKeyAddedBalance(noId, 0, WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE);
+        assertEq(module.getKeyAddedBalance(noId, 0), 0);
+
+        module.syncKeyAddedBalance(noId, 0, WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE - 1 ether);
+        assertEq(module.getKeyAddedBalance(noId, 0), 0);
+    }
+
+    function test_syncKeyAddedBalance_revertWhen_NoRole() public {
+        uint256 noId = createNodeOperator();
+        module.obtainDepositData(1, "");
+
+        vm.prank(stranger);
+        vm.expectRevert();
+        module.syncKeyAddedBalance(noId, 0, WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE + 1 ether);
+    }
+
+    function test_syncKeyAddedBalance_revertWhen_InvalidKeyIndex() public {
+        uint256 noId = createNodeOperator();
+        module.obtainDepositData(1, "");
+
+        vm.expectRevert(IBaseModule.SigningKeysInvalidOffset.selector);
+        module.syncKeyAddedBalance(noId, 1, WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE + 1 ether);
+    }
+}

--- a/test/unit/ModuleAbstract/ModuleAbstract.t.sol
+++ b/test/unit/ModuleAbstract/ModuleAbstract.t.sol
@@ -18,4 +18,6 @@ import "./PenaltiesGeneral.t.sol";
 // forge-lint: disable-next-line(unaliased-plain-import)
 import "./PenaltiesWithdrawn.t.sol";
 // forge-lint: disable-next-line(unaliased-plain-import)
+import "./KeyAddedBalance.t.sol";
+// forge-lint: disable-next-line(unaliased-plain-import)
 import "./ExitDelay.t.sol";

--- a/test/unit/ModuleAbstract/PenaltiesWithdrawn.t.sol
+++ b/test/unit/ModuleAbstract/PenaltiesWithdrawn.t.sol
@@ -3,8 +3,6 @@
 
 pragma solidity 0.8.33;
 
-import { Vm } from "forge-std/Test.sol";
-
 import { ExitPenaltyInfo, MarkedUint248 } from "src/interfaces/IExitPenalties.sol";
 import { IBaseModule, NodeOperator, WithdrawnValidatorInfo } from "src/interfaces/IBaseModule.sol";
 import { WithdrawnValidatorLib } from "src/lib/WithdrawnValidatorLib.sol";
@@ -1119,16 +1117,12 @@ abstract contract ModuleReportWithdrawnValidators is ModuleFixtures {
         vm.expectRevert(IBaseModule.SigningKeysInvalidOffset.selector);
         module.onValidatorSlashed(noId, 0);
     }
-}
 
-abstract contract ModuleKeyAddedBalance is ModuleFixtures {
-    function test_increaseKeyAddedBalance_emitsAndChargesOnWithdraw() public assertInvariants {
+    function test_keyAddedBalance_chargesOnWithdraw() public assertInvariants {
         uint256 noId = createNodeOperator();
         module.obtainDepositData(1, "");
 
-        vm.expectEmit(address(module));
-        emit IBaseModule.KeyAddedBalanceChanged(noId, 0, 10 ether);
-        module.increaseKeyAddedBalance(noId, 0, 10 ether);
+        setKeyAddedBalance(noId, 0, 10 ether);
 
         vm.deal(address(this), 100 ether);
         accounting.depositETH{ value: 100 ether }(noId);
@@ -1147,49 +1141,13 @@ abstract contract ModuleKeyAddedBalance is ModuleFixtures {
         assertEq(accounting.getBond(noId), bondBefore - 10 ether);
     }
 
-    function test_increaseKeyAddedBalance_revertWhen_NoRole() public {
-        uint256 noId = createNodeOperator();
-        module.obtainDepositData(1, "");
-
-        bytes32 role = module.VERIFIER_ROLE();
-        vm.prank(stranger);
-        expectRoleRevert(stranger, role);
-        module.increaseKeyAddedBalance(noId, 0, 1 ether);
-    }
-
-    function test_increaseKeyAddedBalance_revertWhen_InvalidKeyIndex() public {
-        uint256 noId = createNodeOperator();
-        module.obtainDepositData(1, "");
-
-        vm.expectRevert(IBaseModule.SigningKeysInvalidOffset.selector);
-        module.increaseKeyAddedBalance(noId, 1, 1 ether);
-    }
-
-    function test_increaseKeyAddedBalance_revertWhen_Withdrawn() public {
-        uint256 noId = createNodeOperator();
-        module.obtainDepositData(1, "");
-
-        WithdrawnValidatorInfo[] memory validatorInfos = new WithdrawnValidatorInfo[](1);
-        validatorInfos[0] = WithdrawnValidatorInfo({
-            nodeOperatorId: noId,
-            keyIndex: 0,
-            exitBalance: WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE,
-            slashingPenalty: 0,
-            isSlashed: false
-        });
-        module.reportRegularWithdrawnValidators(validatorInfos);
-
-        vm.expectRevert(IBaseModule.InvalidWithdrawnValidatorInfo.selector);
-        module.increaseKeyAddedBalance(noId, 0, 1 ether);
-    }
-
-    function test_increaseKeyAddedBalance_doesNotChargeWhenSlashed() public assertInvariants {
+    function test_keyAddedBalance_doesNotChargeWhenSlashed() public assertInvariants {
         uint256 noId = createNodeOperator();
 
         module.obtainDepositData(1, "");
         module.onValidatorSlashed(noId, 0);
 
-        module.increaseKeyAddedBalance(noId, 0, 10 ether);
+        setKeyAddedBalance(noId, 0, 10 ether);
 
         vm.deal(address(this), 100 ether);
         accounting.depositETH{ value: 100 ether }(noId);
@@ -1206,52 +1164,5 @@ abstract contract ModuleKeyAddedBalance is ModuleFixtures {
 
         module.reportSlashedWithdrawnValidators(validatorInfos);
         assertEq(accounting.getBond(noId), bondBefore);
-    }
-
-    function test_increaseKeyAddedBalance_noEmitWhenAtCap() public assertInvariants {
-        uint256 noId = createNodeOperator();
-        module.obtainDepositData(1, "");
-
-        module.increaseKeyAddedBalance(
-            noId,
-            0,
-            WithdrawnValidatorLib.MAX_EFFECTIVE_BALANCE - WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE
-        );
-
-        vm.recordLogs();
-        module.increaseKeyAddedBalance(noId, 0, 1 ether);
-
-        Vm.Log[] memory entries = vm.getRecordedLogs();
-        bytes32 signature = keccak256("KeyAddedBalanceChanged(uint256,uint256,uint256)");
-        for (uint256 i; i < entries.length; ++i) {
-            assertNotEq(entries[i].topics[0], signature);
-        }
-    }
-
-    function test_increaseKeyAddedBalance_capsAndEmits() public assertInvariants {
-        uint256 noId = createNodeOperator();
-        module.obtainDepositData(1, "");
-
-        uint256 cap = WithdrawnValidatorLib.MAX_EFFECTIVE_BALANCE - WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE;
-
-        vm.expectEmit(address(module));
-        emit IBaseModule.KeyAddedBalanceChanged(noId, 0, cap);
-
-        module.increaseKeyAddedBalance(noId, 0, cap + 1 ether);
-    }
-
-    function test_getKeyAddedBalance_defaultZero() public {
-        uint256 noId = createNodeOperator();
-        module.obtainDepositData(1, "");
-
-        assertEq(module.getKeyAddedBalance(noId, 0), 0);
-    }
-
-    function test_getKeyAddedBalance_afterIncrease() public {
-        uint256 noId = createNodeOperator();
-        module.obtainDepositData(1, "");
-
-        module.increaseKeyAddedBalance(noId, 0, 3 ether);
-        assertEq(module.getKeyAddedBalance(noId, 0), 3 ether);
     }
 }

--- a/test/unit/ModuleAbstract/_Base.t.sol
+++ b/test/unit/ModuleAbstract/_Base.t.sol
@@ -188,6 +188,22 @@ abstract contract ModuleFixtures is Test, Fixtures, Utilities, InvariantAsserts 
         module.reportRegularWithdrawnValidators(withdrawalsInfo);
     }
 
+    function setKeyAddedBalance(uint256 noId, uint256 keyIndex, uint256 amount) internal {
+        // NOTE: so far, this is the only available way to change key added balance value.
+        uint256 current = module.getKeyAddedBalance(noId, keyIndex);
+        if (amount == current) return;
+
+        assertGt(amount, current, "key added balance cannot be decreased");
+
+        module.syncKeyAddedBalance({
+            nodeOperatorId: noId,
+            keyIndex: keyIndex,
+            currentBalanceWei: amount + WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE
+        });
+
+        assertEq(module.getKeyAddedBalance(noId, keyIndex), amount, "key added balance must match target");
+    }
+
     function getNodeOperatorSummary(uint256 noId) public view returns (NodeOperatorSummary memory) {
         (
             uint256 targetLimitMode,

--- a/test/unit/Verifier.t.sol
+++ b/test/unit/Verifier.t.sol
@@ -12,6 +12,7 @@ import { Verifier } from "src/Verifier.sol";
 import { pack } from "src/lib/GIndex.sol";
 import { Slot } from "src/lib/Types.sol";
 import { GIndex } from "src/lib/GIndex.sol";
+import { SSZ } from "src/lib/SSZ.sol";
 
 import { IVerifier } from "src/interfaces/IVerifier.sol";
 import { IBaseModule, WithdrawnValidatorInfo } from "src/interfaces/IBaseModule.sol";
@@ -659,17 +660,6 @@ contract VerifierSlashingTest is VerifierTestBase {
         vm.expectRevert(IVerifier.InvalidPublicKey.selector);
         verifier.processSlashedProof(fixture.data);
     }
-
-    // function test_processSlashed_RevertWhen_ValidatorIsNotWithdrawable()
-    //     public
-    // {
-    //     fixture.data.validator.object.withdrawableEpoch =
-    //         fixture.data.recentBlock.header.slot.unwrap() *
-    //         32 +
-    //         1;
-    //     vm.expectRevert(IVerifier.ValidatorIsNotWithdrawable.selector);
-    //     verifier.processSlashedProof(fixture.data);
-    // }
 
     function test_processSlashed_RevertWhen_InvalidBlockHeader() public {
         vm.mockCall(
@@ -1491,6 +1481,142 @@ contract VerifierValidatorBalanceTest is Test, Utilities {
         );
         assertEq(balance, 0x1817161514131211);
     }
+}
+
+contract VerifierBalanceProofTest is VerifierTestBase {
+    struct Fixture {
+        bytes32 blockRoot;
+        IVerifier.ProcessBalanceProofInput data;
+    }
+
+    Fixture internal fixture;
+
+    function setUp() public {
+        _loadFixture();
+
+        module = new Stub();
+        admin = nextAddress("ADMIN");
+
+        verifier = new Verifier({
+            withdrawalAddress: 0xb3E29C46Ee1745724417C0C51Eb2351A1C01cF36,
+            module: address(module),
+            slotsPerEpoch: 32,
+            slotsPerHistoricalRoot: 8192,
+            gindices: IVerifier.GIndices({
+                gIFirstWithdrawalPrev: NULL_GINDEX,
+                gIFirstWithdrawalCurr: NULL_GINDEX,
+                gIFirstValidatorPrev: GIndices.FIRST_VALIDATOR_ELECTRA,
+                gIFirstValidatorCurr: GIndices.FIRST_VALIDATOR_ELECTRA,
+                gIFirstHistoricalSummaryPrev: NULL_GINDEX,
+                gIFirstHistoricalSummaryCurr: NULL_GINDEX,
+                gIFirstBlockRootInSummaryPrev: NULL_GINDEX,
+                gIFirstBlockRootInSummaryCurr: NULL_GINDEX,
+                gIFirstBalanceNodePrev: GIndices.FIRST_BALANCE_NODE_ELECTRA,
+                gIFirstBalanceNodeCurr: GIndices.FIRST_BALANCE_NODE_ELECTRA
+            }),
+            firstSupportedSlot: fixture.data.recentBlock.header.slot.dec(),
+            pivotSlot: fixture.data.recentBlock.header.slot.dec(),
+            capellaSlot: Slot.wrap(0),
+            admin: admin
+        });
+
+        pauseRole = verifier.PAUSE_ROLE();
+        resumeRole = verifier.RESUME_ROLE();
+
+        vm.startPrank(admin);
+        verifier.grantRole(pauseRole, admin);
+        verifier.grantRole(resumeRole, admin);
+        vm.stopPrank();
+
+        _setMocks();
+    }
+
+    function test_processBalanceProof_HappyPath() public {
+        vm.expectCall(address(module), abi.encodeWithSelector(IBaseModule.syncKeyAddedBalance.selector));
+
+        verifier.processBalanceProof(fixture.data);
+    }
+
+    function test_processBalanceProof_RevertWhen_SlotUnsupported() public {
+        fixture.data.recentBlock.header.slot = verifier.FIRST_SUPPORTED_SLOT().dec();
+
+        vm.expectRevert(
+            abi.encodeWithSelector(IVerifier.UnsupportedSlot.selector, fixture.data.recentBlock.header.slot)
+        );
+        verifier.processBalanceProof(fixture.data);
+    }
+
+    function test_processBalanceProof_RevertWhen_InvalidBlockHeader() public {
+        vm.mockCall(
+            verifier.BEACON_ROOTS(),
+            abi.encode(fixture.data.recentBlock.rootsTimestamp),
+            abi.encode(hex"deadbeef")
+        );
+
+        vm.expectRevert(IVerifier.InvalidBlockHeader.selector);
+        verifier.processBalanceProof(fixture.data);
+    }
+
+    function test_processBalanceProof_RevertWhen_InvalidBalanceNode() public {
+        fixture.data.balance.node = someBytes32();
+
+        vm.expectRevert(SSZ.InvalidProof.selector);
+        verifier.processBalanceProof(fixture.data);
+    }
+
+    function test_processBalanceProof_RevertWhen_InvalidPublicKey() public {
+        vm.mockCall(
+            address(module),
+            abi.encodeWithSelector(
+                IBaseModule.getSigningKeys.selector,
+                fixture.data.validator.nodeOperatorId,
+                fixture.data.validator.keyIndex
+            ),
+            abi.encode(hex"deadbeef")
+        );
+
+        vm.expectRevert(IVerifier.InvalidPublicKey.selector);
+        verifier.processBalanceProof(fixture.data);
+    }
+
+    function test_processBalanceProof_RevertWhen_Paused() public {
+        vm.prank(admin);
+        verifier.pauseFor(1 days);
+
+        vm.expectRevert(PausableUntil.ResumedExpected.selector);
+        verifier.processBalanceProof(fixture.data);
+    }
+
+    function _setMocks() internal {
+        vm.mockCall(
+            verifier.BEACON_ROOTS(),
+            abi.encode(fixture.data.recentBlock.rootsTimestamp),
+            abi.encode(fixture.blockRoot)
+        );
+
+        vm.mockCall(
+            address(module),
+            abi.encodeWithSelector(
+                IBaseModule.getSigningKeys.selector,
+                fixture.data.validator.nodeOperatorId,
+                fixture.data.validator.keyIndex
+            ),
+            abi.encode(fixture.data.validator.object.pubkey)
+        );
+
+        vm.mockCall(address(module), abi.encodeWithSelector(IBaseModule.syncKeyAddedBalance.selector), "");
+    }
+
+    function _loadFixture() internal {
+        string[] memory cmd = new string[](3);
+        cmd[0] = "node";
+        cmd[1] = "--no-warnings";
+        cmd[2] = "test/fixtures/Verifier/balance.mjs";
+        bytes memory res = vm.ffi(cmd);
+        fixture = abi.decode(res, (Fixture));
+    }
+
+    function ffi_interface(Fixture memory) external {}
 }
 
 contract VerifierParentBlockRootTest is Test, Utilities {

--- a/test/unit/VerifierHistorical.t.sol
+++ b/test/unit/VerifierHistorical.t.sol
@@ -43,6 +43,9 @@ GIndex constant FIRST_HISTORICAL_SUMMARY_DENEB = GIndex.wrap(
 GIndex constant FIRST_BLOCK_ROOT_IN_SUMMARY_DENEB = GIndex.wrap(
     0x000000000000000000000000000000000000000000000000000000000040000d
 );
+GIndex constant FIRST_BALANCE_NODE_DENEB = GIndex.wrap(
+    0x0000000000000000000000000000000000000000000000000016000000000028
+);
 
 contract VerifierHistoricalBase is Test, Utilities {
     struct Fixture {
@@ -133,16 +136,6 @@ contract VerifierHistoricalTest is VerifierHistoricalBase {
         verifier.processHistoricalWithdrawalProof(fixture.data);
     }
 
-    function test_processHistoricalWithdrawalProof_RevertWhen_UnsupportedSlot_RecentBlock() public {
-        fixture.data.recentBlock.header.slot = verifier.FIRST_SUPPORTED_SLOT().dec();
-
-        vm.expectRevert(
-            abi.encodeWithSelector(IVerifier.UnsupportedSlot.selector, fixture.data.recentBlock.header.slot)
-        );
-
-        verifier.processHistoricalWithdrawalProof(fixture.data);
-    }
-
     function test_processHistoricalWithdrawalProof_RevertWhen_UnsupportedSlot_WithdrawalBlock() public {
         fixture.data.withdrawalBlock.header.slot = verifier.FIRST_SUPPORTED_SLOT().dec();
 
@@ -228,6 +221,322 @@ contract VerifierHistoricalTest is VerifierHistoricalBase {
         vm.expectRevert(IVerifier.PartialWithdrawal.selector);
         verifier.processHistoricalWithdrawalProof(fixture.data);
     }
+}
+
+contract VerifierCrossForkHistoricalBalanceTest is Test, Utilities {
+    struct Fixture {
+        bytes32 blockRoot;
+        IVerifier.ProcessHistoricalBalanceProofInput data;
+    }
+
+    Fixture public fixture;
+
+    Stub public module;
+    Verifier public verifier;
+    address public admin;
+
+    function setUp() public {
+        _loadFixture("deneb");
+
+        module = new Stub();
+        admin = nextAddress("ADMIN");
+
+        verifier = new Verifier({
+            withdrawalAddress: 0xb3E29C46Ee1745724417C0C51Eb2351A1C01cF36,
+            module: address(module),
+            slotsPerEpoch: 32,
+            slotsPerHistoricalRoot: 8192,
+            gindices: IVerifier.GIndices({
+                gIFirstWithdrawalPrev: NULL_GINDEX,
+                gIFirstWithdrawalCurr: NULL_GINDEX,
+                gIFirstValidatorPrev: FIRST_VALIDATOR_DENEB,
+                gIFirstValidatorCurr: GIndices.FIRST_VALIDATOR_ELECTRA,
+                gIFirstHistoricalSummaryPrev: FIRST_HISTORICAL_SUMMARY_DENEB,
+                gIFirstHistoricalSummaryCurr: GIndices.FIRST_HISTORICAL_SUMMARY_ELECTRA,
+                gIFirstBlockRootInSummaryPrev: FIRST_BLOCK_ROOT_IN_SUMMARY_DENEB,
+                gIFirstBlockRootInSummaryCurr: GIndices.FIRST_BLOCK_ROOT_IN_SUMMARY_ELECTRA,
+                gIFirstBalanceNodePrev: FIRST_BALANCE_NODE_DENEB,
+                gIFirstBalanceNodeCurr: GIndices.FIRST_BALANCE_NODE_ELECTRA
+            }),
+            firstSupportedSlot: fixture.data.historicalBlock.header.slot,
+            pivotSlot: fixture.data.recentBlock.header.slot.dec(),
+            capellaSlot: Slot.wrap(0),
+            admin: admin
+        });
+
+        vm.startPrank(admin);
+        verifier.grantRole(verifier.PAUSE_ROLE(), admin);
+        verifier.grantRole(verifier.RESUME_ROLE(), admin);
+        vm.stopPrank();
+
+        _setMocks();
+    }
+
+    function test_processHistoricalBalanceProof_HappyPath() public {
+        vm.expectCall(address(module), abi.encodeWithSelector(IBaseModule.syncKeyAddedBalance.selector));
+
+        verifier.processHistoricalBalanceProof(fixture.data);
+    }
+
+    function _setMocks() internal {
+        vm.mockCall(
+            verifier.BEACON_ROOTS(),
+            abi.encode(fixture.data.recentBlock.rootsTimestamp),
+            abi.encode(fixture.blockRoot)
+        );
+
+        vm.mockCall(
+            address(module),
+            abi.encodeWithSelector(IBaseModule.getSigningKeys.selector, 0, 0),
+            abi.encode(fixture.data.validator.object.pubkey)
+        );
+
+        vm.mockCall(address(module), abi.encodeWithSelector(IBaseModule.syncKeyAddedBalance.selector), "");
+    }
+
+    function _loadFixture(string memory fork) internal {
+        string[] memory cmd = new string[](4);
+        cmd[0] = "node";
+        cmd[1] = "--no-warnings";
+        cmd[2] = "test/fixtures/Verifier/historical_balance.mjs";
+        cmd[3] = fork;
+        bytes memory res = vm.ffi(cmd);
+        fixture = abi.decode(res, (Fixture));
+    }
+
+    function ffi_interface(Fixture memory) external {}
+}
+
+contract VerifierCrossForkHistoricalBalanceAtPivotSlotTest is Test, Utilities {
+    struct Fixture {
+        bytes32 blockRoot;
+        IVerifier.ProcessHistoricalBalanceProofInput data;
+    }
+
+    Fixture public fixture;
+
+    Stub public module;
+    Verifier public verifier;
+    address public admin;
+
+    function setUp() public {
+        _loadFixture("deneb");
+
+        module = new Stub();
+        admin = nextAddress("ADMIN");
+
+        verifier = new Verifier({
+            withdrawalAddress: 0xb3E29C46Ee1745724417C0C51Eb2351A1C01cF36,
+            module: address(module),
+            slotsPerEpoch: 32,
+            slotsPerHistoricalRoot: 8192,
+            gindices: IVerifier.GIndices({
+                gIFirstWithdrawalPrev: NULL_GINDEX,
+                gIFirstWithdrawalCurr: NULL_GINDEX,
+                gIFirstValidatorPrev: FIRST_VALIDATOR_DENEB,
+                gIFirstValidatorCurr: GIndices.FIRST_VALIDATOR_ELECTRA,
+                gIFirstHistoricalSummaryPrev: FIRST_HISTORICAL_SUMMARY_DENEB,
+                gIFirstHistoricalSummaryCurr: GIndices.FIRST_HISTORICAL_SUMMARY_ELECTRA,
+                gIFirstBlockRootInSummaryPrev: FIRST_BLOCK_ROOT_IN_SUMMARY_DENEB,
+                gIFirstBlockRootInSummaryCurr: GIndices.FIRST_BLOCK_ROOT_IN_SUMMARY_ELECTRA,
+                gIFirstBalanceNodePrev: FIRST_BALANCE_NODE_DENEB,
+                gIFirstBalanceNodeCurr: GIndices.FIRST_BALANCE_NODE_ELECTRA
+            }),
+            firstSupportedSlot: fixture.data.historicalBlock.header.slot,
+            pivotSlot: fixture.data.recentBlock.header.slot,
+            capellaSlot: Slot.wrap(0),
+            admin: admin
+        });
+
+        vm.startPrank(admin);
+        verifier.grantRole(verifier.PAUSE_ROLE(), admin);
+        verifier.grantRole(verifier.RESUME_ROLE(), admin);
+        vm.stopPrank();
+
+        _setMocks();
+    }
+
+    function test_processHistoricalBalanceProof_HappyPath() public {
+        vm.expectCall(address(module), abi.encodeWithSelector(IBaseModule.syncKeyAddedBalance.selector));
+
+        verifier.processHistoricalBalanceProof(fixture.data);
+    }
+
+    function _setMocks() internal {
+        vm.mockCall(
+            verifier.BEACON_ROOTS(),
+            abi.encode(fixture.data.recentBlock.rootsTimestamp),
+            abi.encode(fixture.blockRoot)
+        );
+
+        vm.mockCall(
+            address(module),
+            abi.encodeWithSelector(IBaseModule.getSigningKeys.selector, 0, 0),
+            abi.encode(fixture.data.validator.object.pubkey)
+        );
+
+        vm.mockCall(address(module), abi.encodeWithSelector(IBaseModule.syncKeyAddedBalance.selector), "");
+    }
+
+    function _loadFixture(string memory fork) internal {
+        string[] memory cmd = new string[](4);
+        cmd[0] = "node";
+        cmd[1] = "--no-warnings";
+        cmd[2] = "test/fixtures/Verifier/historical_balance.mjs";
+        cmd[3] = fork;
+        bytes memory res = vm.ffi(cmd);
+        fixture = abi.decode(res, (Fixture));
+    }
+
+    function ffi_interface(Fixture memory) external {}
+}
+
+contract VerifierHistoricalBalanceTest is Test, Utilities {
+    struct Fixture {
+        bytes32 blockRoot;
+        IVerifier.ProcessHistoricalBalanceProofInput data;
+    }
+
+    Fixture public fixture;
+
+    Stub public module;
+    Verifier public verifier;
+    address public admin;
+
+    function setUp() public {
+        _loadFixture();
+
+        module = new Stub();
+        admin = nextAddress("ADMIN");
+
+        verifier = new Verifier({
+            withdrawalAddress: 0xb3E29C46Ee1745724417C0C51Eb2351A1C01cF36,
+            module: address(module),
+            slotsPerEpoch: 32,
+            slotsPerHistoricalRoot: 8192,
+            gindices: IVerifier.GIndices({
+                gIFirstWithdrawalPrev: NULL_GINDEX,
+                gIFirstWithdrawalCurr: NULL_GINDEX,
+                gIFirstValidatorPrev: NULL_GINDEX,
+                gIFirstValidatorCurr: GIndices.FIRST_VALIDATOR_ELECTRA,
+                gIFirstHistoricalSummaryPrev: NULL_GINDEX,
+                gIFirstHistoricalSummaryCurr: GIndices.FIRST_HISTORICAL_SUMMARY_ELECTRA,
+                gIFirstBlockRootInSummaryPrev: NULL_GINDEX,
+                gIFirstBlockRootInSummaryCurr: GIndices.FIRST_BLOCK_ROOT_IN_SUMMARY_ELECTRA,
+                gIFirstBalanceNodePrev: NULL_GINDEX,
+                gIFirstBalanceNodeCurr: GIndices.FIRST_BALANCE_NODE_ELECTRA
+            }),
+            firstSupportedSlot: fixture.data.historicalBlock.header.slot,
+            pivotSlot: fixture.data.historicalBlock.header.slot,
+            capellaSlot: Slot.wrap(0),
+            admin: admin
+        });
+
+        vm.startPrank(admin);
+        verifier.grantRole(verifier.PAUSE_ROLE(), admin);
+        verifier.grantRole(verifier.RESUME_ROLE(), admin);
+        vm.stopPrank();
+
+        _setMocks();
+    }
+
+    function test_processHistoricalBalanceProof_HappyPath() public {
+        vm.expectCall(address(module), abi.encodeWithSelector(IBaseModule.syncKeyAddedBalance.selector));
+
+        verifier.processHistoricalBalanceProof(fixture.data);
+    }
+
+    function test_processHistoricalBalanceProof_RevertWhen_UnsupportedSlot_RecentBlock() public {
+        fixture.data.recentBlock.header.slot = verifier.FIRST_SUPPORTED_SLOT().dec();
+
+        vm.expectRevert(
+            abi.encodeWithSelector(IVerifier.UnsupportedSlot.selector, fixture.data.recentBlock.header.slot)
+        );
+
+        verifier.processHistoricalBalanceProof(fixture.data);
+    }
+
+    function test_processHistoricalBalanceProof_RevertWhen_UnsupportedSlot_HistoricalBlock() public {
+        fixture.data.historicalBlock.header.slot = verifier.FIRST_SUPPORTED_SLOT().dec();
+
+        vm.expectRevert(
+            abi.encodeWithSelector(IVerifier.UnsupportedSlot.selector, fixture.data.historicalBlock.header.slot)
+        );
+
+        verifier.processHistoricalBalanceProof(fixture.data);
+    }
+
+    function test_processHistoricalBalanceProof_RevertWhen_InvalidRecentBlock() public {
+        vm.mockCall(
+            verifier.BEACON_ROOTS(),
+            abi.encode(fixture.data.recentBlock.rootsTimestamp),
+            abi.encode(hex"deadbeef")
+        );
+
+        vm.expectRevert(IVerifier.InvalidBlockHeader.selector);
+        verifier.processHistoricalBalanceProof(fixture.data);
+    }
+
+    function test_processHistoricalBalanceProof_RevertWhen_InvalidHistoricalBlock() public {
+        fixture.data.historicalBlock.header.parentRoot = someBytes32();
+
+        vm.expectRevert(SSZ.InvalidProof.selector);
+        verifier.processHistoricalBalanceProof(fixture.data);
+    }
+
+    function test_processHistoricalBalanceProof_RevertWhen_InvalidBalanceNode() public {
+        fixture.data.balance.node = someBytes32();
+
+        vm.expectRevert(SSZ.InvalidProof.selector);
+        verifier.processHistoricalBalanceProof(fixture.data);
+    }
+
+    function test_processHistoricalBalanceProof_RevertWhen_InvalidPublicKey() public {
+        vm.mockCall(
+            address(module),
+            abi.encodeWithSelector(
+                IBaseModule.getSigningKeys.selector,
+                fixture.data.validator.nodeOperatorId,
+                fixture.data.validator.keyIndex
+            ),
+            abi.encode(hex"deadbeef")
+        );
+
+        vm.expectRevert(IVerifier.InvalidPublicKey.selector);
+        verifier.processHistoricalBalanceProof(fixture.data);
+    }
+
+    function _setMocks() internal {
+        vm.mockCall(
+            verifier.BEACON_ROOTS(),
+            abi.encode(fixture.data.recentBlock.rootsTimestamp),
+            abi.encode(fixture.blockRoot)
+        );
+
+        vm.mockCall(
+            address(module),
+            abi.encodeWithSelector(IBaseModule.getSigningKeys.selector, 0, 0),
+            abi.encode(fixture.data.validator.object.pubkey)
+        );
+
+        vm.mockCall(address(module), abi.encodeWithSelector(IBaseModule.syncKeyAddedBalance.selector), "");
+    }
+
+    function _loadFixture() internal {
+        _loadFixture("electra");
+    }
+
+    function _loadFixture(string memory fork) internal {
+        string[] memory cmd = new string[](4);
+        cmd[0] = "node";
+        cmd[1] = "--no-warnings";
+        cmd[2] = "test/fixtures/Verifier/historical_balance.mjs";
+        cmd[3] = fork;
+        bytes memory res = vm.ffi(cmd);
+        fixture = abi.decode(res, (Fixture));
+    }
+
+    function ffi_interface(Fixture memory) external {}
 }
 
 contract VerifierCrossForkHistoricalTest is VerifierHistoricalBase {


### PR DESCRIPTION
## Description

Replace `increaseKeyAddedBalance` with `syncKeyAddedBalance` that takes a proven absolute validator balance and derives the added balance from it (monotonic, only increases). 
Add `processBalanceProof` and `processHistoricalBalanceProof` to Verifier to call the new function.

## Checklist

- [x] Appropriate PR labels applied
- [x] Test coverage maintained (`just coverage`)
  - [ ] No need to add/update tests
  - [x] Tests are added/updated
- [x] Documentation maintained
  - [x] No need to update
  - [ ] Updated
  
  
<img width="1536" height="1024" alt="ChatGPT Image Feb 25, 2026, 10_55_04 AM" src="https://github.com/user-attachments/assets/b25a598c-ca22-444a-984d-dbb1eb1ba783" />
