### PR TITLE
docs: natspec cleanup across contracts and interfaces

### DIFF
--- a/src/FeeOracle.sol
+++ b/src/FeeOracle.sol
@@ -15,7 +15,7 @@ import { IFeeOracle } from "./interfaces/IFeeOracle.sol";
 contract FeeOracle is IFeeOracle, BaseOracle, PausableWithRoles, AssetRecoverer {
     uint256 internal constant INITIALIZED_VERSION = 3;
 
-    /// @notice No assets are stored in the contract
+    /// @dev No assets are stored in the contract
 
     /// @notice An ACL role granting the permission to submit the data for a committee report.
     bytes32 public constant SUBMIT_DATA_ROLE = keccak256("SUBMIT_DATA_ROLE");

--- a/src/ParametersRegistry.sol
+++ b/src/ParametersRegistry.sol
@@ -51,12 +51,12 @@ contract ParametersRegistry is IParametersRegistry, Initializable, AccessControl
     QueueConfig public defaultQueueConfig;
     mapping(uint256 curveId => QueueConfig) internal _queueConfigs;
 
-    /// @dev Default value for the reward share. Can be only be set as a flat value due to possible sybil attacks
+    /// @dev Default value for the reward share. Can only be set as a flat value due to possible sybil attacks
     ///      Decreased reward share for some validators > N will promote sybils. Increased reward share for validators > N will give large operators an advantage
     uint256 public defaultRewardShare;
     mapping(uint256 curveId => KeyNumberValueInterval[]) internal _rewardShareData;
 
-    /// @dev Default value for the performance leeway. Can be only be set as a flat value due to possible sybil attacks
+    /// @dev Default value for the performance leeway. Can only be set as a flat value due to possible sybil attacks
     ///      Decreased performance leeway for some validators > N will promote sybils. Increased performance leeway for validators > N will give large operators an advantage
     uint256 public defaultPerformanceLeeway;
     mapping(uint256 curveId => KeyNumberValueInterval[]) internal _performanceLeewayData;
@@ -211,7 +211,6 @@ contract ParametersRegistry is IParametersRegistry, Initializable, AccessControl
         _setDefaultMaxElWithdrawalRequestFee(fee);
     }
 
-    /// @inheritdoc IParametersRegistry
     ////////////////////////////////////////////////////////////////////////////////
     // Setters for per-curve parameters
     ////////////////////////////////////////////////////////////////////////////////

--- a/src/abstract/AssetRecoverer.sol
+++ b/src/abstract/AssetRecoverer.sol
@@ -12,8 +12,8 @@ import { AssetRecovererLib } from "../lib/AssetRecovererLib.sol";
 abstract contract AssetRecoverer {
     bytes32 public constant RECOVERER_ROLE = keccak256("RECOVERER_ROLE");
 
-    /// @dev Allows sender to recover Ether held by the contract
-    /// Emits an EtherRecovered event upon success
+    /// @dev Allows sender to recover Ether held by the contract.
+    ///      Emits an EtherRecovered event upon success
     function recoverEther() external {
         _onlyRecoverer();
         AssetRecovererLib.recoverEther();
@@ -22,8 +22,8 @@ abstract contract AssetRecoverer {
     /// @dev Allows sender to recover ERC20 tokens held by the contract
     /// @param token The address of the ERC20 token to recover
     /// @param amount The amount of the ERC20 token to recover
-    /// Emits an ERC20Recovered event upon success
-    /// Optionally, the inheriting contract can override this function to add additional restrictions
+    /// @dev Emits an ERC20Recovered event upon success.
+    ///      Optionally, the inheriting contract can override this function to add additional restrictions
     function recoverERC20(address token, uint256 amount) external virtual {
         _onlyRecoverer();
         AssetRecovererLib.recoverERC20(token, amount);
@@ -32,7 +32,7 @@ abstract contract AssetRecoverer {
     /// @dev Allows sender to recover ERC721 tokens held by the contract
     /// @param token The address of the ERC721 token to recover
     /// @param tokenId The token ID of the ERC721 token to recover
-    /// Emits an ERC721Recovered event upon success
+    /// @dev Emits an ERC721Recovered event upon success
     function recoverERC721(address token, uint256 tokenId) external {
         _onlyRecoverer();
         AssetRecovererLib.recoverERC721(token, tokenId);
@@ -41,7 +41,7 @@ abstract contract AssetRecoverer {
     /// @dev Allows sender to recover ERC1155 tokens held by the contract.
     /// @param token The address of the ERC1155 token to recover.
     /// @param tokenId The token ID of the ERC1155 token to recover.
-    /// Emits an ERC1155Recovered event upon success.
+    /// @dev Emits an ERC1155Recovered event upon success.
     function recoverERC1155(address token, uint256 tokenId) external {
         _onlyRecoverer();
         AssetRecovererLib.recoverERC1155(token, tokenId);

--- a/src/abstract/BaseModule.sol
+++ b/src/abstract/BaseModule.sol
@@ -346,6 +346,7 @@ abstract contract BaseModule is
         });
     }
 
+    /// @inheritdoc IBaseModule
     function reportSlashedWithdrawnValidators(WithdrawnValidatorInfo[] calldata validatorInfos) external {
         _checkRole(REPORT_SLASHED_WITHDRAWN_VALIDATORS_ROLE);
         _reportWithdrawnValidators(validatorInfos, true);

--- a/src/abstract/BondCore.sol
+++ b/src/abstract/BondCore.sol
@@ -178,6 +178,7 @@ abstract contract BondCore is IBondCore {
 
     /// @dev Burn Node Operator's bond shares (stETH). Shares will be burned on the next stETH rebase
     /// @dev The contract that uses this implementation should be granted `Burner.REQUEST_BURN_MY_STETH_ROLE` and have stETH allowance for `Burner`
+    /// @param nodeOperatorId ID of the Node Operator
     /// @param amount Bond amount to burn in ETH (stETH)
     /// @return notBurnedAmount Amount in ETH that was not burned due to insufficient bond shares
     function _burn(uint256 nodeOperatorId, uint256 amount) internal returns (uint256 notBurnedAmount) {
@@ -186,6 +187,7 @@ abstract contract BondCore is IBondCore {
     }
 
     /// @dev Transfer Node Operator's bond shares (stETH) to charge recipient
+    /// @param nodeOperatorId ID of the Node Operator
     /// @param amount Bond amount to charge in ETH (stETH)
     /// @param recipient Address to send charged shares
     /// @return charged Whether any shares were actually transferred

--- a/src/abstract/BondCurve.sol
+++ b/src/abstract/BondCurve.sol
@@ -43,7 +43,7 @@ abstract contract BondCurve is IBondCurve, Initializable {
 
     uint256 public constant DEFAULT_BOND_CURVE_ID = 0;
 
-    // @inheritdoc IBondCurve
+    /// @inheritdoc IBondCurve
     function getCurvesCount() external view returns (uint256) {
         return _getBondCurveStorage().bondCurves.length;
     }

--- a/src/abstract/BondLock.sol
+++ b/src/abstract/BondLock.sol
@@ -112,7 +112,7 @@ abstract contract BondLock is IBondLock, Initializable {
         _setBondLockPeriod(period);
     }
 
-    /// @dev Set default bond lock period. That period will be added to the block timestamp of the lock translation to determine the bond lock duration
+    /// @dev Set default bond lock period. That period will be added to the block timestamp of the lock transition to determine the bond lock duration
     function _setBondLockPeriod(uint256 period) internal {
         if (period < MIN_BOND_LOCK_PERIOD || period > MAX_BOND_LOCK_PERIOD) revert InvalidBondLockPeriod();
         uint256 currentPeriod = _getBondLockStorage().bondLockPeriod;

--- a/src/interfaces/IAccounting.sol
+++ b/src/interfaces/IAccounting.sol
@@ -108,7 +108,7 @@ interface IAccounting is IBondCore, IBondCurve, IBondLock, IFeeSplits, IAssetRec
     /// @return Required bond amount in ETH
     function getRequiredBondForNextKeys(uint256 nodeOperatorId, uint256 additionalKeys) external view returns (uint256);
 
-    /// @notice Get the bond amount in wstETH required for the `keysCount` keys using the default bond curve
+    /// @notice Get the bond amount in wstETH required for the `keysCount` keys for the given bond curve
     /// @param keysCount Keys count to calculate the required bond amount
     /// @param curveId Id of the curve to perform calculations against
     /// @return wstETH amount required for the `keysCount`
@@ -130,7 +130,7 @@ interface IAccounting is IBondCore, IBondCurve, IBondLock, IFeeSplits, IAssetRec
 
     /// @notice Get the number of the unbonded keys to be ejected using a forcedTargetLimit
     ///         Locked bond is not considered for this calculation to allow Node Operators to
-    ///         compensate the locked bond via `compensateLockedBondETH` method before the ejection happens
+    ///         compensate the locked bond via `compensateLockedBond` method before the ejection happens
     /// @param nodeOperatorId ID of the Node Operator
     /// @return Unbonded keys count
     function getUnbondedKeysCountToEject(uint256 nodeOperatorId) external view returns (uint256);
@@ -255,7 +255,7 @@ interface IAccounting is IBondCore, IBondCurve, IBondLock, IFeeSplits, IAssetRec
     ///         `rewardsProof` and `cumulativeFeeShares` might be empty in order to claim only excess bond
     /// @dev Reverts if amount isn't between `MIN_STETH_WITHDRAWAL_AMOUNT` and `MAX_STETH_WITHDRAWAL_AMOUNT`
     /// @param nodeOperatorId ID of the Node Operator
-    /// @param stETHAmount Amount of ETH to request
+    /// @param stETHAmount Amount of stETH to request
     /// @param cumulativeFeeShares Cumulative fee stETH shares for the Node Operator
     /// @param rewardsProof Merkle proof of the rewards
     /// @return requestId Withdrawal NFT ID

--- a/src/interfaces/IBaseModule.sol
+++ b/src/interfaces/IBaseModule.sol
@@ -223,7 +223,7 @@ interface IBaseModule is IStakingModule, IAccessControlEnumerable, INOAddresses,
     ) external;
 
     /// @notice Report general delayed penalty for the given Node Operator
-    /// @notice The final locked amount will be equal to the penalty amount plus additional fine
+    /// @notice Increases locked bond by `amount + additionalFine` for this report
     /// @param nodeOperatorId ID of the Node Operator
     /// @param penaltyType Type of the penalty
     /// @param amount Penalty amount in ETH
@@ -246,7 +246,7 @@ interface IBaseModule is IStakingModule, IAccessControlEnumerable, INOAddresses,
     /// @param amount Amount of penalty to cancel
     function cancelGeneralDelayedPenalty(uint256 nodeOperatorId, uint256 amount) external;
 
-    /// @notice Settles locked bond and sets the target limit to 0 or the given Node Operators
+    /// @notice Settles locked bond for eligible Node Operators and sets target limit to 0 only for settled ones
     /// @dev SETTLE_GENERAL_DELAYED_PENALTY_ROLE role is expected to be assigned to Easy Track
     /// @param nodeOperatorIds IDs of the Node Operators
     /// @param maxAmounts Maximum amounts to settle for each Node Operator
@@ -282,8 +282,7 @@ interface IBaseModule is IStakingModule, IAccessControlEnumerable, INOAddresses,
     /// @param newAddress Proposed reward address
     function changeNodeOperatorRewardAddress(uint256 nodeOperatorId, address newAddress) external;
 
-    /// @notice Update depositable validators data and enqueue all unqueued keys for the given Node Operator.
-    ///         Unqueued stands for vetted but not enqueued keys.
+    /// @notice Update depositable validators data for the given Node Operator.
     /// @dev The following rules are applied:
     ///         - Unbonded keys can not be depositable
     ///         - Unvetted keys can not be depositable
@@ -384,12 +383,12 @@ interface IBaseModule is IStakingModule, IAccessControlEnumerable, INOAddresses,
     ///         - if it's a consolidated validator, when the corresponding pending consolidation is processed and the
     ///           balance of the validator has been moved to another validator.
     /// @notice Called by `Verifier` contract.
-    /// @param validatorInfos An array WithdrawnValidatorInfo structs
+    /// @param validatorInfos An array of WithdrawnValidatorInfo structs
     function reportRegularWithdrawnValidators(WithdrawnValidatorInfo[] calldata validatorInfos) external;
 
     /// @notice Report withdrawn validators that have been slashed.
     /// @notice Called by the Easy Track EVM script executor via a motion started by the dedicated committee.
-    /// @param validatorInfos An array WithdrawnValidatorInfo structs
+    /// @param validatorInfos An array of WithdrawnValidatorInfo structs
     function reportSlashedWithdrawnValidators(WithdrawnValidatorInfo[] calldata validatorInfos) external;
 
     /// @notice Checks if a validator was reported as slashed

--- a/src/interfaces/IBondCurve.sol
+++ b/src/interfaces/IBondCurve.sol
@@ -90,7 +90,7 @@ interface IBondCurve {
     /// @return Bond curve ID
     function getBondCurveId(uint256 nodeOperatorId) external view returns (uint256);
 
-    /// @notice Get required bond in ETH for the given number of keys for default bond curve
+    /// @notice Get required bond in ETH for the given number of keys for the given bond curve
     /// @dev To calculate the amount for the new keys 2 calls are required:
     ///      getBondAmountByKeysCount(newTotal) - getBondAmountByKeysCount(currentTotal)
     /// @param keys Number of keys to get required bond for
@@ -98,8 +98,8 @@ interface IBondCurve {
     /// @return Amount for particular keys count
     function getBondAmountByKeysCount(uint256 keys, uint256 curveId) external view returns (uint256);
 
-    /// @notice Get keys count for the given bond amount with default bond curve
-    /// @param amount Bond amount in ETH (stETH)to get keys count for
+    /// @notice Get keys count for the given bond amount with the given bond curve
+    /// @param amount Bond amount in ETH (stETH) to get keys count for
     /// @param curveId Id of the curve to perform calculations against
     /// @return Keys count
     function getKeysCountByBondAmount(uint256 amount, uint256 curveId) external view returns (uint256);

--- a/src/interfaces/ICSModule.sol
+++ b/src/interfaces/ICSModule.sol
@@ -42,7 +42,7 @@ interface ICSModule is IBaseModule, IStakingModuleV2, IDepositQueueLib, ITopUpQu
     /// @param limit How many items may sit in the top-up queue at most.
     function setTopUpQueueLimit(uint256 limit) external;
 
-    /// @notice Rewind the top-up queue to able to deposit to mistakenly skipped items.
+    /// @notice Rewind the top-up queue to be able to deposit to mistakenly skipped items.
     /// @param to Pointer to move the queue `head` to.
     function rewindTopUpQueue(uint256 to) external;
 

--- a/src/interfaces/IEjector.sol
+++ b/src/interfaces/IEjector.sol
@@ -32,8 +32,8 @@ interface IEjector is IExitTypes {
 
     function STRIKES() external view returns (address);
 
-    /// @notice Withdraw the validator key from the Node Operator
-    /// @notice Called by the node operator
+    /// @notice Request triggerable full withdrawals for Node Operator validator keys
+    /// @dev Called by the node operator
     /// @param nodeOperatorId ID of the Node Operator
     /// @param keyIndices Array of indices of the keys to withdraw
     /// @param refundRecipient Address to send the refund to
@@ -44,7 +44,7 @@ interface IEjector is IExitTypes {
     ) external payable;
 
     /// @notice Eject Node Operator's key as a bad performer
-    /// @notice Called by the `ValidatorStrikes` contract.
+    /// @dev Called by the `ValidatorStrikes` contract.
     ///         See `ValidatorStrikes.processBadPerformanceProof` to use this method permissionless
     /// @param nodeOperatorId ID of the Node Operator
     /// @param keyIndex index of deposited key to eject

--- a/src/interfaces/IExitPenalties.sol
+++ b/src/interfaces/IExitPenalties.sol
@@ -60,7 +60,7 @@ interface IExitPenalties is IExitTypes {
     /// @param nodeOperatorId ID of the Node Operator
     /// @param publicKey Public key of the validator
     /// @param elWithdrawalRequestFeePaid The fee paid for the withdrawal request
-    /// @param exitType The type of the exit (0 - direct exit, 1 - forced exit)
+    /// @param exitType The type of the exit; only `VOLUNTARY_EXIT_TYPE_ID` skips recording EL withdrawal request fee
     function processTriggeredExit(
         uint256 nodeOperatorId,
         bytes calldata publicKey,

--- a/src/interfaces/IFeeOracle.sol
+++ b/src/interfaces/IFeeOracle.sol
@@ -46,6 +46,6 @@ interface IFeeOracle is IAssetRecovererLib {
 
     /// @notice Submit the data for a committee report
     /// @param data Data for a committee report
-    /// @param contractVersion Version of the oracle consensus rules
+    /// @param contractVersion Expected storage contract version of the FeeOracle implementation
     function submitReportData(ReportData calldata data, uint256 contractVersion) external;
 }

--- a/src/interfaces/IParametersRegistry.sol
+++ b/src/interfaces/IParametersRegistry.sol
@@ -221,7 +221,7 @@ interface IParametersRegistry {
         uint256 syncWeight
     ) external;
 
-    /// @notice set default value for allowed delay before the exit was initiated exit delay in seconds. Default value is used if a specific value is not set for the curveId
+    /// @notice set default value for the allowed exit delay in seconds. Default value is used if a specific value is not set for the curveId
     /// @param delay value to be set as default for the allowed exit delay
     function setDefaultAllowedExitDelay(uint256 delay) external;
 
@@ -269,8 +269,8 @@ interface IParametersRegistry {
     /// @param limit Keys limit
     function setKeysLimit(uint256 curveId, uint256 limit) external;
 
-    /// @notice Unset key removal charge for the curveId
-    /// @param curveId Curve Id to unset custom key removal charge for
+    /// @notice Unset keys limit for the curveId
+    /// @param curveId Curve Id to unset custom keys limit for
     function unsetKeysLimit(uint256 curveId) external;
 
     /// @notice Get keys limit by the curveId. A limit indicates the maximal amount of the non-exited keys Node Operator can upload
@@ -294,9 +294,9 @@ interface IParametersRegistry {
     /// @notice Get the queue config for the given curve. This parameter is not used in Curated Module
     /// @param curveId Curve Id to get the queue config for.
     /// @return priority Queue priority.
-    /// @param maxDeposits Maximum number of the first deposits a Node Operator can get via the priority queue.
-    ///                    Ex. with `maxDeposits = 10` the Node Operator сan get keys added to the priority queue
-    ///                    until the Node Operator has totalDepositedKeys + enqueued >= 10.
+    /// @return maxDeposits Maximum number of the first deposits a Node Operator can get via the priority queue.
+    ///                     Ex. with `maxDeposits = 10` the Node Operator сan get keys added to the priority queue
+    ///                     until the Node Operator has totalDepositedKeys + enqueued >= 10.
     function getQueueConfig(uint256 curveId) external view returns (uint32 priority, uint32 maxDeposits);
 
     /// @notice Set reward share parameters for the curveId
@@ -315,11 +315,10 @@ interface IParametersRegistry {
     /// @dev KeyNumberValueInterval = [[1, 10000], [11, 8000], [51, 5000]] stands for
     ///      100% rewards for the first 10 keys, 80% rewards for the keys 11-50, and 50% rewards for the keys > 50
     /// @param curveId Curve Id to get reward share data for
-    /// @param data Interval values for keys count and reward share percentages in BP (ex. [[1, 10000], [11, 8000], [51, 5000]])
+    /// @return data Interval values for keys count and reward share percentages in BP (ex. [[1, 10000], [11, 8000], [51, 5000]])
     function getRewardShareData(uint256 curveId) external view returns (KeyNumberValueInterval[] memory data);
 
     /// @notice Set performance leeway parameters for the curveId
-    /// @dev Returns [[1, defaultPerformanceLeeway]] if no intervals are set for the given curveId.
     /// @dev KeyNumberValueInterval = [[1, 500], [101, 450], [501, 400]] stands for
     ///      5% performance leeway for the first 100 keys, 4.5% performance leeway for the keys 101-500, and 4% performance leeway for the keys > 500
     /// @param curveId Curve Id to associate performance leeway data with
@@ -335,7 +334,7 @@ interface IParametersRegistry {
     /// @dev KeyNumberValueInterval = [[1, 500], [101, 450], [501, 400]] stands for
     ///      5% performance leeway for the first 100 keys, 4.5% performance leeway for the keys 101-500, and 4% performance leeway for the keys > 500
     /// @param curveId Curve Id to get performance leeway data for
-    /// @param data Interval values for keys count and performance leeway percentages in BP (ex. [[1, 500], [101, 450], [501, 400]])
+    /// @return data Interval values for keys count and performance leeway percentages in BP (ex. [[1, 500], [101, 450], [501, 400]])
     function getPerformanceLeewayData(uint256 curveId) external view returns (KeyNumberValueInterval[] memory data);
 
     /// @notice Set performance strikes lifetime and threshold for the curveId
@@ -401,7 +400,7 @@ interface IParametersRegistry {
     /// @param delay allowed exit delay
     function setAllowedExitDelay(uint256 curveId, uint256 delay) external;
 
-    /// @notice Unset exit timeframe deadline delay for the curveId
+    /// @notice Unset allowed exit delay for the curveId
     /// @param curveId Curve Id to unset allowed exit delay for
     function unsetAllowedExitDelay(uint256 curveId) external;
 
@@ -411,7 +410,6 @@ interface IParametersRegistry {
     function getAllowedExitDelay(uint256 curveId) external view returns (uint256 delay);
 
     /// @notice Set the exit delay penalty for a single 32 ether validator for the given curveId
-    /// @dev cannot be zero
     /// @param curveId Curve Id to associate exit delay penalty with
     /// @param fee Exit delay fee
     function setExitDelayFee(uint256 curveId, uint256 fee) external;

--- a/src/interfaces/IValidatorStrikes.sol
+++ b/src/interfaces/IValidatorStrikes.sol
@@ -78,6 +78,7 @@ interface IValidatorStrikes {
 
     /// @notice Check the contract accepts the provided multi-proof
     /// @param keyStrikesList List of KeyStrikes structs
+    /// @param pubkeys Public keys corresponding to each entry in keyStrikesList
     /// @param proof Multi-proof of the strikes
     /// @param proofFlags Flags to process the multi-proof, see OZ `processMultiProof`
     /// @return bool True if proof is accepted
@@ -88,7 +89,7 @@ interface IValidatorStrikes {
         bool[] calldata proofFlags
     ) external view returns (bool);
 
-    /// @notice Get a hash of a leaf a tree of strikes
+    /// @notice Get a hash of a leaf in a tree of strikes
     /// @param keyStrikes KeyStrikes struct
     /// @param pubkey Public key
     /// @return Hash of the leaf

--- a/src/lib/SSZ.sol
+++ b/src/lib/SSZ.sol
@@ -55,7 +55,7 @@ library SSZ {
                     )
 
                     if iszero(result) {
-                        // Precompiles returns no data on OutOfGas error.
+                        // Precompile returns no data on OutOfGas error.
                         revert(0, 0)
                     }
 
@@ -95,7 +95,7 @@ library SSZ {
             let result := staticcall(gas(), 0x02, 0x00, 0x40, 0x00, 0x20)
 
             if iszero(result) {
-                // Precompiles returns no data on OutOfGas error.
+                // Precompile returns no data on OutOfGas error.
                 revert(0, 0)
             }
 
@@ -143,7 +143,7 @@ library SSZ {
                     )
 
                     if iszero(result) {
-                        // Precompiles returns no data on OutOfGas error.
+                        // Precompile returns no data on OutOfGas error.
                         revert(0, 0)
                     }
 

--- a/src/lib/WithdrawnValidatorLib.sol
+++ b/src/lib/WithdrawnValidatorLib.sol
@@ -11,7 +11,7 @@ import { IAccounting } from "../interfaces/IAccounting.sol";
 
 import { SigningKeys } from "./SigningKeys.sol";
 
-/// @dev A library to extract a part of the code from the the CSModule contract.
+/// @dev A library to extract a part of the code from the CSModule contract.
 library WithdrawnValidatorLib {
     uint256 public constant MAX_EFFECTIVE_BALANCE = 2048 ether;
     uint256 public constant MIN_ACTIVATION_BALANCE = 32 ether;

--- a/src/lib/base-oracle/HashConsensus.sol
+++ b/src/lib/base-oracle/HashConsensus.sol
@@ -82,7 +82,7 @@ contract HashConsensus is IConsensusContract, AccessControlEnumerableUpgradeable
 
     /// @notice An ACL role granting the permission to disable the consensus by calling
     /// the disableConsensus function. Enabling the consensus back requires the possession
-    /// of the MANAGE_QUORUM_ROLE.
+    /// of the MANAGE_MEMBERS_AND_QUORUM_ROLE.
     bytes32 public constant DISABLE_CONSENSUS_ROLE = keccak256("DISABLE_CONSENSUS_ROLE");
 
     /// @notice An ACL role granting the permission to change reporting interval duration

--- a/src/lib/base-oracle/interfaces/IReportAsyncProcessor.sol
+++ b/src/lib/base-oracle/interfaces/IReportAsyncProcessor.sol
@@ -55,7 +55,7 @@ interface IReportAsyncProcessor {
     /// Consensus version must change every time consensus rules change, meaning that
     /// an oracle looking at the same reference slot would calculate a different hash.
     ///
-    /// HashConsensus won't accept member reports any consensus version different form the
+    /// HashConsensus won't accept member reports any consensus version different from the
     /// one returned from this function.
     ///
     function getConsensusVersion() external view returns (uint256);

--- a/src/lib/utils/PausableUntil.sol
+++ b/src/lib/utils/PausableUntil.sol
@@ -35,9 +35,9 @@ contract PausableUntil {
     }
 
     /// @notice Returns one of:
-    ///  - PAUSE_INFINITELY if paused infinitely returns
-    ///  - first second when get contract get resumed if paused for specific duration
-    ///  - some timestamp in past if not paused
+    ///  - PAUSE_INFINITELY if paused infinitely
+    ///  - first second when the contract gets resumed if paused for a specific duration
+    ///  - some timestamp in the past if not paused
     function getResumeSinceTimestamp() external view returns (uint256) {
         return RESUME_SINCE_TIMESTAMP_POSITION.getStorageUint256();
     }


### PR DESCRIPTION
## Description

- Fix and clarify NatSpec across contracts, interfaces, and libraries to match current behavior.
- Correct `@notice`/`@dev` usage, parameter and return annotations, and several wording/grammar issues.
- Add missing docs tags such as `@inheritdoc` and missing parameter descriptions where required.
- This PR is comment-only and does not change runtime logic.

## Checklist

- [x] Appropriate PR labels applied
- [x] Test coverage maintained (`just coverage`)
  - [x] No need to add/update tests
  - [ ] Tests are added/updated
- [x] Documentation maintained
  - [ ] No need to update
  - [x] Updated
