### PR TITLE
fix: several audit fixes

### DIFF
--- a/.claude/skills
+++ b/.claude/skills
@@ -1,0 +1,1 @@
+../.agents/skills

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/script/csm/DeployBase.s.sol
+++ b/script/csm/DeployBase.s.sol
@@ -321,7 +321,7 @@ abstract contract DeployBase is Script {
 
             ValidatorStrikes strikesImpl = new ValidatorStrikes({ module: address(csm), oracle: address(oracle) });
 
-            strikes = ValidatorStrikes(_deployProxy(config.proxyAdmin, address(strikesImpl)));
+            strikes = ValidatorStrikes(_deployProxy(deployer, address(new Dummy())));
 
             ExitPenalties exitPenaltiesImpl = new ExitPenalties(address(csm), address(strikes));
 
@@ -333,7 +333,14 @@ abstract contract DeployBase is Script {
 
             ejector = new Ejector(address(csm), address(strikes), deployer);
 
-            strikes.initialize(deployer, address(ejector));
+            {
+                OssifiableProxy strikesProxy = OssifiableProxy(payable(address(strikes)));
+                strikesProxy.proxy__upgradeToAndCall(
+                    address(strikesImpl),
+                    abi.encodeCall(ValidatorStrikes.initialize, (deployer, address(ejector)))
+                );
+                strikesProxy.proxy__changeAdmin(config.proxyAdmin);
+            }
 
             permissionlessGate = new PermissionlessGate(address(csm), deployer);
 
@@ -341,15 +348,9 @@ abstract contract DeployBase is Script {
             vettedGateFactory = new MerkleGateFactory(vettedGateImpl);
             vettedGate = VettedGate(
                 vettedGateFactory.create(
-                    abi.encodeCall(
-                        VettedGate.initialize,
-                        (
-                            identifiedCommunityStakersGateBondCurveId,
-                            config.identifiedCommunityStakersGateTreeRoot,
-                            config.identifiedCommunityStakersGateTreeCid,
-                            deployer
-                        )
-                    ),
+                    identifiedCommunityStakersGateBondCurveId,
+                    config.identifiedCommunityStakersGateTreeRoot,
+                    config.identifiedCommunityStakersGateTreeCid,
                     deployer
                 )
             );

--- a/script/csm0x02/DeployCSM0x02Base.s.sol
+++ b/script/csm0x02/DeployCSM0x02Base.s.sol
@@ -288,7 +288,7 @@ abstract contract DeployCSM0x02Base is Script {
 
             ValidatorStrikes strikesImpl = new ValidatorStrikes({ module: address(csm), oracle: address(oracle) });
 
-            strikes = ValidatorStrikes(_deployProxy(config.proxyAdmin, address(strikesImpl)));
+            strikes = ValidatorStrikes(_deployProxy(deployer, address(new Dummy())));
 
             ExitPenalties exitPenaltiesImpl = new ExitPenalties(address(csm), address(strikes));
 
@@ -300,7 +300,14 @@ abstract contract DeployCSM0x02Base is Script {
 
             ejector = new Ejector(address(csm), address(strikes), deployer);
 
-            strikes.initialize(deployer, address(ejector));
+            {
+                OssifiableProxy strikesProxy = OssifiableProxy(payable(address(strikes)));
+                strikesProxy.proxy__upgradeToAndCall(
+                    address(strikesImpl),
+                    abi.encodeCall(ValidatorStrikes.initialize, (deployer, address(ejector)))
+                );
+                strikesProxy.proxy__changeAdmin(config.proxyAdmin);
+            }
 
             permissionlessGate = new PermissionlessGate(address(csm), deployer);
 

--- a/script/curated/DeployBase.s.sol
+++ b/script/curated/DeployBase.s.sol
@@ -377,7 +377,7 @@ abstract contract DeployBase is Script {
                 oracle: address(oracle)
             });
 
-            strikes = ValidatorStrikes(_deployProxy(config.proxyAdmin, address(strikesImpl)));
+            strikes = ValidatorStrikes(_deployProxy(deployer, address(new Dummy())));
 
             ExitPenalties exitPenaltiesImpl = new ExitPenalties(address(curatedModule), address(strikes));
 
@@ -389,7 +389,14 @@ abstract contract DeployBase is Script {
 
             ejector = new Ejector(address(curatedModule), address(strikes), deployer);
 
-            strikes.initialize(deployer, address(ejector));
+            {
+                OssifiableProxy strikesProxy = OssifiableProxy(payable(address(strikes)));
+                strikesProxy.proxy__upgradeToAndCall(
+                    address(strikesImpl),
+                    abi.encodeCall(ValidatorStrikes.initialize, (deployer, address(ejector)))
+                );
+                strikesProxy.proxy__changeAdmin(config.proxyAdmin);
+            }
 
             curatedGateImpl = address(new CuratedGate(address(curatedModule)));
 
@@ -572,13 +579,7 @@ abstract contract DeployBase is Script {
             uint256 gateCurveId = curveIds[i];
             CuratedGateConfig storage gateConfig = config.curatedGates[i];
             CuratedGate gate = CuratedGate(
-                gateFactory.create(
-                    abi.encodeCall(
-                        CuratedGate.initialize,
-                        (gateCurveId, gateConfig.treeRoot, gateConfig.treeCid, deployer)
-                    ),
-                    deployer
-                )
+                gateFactory.create(gateCurveId, gateConfig.treeRoot, gateConfig.treeCid, deployer)
             );
 
             {

--- a/src/Accounting.sol
+++ b/src/Accounting.sol
@@ -302,8 +302,8 @@ contract Accounting is
     }
 
     /// @inheritdoc IAccounting
-    function chargeFee(uint256 nodeOperatorId, uint256 amount) external onlyModule {
-        BondCore._charge(nodeOperatorId, amount, chargePenaltyRecipient);
+    function chargeFee(uint256 nodeOperatorId, uint256 amount) external onlyModule returns (bool) {
+        return BondCore._charge(nodeOperatorId, amount, chargePenaltyRecipient);
     }
 
     /// @inheritdoc IAccounting

--- a/src/CSModule.sol
+++ b/src/CSModule.sol
@@ -29,8 +29,6 @@ contract CSModule is ICSModule, BaseModule {
         TopUpQueueLib.Queue topUpQueue;
     }
 
-    uint256 public immutable QUEUE_LOWEST_PRIORITY;
-
     bytes32 public constant MANAGE_TOP_UP_QUEUE_ROLE = keccak256("MANAGE_TOP_UP_QUEUE_ROLE");
     bytes32 public constant REWIND_TOP_UP_QUEUE_ROLE = keccak256("REWIND_TOP_UP_QUEUE_ROLE");
 
@@ -46,9 +44,7 @@ contract CSModule is ICSModule, BaseModule {
         address parametersRegistry,
         address accounting,
         address exitPenalties
-    ) BaseModule(moduleType, lidoLocator, parametersRegistry, accounting, exitPenalties) {
-        QUEUE_LOWEST_PRIORITY = PARAMETERS_REGISTRY.QUEUE_LOWEST_PRIORITY();
-    }
+    ) BaseModule(moduleType, lidoLocator, parametersRegistry, accounting, exitPenalties) {}
 
     /// @dev Initialize contract from scratch. In case of a method call frontrun, the contract instance should be discarded.
     ///      It is recommended to call this method in the same transaction as the deployment transaction
@@ -387,9 +383,8 @@ contract CSModule is ICSModule, BaseModule {
         enabled = _topUpQueue().enabled;
     }
 
-    /// @dev This function is used to get the queue lowest priority from immutables to save bytecode.
     function _queueLowestPriority() internal view returns (uint256) {
-        return QUEUE_LOWEST_PRIORITY;
+        return PARAMETERS_REGISTRY.QUEUE_LOWEST_PRIORITY();
     }
 
     function _storage() internal pure returns (CSModuleStorage storage $) {

--- a/src/CSModule.sol
+++ b/src/CSModule.sol
@@ -384,7 +384,7 @@ contract CSModule is ICSModule, BaseModule {
     }
 
     function _queueLowestPriority() internal view returns (uint256) {
-        return PARAMETERS_REGISTRY.QUEUE_LOWEST_PRIORITY();
+        return _parametersRegistry().QUEUE_LOWEST_PRIORITY();
     }
 
     function _storage() internal pure returns (CSModuleStorage storage $) {

--- a/src/CuratedGate.sol
+++ b/src/CuratedGate.sol
@@ -8,6 +8,7 @@ import { ICuratedGate } from "./interfaces/ICuratedGate.sol";
 import { NodeOperatorManagementProperties } from "./interfaces/IBaseModule.sol";
 import { IMetaRegistry, OperatorMetadata } from "./interfaces/IMetaRegistry.sol";
 import { IAccounting } from "./interfaces/IAccounting.sol";
+import { IMerkleGate } from "./interfaces/IMerkleGate.sol";
 import { MerkleGate } from "./abstract/MerkleGate.sol";
 
 /// @notice Merkle gate for Curated Module
@@ -35,16 +36,14 @@ contract CuratedGate is ICuratedGate, MerkleGate {
         _disableInitializers();
     }
 
-    /// @dev Initialize contract from scratch. In case of a method call frontrun, the contract instance should be discarded.
-    ///      It is recommended to call this method in the same transaction as the deployment transaction
-    ///      and perform extensive deployment verification before using the contract instance.
+    /// @inheritdoc MerkleGate
     function initialize(
         uint256 curveId,
         bytes32 treeRoot,
         string calldata treeCid,
         address admin
-    ) external initializer {
-        __MerkleGate_init(curveId, treeRoot, treeCid, admin);
+    ) public override(IMerkleGate, MerkleGate) initializer {
+        super.initialize(curveId, treeRoot, treeCid, admin);
     }
 
     /// @inheritdoc ICuratedGate

--- a/src/MerkleGateFactory.sol
+++ b/src/MerkleGateFactory.sol
@@ -4,6 +4,7 @@
 pragma solidity 0.8.33;
 
 import { OssifiableProxy } from "./lib/proxy/OssifiableProxy.sol";
+import { IMerkleGate } from "./interfaces/IMerkleGate.sol";
 import { IMerkleGateFactory } from "./interfaces/IMerkleGateFactory.sol";
 
 contract MerkleGateFactory is IMerkleGateFactory {
@@ -15,9 +16,15 @@ contract MerkleGateFactory is IMerkleGateFactory {
     }
 
     /// @inheritdoc IMerkleGateFactory
-    function create(bytes calldata initCalldata, address admin) external returns (address instance) {
-        instance = address(new OssifiableProxy({ implementation_: GATE_IMPL, data_: initCalldata, admin_: admin }));
+    function create(
+        uint256 curveId,
+        bytes32 treeRoot,
+        string calldata treeCid,
+        address admin
+    ) external returns (address instance) {
+        instance = address(new OssifiableProxy({ implementation_: GATE_IMPL, data_: "", admin_: admin }));
+        IMerkleGate(instance).initialize(curveId, treeRoot, treeCid, admin);
 
-        emit MerkleGateCreated(instance, GATE_IMPL, admin);
+        emit MerkleGateCreated(instance, admin, curveId);
     }
 }

--- a/src/ParametersRegistry.sol
+++ b/src/ParametersRegistry.sol
@@ -553,7 +553,7 @@ contract ParametersRegistry is IParametersRegistry, Initializable, AccessControl
     }
 
     function _setDefaultRewardShare(uint256 share) internal {
-        if (share > MAX_BP) revert InvalidRewardShareData();
+        if (share == 0 || share > MAX_BP) revert InvalidRewardShareData();
 
         defaultRewardShare = share;
         emit DefaultRewardShareSet(share);
@@ -644,7 +644,7 @@ contract ParametersRegistry is IParametersRegistry, Initializable, AccessControl
     function _validateKeyNumberValueIntervals(KeyNumberValueInterval[] calldata intervals) private pure {
         if (intervals.length == 0) revert InvalidKeyNumberValueIntervals();
         if (intervals[0].minKeyNumber != 1) revert InvalidKeyNumberValueIntervals();
-        if (intervals[0].value > MAX_BP) revert InvalidKeyNumberValueIntervals();
+        if (intervals[0].value == 0 || intervals[0].value > MAX_BP) revert InvalidKeyNumberValueIntervals();
 
         for (uint256 i = 1; i < intervals.length; ++i) {
             unchecked {

--- a/src/ParametersRegistry.sol
+++ b/src/ParametersRegistry.sol
@@ -256,6 +256,9 @@ contract ParametersRegistry is IParametersRegistry, Initializable, AccessControl
         uint256 curveId,
         KeyNumberValueInterval[] calldata data
     ) external onlyRoleMemberOrAdmin(MANAGE_REWARD_SHARE_ROLE) {
+        // NOTE: The shared interval validator enforces `data[0].value > 0`.
+        // Zero reward share for the first interval would allow rebate-only oracle reports (`distributed == 0 && rebate > 0`),
+        // and those are rejected by FeeDistributor.
         _validateKeyNumberValueIntervals(data);
         KeyNumberValueInterval[] storage intervals = _rewardShareData[curveId];
         if (intervals.length > 0) delete _rewardShareData[curveId];

--- a/src/VettedGate.sol
+++ b/src/VettedGate.sol
@@ -5,6 +5,7 @@ pragma solidity 0.8.33;
 
 import { IAccounting } from "./interfaces/IAccounting.sol";
 import { IBaseModule, NodeOperatorManagementProperties } from "./interfaces/IBaseModule.sol";
+import { IMerkleGate } from "./interfaces/IMerkleGate.sol";
 import { IVettedGate } from "./interfaces/IVettedGate.sol";
 import { MerkleGate } from "./abstract/MerkleGate.sol";
 
@@ -25,17 +26,15 @@ contract VettedGate is IVettedGate, MerkleGate {
         _disableInitializers();
     }
 
-    /// @dev Initialize contract from scratch. In case of a method call frontrun, the contract instance should be discarded.
-    ///      It is recommended to call this method in the same transaction as the deployment transaction
-    ///      and perform extensive deployment verification before using the contract instance.
+    /// @inheritdoc MerkleGate
     function initialize(
         uint256 curveId,
         bytes32 treeRoot,
         string calldata treeCid,
         address admin
-    ) external initializer {
+    ) public override(IMerkleGate, MerkleGate) initializer {
         if (curveId == ACCOUNTING.DEFAULT_BOND_CURVE_ID()) revert InvalidCurveId();
-        __MerkleGate_init(curveId, treeRoot, treeCid, admin);
+        super.initialize(curveId, treeRoot, treeCid, admin);
     }
 
     /// @inheritdoc IVettedGate

--- a/src/abstract/BondCore.sol
+++ b/src/abstract/BondCore.sol
@@ -188,16 +188,18 @@ abstract contract BondCore is IBondCore {
     /// @dev Transfer Node Operator's bond shares (stETH) to charge recipient
     /// @param amount Bond amount to charge in ETH (stETH)
     /// @param recipient Address to send charged shares
-    function _charge(uint256 nodeOperatorId, uint256 amount, address recipient) internal {
+    /// @return charged Whether any shares were actually transferred
+    function _charge(uint256 nodeOperatorId, uint256 amount, address recipient) internal returns (bool charged) {
         uint256 sharesToCharge = _sharesByEth(amount);
         uint256 effectiveSharesToCharge = _reduceBond(nodeOperatorId, sharesToCharge);
 
         // If no bond already or the amount to charge is zero
-        if (effectiveSharesToCharge == 0) return;
+        if (effectiveSharesToCharge == 0) return false;
 
         uint256 chargedEth = LIDO.transferShares(recipient, effectiveSharesToCharge);
 
         emit BondCharged(nodeOperatorId, _ethByShares(sharesToCharge), chargedEth);
+        return true;
     }
 
     /// @dev Unsafe reduce bond shares (stETH) (possible underflow). Safety checks should be done outside

--- a/src/abstract/MerkleGate.sol
+++ b/src/abstract/MerkleGate.sol
@@ -38,6 +38,19 @@ abstract contract MerkleGate is IMerkleGate, AccessControlEnumerableUpgradeable,
     }
 
     /// @inheritdoc IMerkleGate
+    function initialize(
+        uint256 curveId_,
+        bytes32 treeRoot_,
+        string calldata treeCid_,
+        address admin
+    ) public virtual onlyInitializing {
+        if (admin == address(0)) revert ZeroAdminAddress();
+        curveId = curveId_;
+        _setTreeParams(treeRoot_, treeCid_);
+        _grantRole(DEFAULT_ADMIN_ROLE, admin);
+    }
+
+    /// @inheritdoc IMerkleGate
     function isConsumed(address member) public view returns (bool) {
         return _consumedAddresses[member];
     }
@@ -50,21 +63,6 @@ abstract contract MerkleGate is IMerkleGate, AccessControlEnumerableUpgradeable,
     /// @inheritdoc IMerkleGate
     function hashLeaf(address member) public pure returns (bytes32) {
         return keccak256(bytes.concat(keccak256(abi.encode(member))));
-    }
-
-    /// @dev Shared initialization for gate implementations.
-    // solhint-disable-next-line func-name-mixedcase
-    function __MerkleGate_init(
-        uint256 curveId_,
-        bytes32 treeRoot_,
-        string calldata treeCid_,
-        address admin
-    ) internal onlyInitializing {
-        if (admin == address(0)) revert ZeroAdminAddress();
-
-        curveId = curveId_;
-        _setTreeParams(treeRoot_, treeCid_);
-        _grantRole(DEFAULT_ADMIN_ROLE, admin);
     }
 
     function _consume(bytes32[] calldata proof) internal {

--- a/src/interfaces/IAccounting.sol
+++ b/src/interfaces/IAccounting.sol
@@ -310,7 +310,8 @@ interface IAccounting is IBondCore, IBondCurve, IBondLock, IFeeSplits, IAssetRec
     ///      Method call can result in the remaining bond being lower than the locked bond.
     /// @param nodeOperatorId ID of the Node Operator
     /// @param amount Amount to charge in ETH (stETH)
-    function chargeFee(uint256 nodeOperatorId, uint256 amount) external;
+    /// @return Whether any shares were actually transferred
+    function chargeFee(uint256 nodeOperatorId, uint256 amount) external returns (bool);
 
     /// @notice Pull fees (if proof provided) from FeeDistributor to the Node Operator's bond and split according to configured fee splits.
     /// @param nodeOperatorId ID of the Node Operator

--- a/src/interfaces/ICSModule.sol
+++ b/src/interfaces/ICSModule.sol
@@ -59,9 +59,6 @@ interface ICSModule is IBaseModule, IStakingModuleV2, IDepositQueueLib, ITopUpQu
     /// @return keyIndex Index of the key in the Node Operator's keys storage
     function getTopUpQueueItem(uint256 index) external view returns (uint256 nodeOperatorId, uint256 keyIndex);
 
-    /// @notice Returns the number reserved for the lowest queue priority.
-    function QUEUE_LOWEST_PRIORITY() external view returns (uint256);
-
     /// @notice Get the pointers to the head and tail of queue with the given priority.
     /// @param queuePriority Priority of the queue to get the pointers.
     /// @return head Pointer to the head of the queue.

--- a/src/interfaces/IMerkleGate.sol
+++ b/src/interfaces/IMerkleGate.sol
@@ -48,6 +48,13 @@ interface IMerkleGate {
     /// @notice Hash leaf encoding for addresses in the Merkle tree
     function hashLeaf(address member) external pure returns (bytes32);
 
+    /// @notice Initialize the gate instance.
+    /// @param curveId Bond curve id to assign to eligible members.
+    /// @param treeRoot Initial Merkle tree root.
+    /// @param treeCid Initial Merkle tree CID.
+    /// @param admin Address to be granted DEFAULT_ADMIN_ROLE.
+    function initialize(uint256 curveId, bytes32 treeRoot, string calldata treeCid, address admin) external;
+
     /// @notice Initialized version for upgradeable tooling
     function getInitializedVersion() external view returns (uint64);
 }

--- a/src/interfaces/IMerkleGateFactory.sol
+++ b/src/interfaces/IMerkleGateFactory.sol
@@ -4,16 +4,23 @@
 pragma solidity 0.8.33;
 
 interface IMerkleGateFactory {
-    event MerkleGateCreated(address indexed gate, address indexed implementation, address indexed admin);
+    event MerkleGateCreated(address indexed gate, address indexed admin, uint256 curveId);
 
     error ZeroImplementationAddress();
 
     /// @dev Address of the gate implementation used for new instances.
     function GATE_IMPL() external view returns (address);
 
-    /// @notice Creates a new gate proxy for the predefined implementation.
-    /// @param initCalldata Initialization calldata delegated in proxy constructor.
-    /// @param admin Address of the proxy admin.
+    /// @notice Creates a new gate proxy for the predefined implementation and initializes it.
+    /// @param curveId Bond curve id to assign to eligible members.
+    /// @param treeRoot Initial Merkle tree root.
+    /// @param treeCid Initial Merkle tree CID.
+    /// @param admin Address of the proxy admin and DEFAULT_ADMIN_ROLE holder.
     /// @return instance Address of the created proxy instance.
-    function create(bytes calldata initCalldata, address admin) external returns (address instance);
+    function create(
+        uint256 curveId,
+        bytes32 treeRoot,
+        string calldata treeCid,
+        address admin
+    ) external returns (address instance);
 }

--- a/src/lib/NodeOperatorOps.sol
+++ b/src/lib/NodeOperatorOps.sol
@@ -131,8 +131,10 @@ library NodeOperatorOps {
 
             NodeOperator storage no = nodeOperators[nodeOperatorId];
 
+            if (vettedSigningKeysCount == no.totalVettedKeys) continue;
+
             if (no.managerAddress == address(0)) revert IBaseModule.NodeOperatorDoesNotExist();
-            if (vettedSigningKeysCount >= no.totalVettedKeys) revert IBaseModule.InvalidVetKeysPointer();
+            if (vettedSigningKeysCount > no.totalVettedKeys) revert IBaseModule.InvalidVetKeysPointer();
             if (vettedSigningKeysCount < no.totalDepositedKeys) revert IBaseModule.InvalidVetKeysPointer();
 
             // NodeOperator.totalVettedKeys and totalDepositedKeys are uint32 slots; the checks above keep
@@ -237,8 +239,7 @@ library NodeOperatorOps {
         uint256 amountToCharge = parametersRegistry.getKeyRemovalCharge(accounting.getBondCurveId(nodeOperatorId)) *
             keysCount;
 
-        if (amountToCharge != 0) {
-            accounting.chargeFee(nodeOperatorId, amountToCharge);
+        if (amountToCharge != 0 && accounting.chargeFee(nodeOperatorId, amountToCharge)) {
             emit IBaseModule.KeyRemovalChargeApplied(nodeOperatorId);
         }
 

--- a/src/lib/TopUpQueueOps.sol
+++ b/src/lib/TopUpQueueOps.sol
@@ -15,14 +15,14 @@ import { SigningKeys } from "./SigningKeys.sol";
 library TopUpQueueOps {
     using TopUpQueueLib for TopUpQueueLib.Queue;
 
-    // StakingRouter expects non-zero top-up allocations to be at least 1 ether.
-    uint256 internal constant TOP_UP_STEP = 1 ether;
-
     struct TopUpKeyParams {
         uint256[] keyIndices;
         uint256[] operatorIds;
         uint256[] topUpLimits;
     }
+
+    // StakingRouter expects non-zero top-up allocations to be at least 1 ether.
+    uint256 internal constant TOP_UP_STEP = 1 ether;
 
     function allocateDeposits(
         TopUpQueueLib.Queue storage topUpQueue,
@@ -66,7 +66,7 @@ library TopUpQueueOps {
 
             SigningKeys.verifySigningKey(item.noId(), item.keyIndex(), pubkeys[i]);
 
-            uint256 limit = _normalizeAmount(data.topUpLimits[i]);
+            uint256 limit = _quantizeAmount(data.topUpLimits[i]);
 
             if (maxDepositAmount > 0) {
                 allocations[i] = Math.min(limit, maxDepositAmount);
@@ -79,9 +79,9 @@ library TopUpQueueOps {
         }
     }
 
-    function _normalizeAmount(uint256 value) private pure returns (uint256 normalized) {
+    function _quantizeAmount(uint256 value) private pure returns (uint256 quantized) {
         unchecked {
-            normalized = value - (value % TOP_UP_STEP);
+            quantized = value - (value % TOP_UP_STEP);
         }
     }
 }

--- a/test/fork/integration/csm/Misc.t.sol
+++ b/test/fork/integration/csm/Misc.t.sol
@@ -23,10 +23,7 @@ contract VettedGateFactoryTest is MiscTest {
         string memory cid = "someOtherCid";
 
         vm.startSnapshotGas("VettedGateFactory.createVetted");
-        address instance = vettedGateFactory.create(
-            abi.encodeCall(VettedGate.initialize, (curveId, root, cid, address(this))),
-            address(this)
-        );
+        address instance = vettedGateFactory.create(curveId, root, cid, address(this));
         vm.stopSnapshotGas();
 
         VettedGate gate = VettedGate(instance);

--- a/test/fork/integration/curated/CuratedGateFactory.t.sol
+++ b/test/fork/integration/curated/CuratedGateFactory.t.sol
@@ -21,10 +21,7 @@ contract CuratedGateFactoryTest is CuratedIntegrationBase {
         address admin = nextAddress("GateAdmin");
 
         vm.startSnapshotGas("CuratedGateFactory.createCurated");
-        address instance = curatedGateFactory.create(
-            abi.encodeCall(CuratedGate.initialize, (curveId, root, cid, admin)),
-            admin
-        );
+        address instance = curatedGateFactory.create(curveId, root, cid, admin);
         vm.stopSnapshotGas();
 
         CuratedGate gate = CuratedGate(instance);

--- a/test/fork/vote-upgrade/V3Upgrade.t.sol
+++ b/test/fork/vote-upgrade/V3Upgrade.t.sol
@@ -161,10 +161,10 @@ contract VoteChangesTest is V3UpgradeTestBase {
 
     function test_csmQueuePriorityRange() public {
         vm.selectFork(forkIdBeforeUpgrade);
-        uint256 queueLowestPriorityBefore = module.QUEUE_LOWEST_PRIORITY();
+        uint256 queueLowestPriorityBefore = parametersRegistry.QUEUE_LOWEST_PRIORITY();
 
         vm.selectFork(forkIdAfterUpgrade);
-        uint256 queueLowestPriorityAfter = module.QUEUE_LOWEST_PRIORITY();
+        uint256 queueLowestPriorityAfter = parametersRegistry.QUEUE_LOWEST_PRIORITY();
 
         assertGe(queueLowestPriorityAfter, queueLowestPriorityBefore, "queue priority range shrunk");
     }

--- a/test/helpers/Fixtures.sol
+++ b/test/helpers/Fixtures.sol
@@ -1020,7 +1020,7 @@ contract CSMIntegrationHelpers is ForkIntegrationHelpersBase {
     ) external override returns (uint256 noId, uint256 keysCount) {
         (, , uint256 depositableValidatorsCount) = module.getStakingModuleSummary();
         module.cleanDepositQueue({ maxItems: 2 * depositableValidatorsCount });
-        for (uint256 i = 0; i <= module.QUEUE_LOWEST_PRIORITY(); ++i) {
+        for (uint256 i = 0; i <= module.PARAMETERS_REGISTRY().QUEUE_LOWEST_PRIORITY(); ++i) {
             (uint128 head, ) = module.depositQueuePointers(i);
             Batch batch = module.depositQueueItem(i, head);
             if (!batch.isNil()) return (batch.noId(), batch.keys());

--- a/test/helpers/InvariantAsserts.sol
+++ b/test/helpers/InvariantAsserts.sol
@@ -120,7 +120,7 @@ contract InvariantAsserts is Test {
         uint256 noCount = csm.getNodeOperatorsCount();
         NodeOperator memory no;
 
-        for (uint256 p = 0; p <= csm.QUEUE_LOWEST_PRIORITY(); ++p) {
+        for (uint256 p = 0; p <= csm.PARAMETERS_REGISTRY().QUEUE_LOWEST_PRIORITY(); ++p) {
             (uint128 head, uint128 tail) = csm.depositQueuePointers(p);
 
             for (uint128 i = head; i < tail; ) {

--- a/test/unit/CSModule.t.sol
+++ b/test/unit/CSModule.t.sol
@@ -154,7 +154,7 @@ contract CSMCommon is ModuleFixtures {
     }
 
     function _assertQueueIsEmpty() internal view {
-        for (uint256 p = 0; p <= csm.QUEUE_LOWEST_PRIORITY(); ++p) {
+        for (uint256 p = 0; p <= parametersRegistry.QUEUE_LOWEST_PRIORITY(); ++p) {
             (uint128 curr, ) = csm.depositQueuePointers(p); // queue.head
             assertTrue(
                 csm.depositQueueItem(p, curr).isNil(),
@@ -164,7 +164,7 @@ contract CSMCommon is ModuleFixtures {
     }
 
     function _printQueue() internal view {
-        for (uint256 p = 0; p <= csm.QUEUE_LOWEST_PRIORITY(); ++p) {
+        for (uint256 p = 0; p <= parametersRegistry.QUEUE_LOWEST_PRIORITY(); ++p) {
             (uint128 curr, ) = csm.depositQueuePointers(p);
 
             for (;;) {
@@ -415,7 +415,7 @@ contract CSMAddValidatorKeys is ModuleAddValidatorKeys, CSMCommon {
         vm.deal(nodeOperator, required);
 
         vm.expectEmit(address(module));
-        emit ICSModule.BatchEnqueued(ICSModule(address(module)).QUEUE_LOWEST_PRIORITY(), noId, 1);
+        emit ICSModule.BatchEnqueued(parametersRegistry.QUEUE_LOWEST_PRIORITY(), noId, 1);
         vm.prank(nodeOperator);
         module.addValidatorKeysETH{ value: required }(nodeOperator, noId, 1, keys, signatures);
     }
@@ -429,7 +429,7 @@ contract CSMAddValidatorKeys is ModuleAddValidatorKeys, CSMCommon {
         stETH.submit{ value: BOND_SIZE + 1 wei }(address(0));
 
         vm.expectEmit(address(module));
-        emit ICSModule.BatchEnqueued(ICSModule(address(module)).QUEUE_LOWEST_PRIORITY(), noId, 1);
+        emit ICSModule.BatchEnqueued(parametersRegistry.QUEUE_LOWEST_PRIORITY(), noId, 1);
         module.addValidatorKeysStETH(
             nodeOperator,
             noId,
@@ -452,7 +452,7 @@ contract CSMAddValidatorKeys is ModuleAddValidatorKeys, CSMCommon {
         (bytes memory keys, bytes memory signatures) = keysSignatures(1, 1);
 
         vm.expectEmit(address(module));
-        emit ICSModule.BatchEnqueued(ICSModule(address(module)).QUEUE_LOWEST_PRIORITY(), noId, 1);
+        emit ICSModule.BatchEnqueued(parametersRegistry.QUEUE_LOWEST_PRIORITY(), noId, 1);
         module.addValidatorKeysWstETH(
             nodeOperator,
             noId,
@@ -1378,7 +1378,7 @@ contract CSMQueueOps is CSMCommon {
         BatchInfo[] memory exp = new BatchInfo[](2);
         exp[0] = BatchInfo({ nodeOperatorId: 0, count: 3 });
         exp[1] = BatchInfo({ nodeOperatorId: 1, count: 5 });
-        _assertQueueState(csm.QUEUE_LOWEST_PRIORITY(), exp);
+        _assertQueueState(parametersRegistry.QUEUE_LOWEST_PRIORITY(), exp);
 
         (toRemove, ) = csm.cleanDepositQueue(LOOKUP_DEPTH);
         assertEq(toRemove, 0, "queue should be clean");
@@ -1479,7 +1479,7 @@ contract CSMQueueOps is CSMCommon {
         csm.cleanDepositQueue(1);
 
         vm.expectEmit(address(module));
-        emit ICSModule.BatchEnqueued(csm.QUEUE_LOWEST_PRIORITY(), noId, 7);
+        emit ICSModule.BatchEnqueued(parametersRegistry.QUEUE_LOWEST_PRIORITY(), noId, 7);
 
         module.updateTargetValidatorsLimits({ nodeOperatorId: noId, targetLimitMode: 1, targetLimit: 7 });
     }
@@ -1501,7 +1501,7 @@ contract CSMQueueOps is CSMCommon {
         });
 
         vm.expectEmit(address(module));
-        emit ICSModule.BatchEnqueued(csm.QUEUE_LOWEST_PRIORITY(), noId, 1);
+        emit ICSModule.BatchEnqueued(parametersRegistry.QUEUE_LOWEST_PRIORITY(), noId, 1);
         module.reportRegularWithdrawnValidators(validatorInfos);
     }
 }
@@ -1852,7 +1852,7 @@ contract CSMReportGeneralDelayedPenalty is ModuleReportGeneralDelayedPenalty, CS
         vm.warp(accounting.getBondLockPeriod() + 1);
 
         vm.expectEmit(address(csm));
-        emit ICSModule.BatchEnqueued(ICSModule(address(csm)).QUEUE_LOWEST_PRIORITY(), noId, 1);
+        emit ICSModule.BatchEnqueued(parametersRegistry.QUEUE_LOWEST_PRIORITY(), noId, 1);
         csm.updateDepositableValidatorsCount(noId);
 
         no = csm.getNodeOperator(noId);

--- a/test/unit/MerkleGateFactory.t.sol
+++ b/test/unit/MerkleGateFactory.t.sol
@@ -34,12 +34,11 @@ contract MerkleGateFactoryTest is Test, Utilities {
         CSMMock csm = new CSMMock();
         address impl = address(new VettedGate(address(csm)));
         MerkleGateFactory factory = new MerkleGateFactory(impl);
-        bytes memory initCalldata = abi.encodeCall(VettedGate.initialize, (curveId, root, cid, admin));
 
-        vm.expectEmit(false, true, true, false, address(factory));
-        emit IMerkleGateFactory.MerkleGateCreated(address(0), impl, admin);
+        vm.expectEmit(false, true, true, true, address(factory));
+        emit IMerkleGateFactory.MerkleGateCreated(address(0), admin, curveId);
 
-        address instance = factory.create(initCalldata, admin);
+        address instance = factory.create(curveId, root, cid, admin);
         IVettedGate gate = IVettedGate(instance);
 
         assertEq(gate.curveId(), curveId);
@@ -62,12 +61,11 @@ contract MerkleGateFactoryTest is Test, Utilities {
 
         address impl = address(new CuratedGate(address(module)));
         MerkleGateFactory factory = new MerkleGateFactory(impl);
-        bytes memory initCalldata = abi.encodeCall(CuratedGate.initialize, (curveId, root, cid, admin));
 
-        vm.expectEmit(false, true, true, false, address(factory));
-        emit IMerkleGateFactory.MerkleGateCreated(address(0), impl, admin);
+        vm.expectEmit(false, true, true, true, address(factory));
+        emit IMerkleGateFactory.MerkleGateCreated(address(0), admin, curveId);
 
-        address instance = factory.create(initCalldata, admin);
+        address instance = factory.create(curveId, root, cid, admin);
         ICuratedGate gate = ICuratedGate(instance);
 
         assertEq(gate.curveId(), curveId);
@@ -96,13 +94,12 @@ contract MerkleGateFactoryTest is Test, Utilities {
         assertEq(factory.GATE_IMPL(), impl);
 
         address secondImpl = address(new VettedGate(address(new CSMMock())));
-        bytes memory initCalldata = abi.encodeCall(VettedGate.initialize, (curveId, root, cid, admin));
 
         // The factory should always use its immutable implementation.
-        vm.expectEmit(false, true, true, false, address(factory));
-        emit IMerkleGateFactory.MerkleGateCreated(address(0), impl, admin);
+        vm.expectEmit(false, true, true, true, address(factory));
+        emit IMerkleGateFactory.MerkleGateCreated(address(0), admin, curveId);
 
-        address instance = factory.create(initCalldata, admin);
+        address instance = factory.create(curveId, root, cid, admin);
         OssifiableProxy proxy = OssifiableProxy(payable(instance));
         assertEq(proxy.proxy__getImplementation(), impl);
         assertNotEq(proxy.proxy__getImplementation(), secondImpl);

--- a/test/unit/ModuleAbstract/KeysManage.t.sol
+++ b/test/unit/ModuleAbstract/KeysManage.t.sol
@@ -104,6 +104,37 @@ abstract contract ModuleDecreaseVettedSigningKeysCount is ModuleFixtures {
         assertEq(actualVettedThird, 15);
     }
 
+    function test_decreaseVettedSigningKeysCount_MultipleOperators_NoopOnEqualStaleValue() public assertInvariants {
+        uint256 staleNoId = createNodeOperator(10);
+        uint256 activeNoId = createNodeOperator(7);
+        uint256 staleReportedVetted = 5;
+        uint256 activeReportedVetted = 3;
+
+        vm.prank(nodeOperator);
+        module.removeKeys(staleNoId, staleReportedVetted, 5);
+        uint256 nonce = module.getNonce();
+
+        vm.expectEmit(address(module));
+        emit IBaseModule.VettedSigningKeysCountChanged(activeNoId, activeReportedVetted);
+        vm.expectEmit(address(module));
+        emit IBaseModule.VettedSigningKeysCountDecreased(activeNoId);
+
+        module.decreaseVettedSigningKeysCount(
+            _encodeNodeOperatorPair(staleNoId, activeNoId),
+            bytes.concat(
+                // Each vetted value mirrors the uint128 field used on-chain, so truncation is safe.
+                // forge-lint: disable-next-line(unsafe-typecast)
+                bytes16(uint128(staleReportedVetted)),
+                // forge-lint: disable-next-line(unsafe-typecast)
+                bytes16(uint128(activeReportedVetted))
+            )
+        );
+
+        assertEq(module.getNonce(), nonce + 1);
+        assertEq(module.getNodeOperator(staleNoId).totalVettedKeys, staleReportedVetted);
+        assertEq(module.getNodeOperator(activeNoId).totalVettedKeys, activeReportedVetted);
+    }
+
     function test_decreaseVettedSigningKeysCount_RevertWhen_MissingVettedData() public {
         uint256 firstNoId = createNodeOperator(10);
         uint256 secondNoId = createNodeOperator(7);
@@ -116,12 +147,16 @@ abstract contract ModuleDecreaseVettedSigningKeysCount is ModuleFixtures {
         );
     }
 
-    function test_decreaseVettedSigningKeysCount_RevertWhen_NewVettedEqOld() public {
+    function test_decreaseVettedSigningKeysCount_NoopWhen_NewVettedEqOld() public {
         uint256 noId = createNodeOperator(10);
         uint256 newVetted = 10;
+        uint256 nonce = module.getNonce();
 
-        vm.expectRevert(IBaseModule.InvalidVetKeysPointer.selector);
         unvetKeys(noId, newVetted);
+
+        NodeOperator memory no = module.getNodeOperator(noId);
+        assertEq(module.getNonce(), nonce);
+        assertEq(no.totalVettedKeys, newVetted);
     }
 
     function test_decreaseVettedSigningKeysCount_RevertWhen_NewVettedGreaterOld() public {

--- a/test/unit/ParametersRegistry.t.sol
+++ b/test/unit/ParametersRegistry.t.sol
@@ -173,6 +173,16 @@ contract ParametersRegistryInitTest is ParametersRegistryBaseTest {
         parametersRegistry.initialize(admin, customInitData);
     }
 
+    function test_initialize_RevertWhen_ZeroDefaultRewardShare() public {
+        _enableInitializers(address(parametersRegistry));
+
+        IParametersRegistry.InitializationData memory customInitData = defaultInitData;
+        customInitData.defaultRewardShare = 0;
+
+        vm.expectRevert(IParametersRegistry.InvalidRewardShareData.selector);
+        parametersRegistry.initialize(admin, customInitData);
+    }
+
     function test_initialize_RevertWhen_InvalidDefaultPerformanceLeeway() public {
         _enableInitializers(address(parametersRegistry));
 
@@ -303,6 +313,12 @@ contract ParametersRegistryRewardShareDataTest is ParametersRegistryBaseTestInit
         parametersRegistry.setDefaultRewardShare(rewardShare);
     }
 
+    function test_setDefault_RevertWhen_ZeroRewardShare() public {
+        vm.expectRevert(IParametersRegistry.InvalidRewardShareData.selector);
+        vm.prank(admin);
+        parametersRegistry.setDefaultRewardShare(0);
+    }
+
     function test_setDefault_RevertWhen_noRole() public override {
         uint256 rewardShare = 70001;
 
@@ -382,6 +398,17 @@ contract ParametersRegistryRewardShareDataTest is ParametersRegistryBaseTestInit
         uint256 curveId = 1;
         IParametersRegistry.KeyNumberValueInterval[] memory data = new IParametersRegistry.KeyNumberValueInterval[](2);
         data[0] = IParametersRegistry.KeyNumberValueInterval(1, 100000);
+        data[1] = IParametersRegistry.KeyNumberValueInterval(10, 8000);
+
+        vm.expectRevert(IParametersRegistry.InvalidKeyNumberValueIntervals.selector);
+        vm.prank(admin);
+        parametersRegistry.setRewardShareData(curveId, data);
+    }
+
+    function test_set_RevertWhen_zeroFirstIntervalValue() public {
+        uint256 curveId = 1;
+        IParametersRegistry.KeyNumberValueInterval[] memory data = new IParametersRegistry.KeyNumberValueInterval[](2);
+        data[0] = IParametersRegistry.KeyNumberValueInterval(1, 0);
         data[1] = IParametersRegistry.KeyNumberValueInterval(10, 8000);
 
         vm.expectRevert(IParametersRegistry.InvalidKeyNumberValueIntervals.selector);


### PR DESCRIPTION
## Description

Address audit findings from the security review:

- **INIT-8-01**: Move `initialize` to `IMerkleGate` interface and bind typed params in `MerkleGateFactory.create`, preventing non-initializing gate deployments
- **INIT-10-01**: Use dummy-impl-under-proxy pattern for `ValidatorStrikes` deployment to make `upgradeToAndCall` atomic, eliminating the uninitialized proxy window
- **QUEUE-1-02**: Remove `QUEUE_LOWEST_PRIORITY` immutable from `CSModule`, delegate to `ParametersRegistry` to prevent silent drift on proxy upgrades
- **BOND-1-02**: Thread `bool charged` return from `BondCore._charge` through `Accounting.chargeFee` so `KeyRemovalChargeApplied` is only emitted when shares are actually transferred
- **TRUST-1-02**: Add `curveId` to `MerkleGateCreated` event for provenance; drop `implementation` (immutable on factory) from the event
- **ORAPARAM-1-01**: Enforce non-zero first reward-share interval in `ParametersRegistry` to prevent rebate-only oracle reports from reverting `FeeDistributor`
- **KEYS-2-01**: Make `decreaseVettedSigningKeysCount` idempotent for stale entries — skip instead of revert when reported value equals current `totalVettedKeys`

Also includes minor cleanups: rename `_normalizeAmount` → `_quantizeAmount`, fix solhint ordering warnings.

## Checklist

- [x] Appropriate PR labels applied
- [x] Test coverage maintained (`just coverage`)
  - [ ] No need to add/update tests
  - [x] Tests are added/updated
- [x] Documentation maintained
  - [x] No need to update
  - [ ] Updated
