### PR TITLE
feat: Rework bond lock from automatic unlock to manual unlock

### DIFF
--- a/script/fork-helpers/NodeOperators.s.sol
+++ b/script/fork-helpers/NodeOperators.s.sol
@@ -173,11 +173,11 @@ contract NodeOperators is Script, DeploymentFixtures, ForkHelpersCommon, Utiliti
     }
 
     function reportGeneralDelayedPenalty(uint256 noId, uint256 amount) external broadcastPenaltyReporter {
-        uint256 lockedBefore = accounting.getActualLockedBond(noId);
+        uint256 lockedBefore = accounting.getLockedBond(noId);
 
         module.reportGeneralDelayedPenalty(noId, bytes32(abi.encode(1)), amount, "Test penalty");
 
-        uint256 lockedAfter = accounting.getActualLockedBond(noId);
+        uint256 lockedAfter = accounting.getLockedBond(noId);
         assertEq(
             lockedAfter,
             lockedBefore +
@@ -187,11 +187,11 @@ contract NodeOperators is Script, DeploymentFixtures, ForkHelpersCommon, Utiliti
     }
 
     function cancelGeneralDelayedPenalty(uint256 noId, uint256 amount) external broadcastPenaltyReporter {
-        uint256 lockedBefore = accounting.getActualLockedBond(noId);
+        uint256 lockedBefore = accounting.getLockedBond(noId);
 
         module.cancelGeneralDelayedPenalty(noId, amount);
 
-        uint256 lockedAfter = accounting.getActualLockedBond(noId);
+        uint256 lockedAfter = accounting.getLockedBond(noId);
         assertEq(lockedAfter, lockedBefore - amount);
     }
 
@@ -202,7 +202,7 @@ contract NodeOperators is Script, DeploymentFixtures, ForkHelpersCommon, Utiliti
         maxAmounts[0] = type(uint256).max; // Set to max to settle
         module.settleGeneralDelayedPenalty(noIds, maxAmounts);
 
-        assertEq(accounting.getActualLockedBond(noId), 0);
+        assertEq(accounting.getLockedBond(noId), 0);
     }
 
     function compensateGeneralDelayedPenalty(uint256 noId) external broadcastStranger {

--- a/src/Accounting.sol
+++ b/src/Accounting.sol
@@ -269,8 +269,19 @@ contract Accounting is
     }
 
     /// @inheritdoc IAccounting
+    function unlockExpiredLock(uint256 nodeOperatorId) public {
+        BondLock._unlockExpiredLock(nodeOperatorId);
+        MODULE.updateDepositableValidatorsCount(nodeOperatorId);
+    }
+
+    /// @inheritdoc IAccounting
     function compensateLockedBond(uint256 nodeOperatorId) external onlyModule returns (uint256 compensatedAmount) {
-        uint256 lockedAmount = BondLock.getActualLockedBond(nodeOperatorId);
+        uint256 lockedAmount = BondLock.getLockedBond(nodeOperatorId);
+        if (BondLock.isLockExpired(nodeOperatorId) && lockedAmount != 0) {
+            unlockExpiredLock(nodeOperatorId);
+            return 0;
+        }
+
         if (lockedAmount == 0) return 0;
 
         (uint256 currentBond, uint256 requiredBond) = getBondSummary(nodeOperatorId);
@@ -290,7 +301,11 @@ contract Accounting is
         uint256 nodeOperatorId,
         uint256 maxAmount
     ) external onlyModule returns (uint256 amountSettled) {
-        uint256 lockedAmount = BondLock.getActualLockedBond(nodeOperatorId);
+        uint256 lockedAmount = BondLock.getLockedBond(nodeOperatorId);
+        if (BondLock.isLockExpired(nodeOperatorId) && lockedAmount != 0) {
+            unlockExpiredLock(nodeOperatorId);
+            return 0;
+        }
         amountSettled = lockedAmount < maxAmount ? lockedAmount : maxAmount;
         if (lockedAmount > 0) {
             BondCore._burn(nodeOperatorId, amountSettled);
@@ -491,10 +506,10 @@ contract Accounting is
         uint256 curveId = BondCurve.getBondCurveId(nodeOperatorId);
         uint256 nonWithdrawnKeys = MODULE.getNodeOperatorNonWithdrawnKeys(nodeOperatorId);
         uint256 requiredBondForKeys = BondCurve.getBondAmountByKeysCount(nonWithdrawnKeys + additionalKeys, curveId);
-        uint256 actualLockedBond = BondLock.getActualLockedBond(nodeOperatorId);
+        uint256 lockedBond = BondLock.getLockedBond(nodeOperatorId);
         uint256 bondDebt = BondCore.getBondDebt(nodeOperatorId);
 
-        return requiredBondForKeys + actualLockedBond + bondDebt;
+        return requiredBondForKeys + lockedBond + bondDebt;
     }
 
     function _getRequiredBondShares(uint256 nodeOperatorId, uint256 additionalKeys) internal view returns (uint256) {
@@ -513,7 +528,7 @@ contract Accounting is
 
         // Optionally account for locked bond depending on the flag
         if (includeLockedBond) {
-            uint256 lockedBond = BondLock.getActualLockedBond(nodeOperatorId);
+            uint256 lockedBond = BondLock.getLockedBond(nodeOperatorId);
             // We use strict condition here since in rare case of equality the outcome of the function will not change
             if (lockedBond > currentBond) return nonWithdrawnKeys;
             unchecked {

--- a/src/Accounting.sol
+++ b/src/Accounting.sol
@@ -264,8 +264,14 @@ contract Accounting is
     }
 
     /// @inheritdoc IAccounting
-    function releaseLockedBond(uint256 nodeOperatorId, uint256 amount) external onlyModule {
+    function releaseLockedBond(uint256 nodeOperatorId, uint256 amount) external onlyModule returns (bool) {
+        uint256 lockedAmount = BondLock.getLockedBond(nodeOperatorId);
+        if (BondLock.isLockExpired(nodeOperatorId) && lockedAmount != 0) {
+            unlockExpiredLock(nodeOperatorId);
+            return false;
+        }
         BondLock._unlock(nodeOperatorId, amount);
+        return true;
     }
 
     /// @inheritdoc IAccounting

--- a/src/Accounting.sol
+++ b/src/Accounting.sol
@@ -264,14 +264,16 @@ contract Accounting is
     }
 
     /// @inheritdoc IAccounting
-    function releaseLockedBond(uint256 nodeOperatorId, uint256 amount) external onlyModule returns (bool) {
+    function releaseLockedBond(uint256 nodeOperatorId, uint256 amount) external onlyModule returns (bool released) {
         uint256 lockedAmount = BondLock.getLockedBond(nodeOperatorId);
-        if (BondLock.isLockExpired(nodeOperatorId) && lockedAmount != 0) {
+        if (lockedAmount == 0) return released;
+
+        if (BondLock.isLockExpired(nodeOperatorId)) {
             unlockExpiredLock(nodeOperatorId);
-            return false;
+            return released;
         }
         BondLock._unlock(nodeOperatorId, amount);
-        return true;
+        released = true;
     }
 
     /// @inheritdoc IAccounting
@@ -283,17 +285,17 @@ contract Accounting is
     /// @inheritdoc IAccounting
     function compensateLockedBond(uint256 nodeOperatorId) external onlyModule returns (uint256 compensatedAmount) {
         uint256 lockedAmount = BondLock.getLockedBond(nodeOperatorId);
-        if (BondLock.isLockExpired(nodeOperatorId) && lockedAmount != 0) {
-            unlockExpiredLock(nodeOperatorId);
-            return 0;
-        }
+        if (lockedAmount == 0) return compensatedAmount;
 
-        if (lockedAmount == 0) return 0;
+        if (BondLock.isLockExpired(nodeOperatorId)) {
+            unlockExpiredLock(nodeOperatorId);
+            return compensatedAmount;
+        }
 
         (uint256 currentBond, uint256 requiredBond) = getBondSummary(nodeOperatorId);
         // `requiredBond` already includes `lockedAmount`
         uint256 requiredBondWithoutLock = requiredBond - lockedAmount;
-        if (currentBond <= requiredBondWithoutLock) return 0;
+        if (currentBond <= requiredBondWithoutLock) return compensatedAmount;
 
         uint256 maxCompensatableAmount = currentBond - requiredBondWithoutLock;
         compensatedAmount = lockedAmount < maxCompensatableAmount ? lockedAmount : maxCompensatableAmount;
@@ -308,12 +310,14 @@ contract Accounting is
         uint256 maxAmount
     ) external onlyModule returns (uint256 amountSettled) {
         uint256 lockedAmount = BondLock.getLockedBond(nodeOperatorId);
-        if (BondLock.isLockExpired(nodeOperatorId) && lockedAmount != 0) {
+        if (lockedAmount == 0) return amountSettled;
+
+        if (BondLock.isLockExpired(nodeOperatorId)) {
             unlockExpiredLock(nodeOperatorId);
-            return 0;
+            return amountSettled;
         }
         amountSettled = lockedAmount < maxAmount ? lockedAmount : maxAmount;
-        if (lockedAmount > 0) {
+        if (amountSettled > 0) {
             BondCore._burn(nodeOperatorId, amountSettled);
             // unlock all amountSettled even if bond isn't covered lock fully since debt will be created in this case
             BondLock._unlock(nodeOperatorId, amountSettled);

--- a/src/abstract/BondLock.sol
+++ b/src/abstract/BondLock.sol
@@ -66,9 +66,13 @@ abstract contract BondLock is IBondLock, Initializable {
     }
 
     /// @inheritdoc IBondLock
-    function getActualLockedBond(uint256 nodeOperatorId) public view returns (uint256) {
-        BondLockData storage bondLock = _getBondLockStorage().bondLock[nodeOperatorId];
-        return bondLock.until > block.timestamp ? bondLock.amount : 0;
+    function getLockedBond(uint256 nodeOperatorId) public view returns (uint256) {
+        return _getBondLockStorage().bondLock[nodeOperatorId].amount;
+    }
+
+    /// @inheritdoc IBondLock
+    function isLockExpired(uint256 nodeOperatorId) public view returns (bool) {
+        return _getBondLockStorage().bondLock[nodeOperatorId].until <= block.timestamp;
     }
 
     /// @dev Lock bond amount for the given Node Operator until the period.
@@ -87,7 +91,7 @@ abstract contract BondLock is IBondLock, Initializable {
     /// @dev Unlock the locked bond amount for the given Node Operator without changing the lock period
     function _unlock(uint256 nodeOperatorId, uint256 amount) internal {
         if (amount == 0) revert InvalidBondLockAmount();
-        uint256 locked = getActualLockedBond(nodeOperatorId);
+        uint256 locked = getLockedBond(nodeOperatorId);
         if (locked < amount) revert InvalidBondLockAmount();
         unchecked {
             _changeBondLock(nodeOperatorId, locked - amount, _getBondLockStorage().bondLock[nodeOperatorId].until);
@@ -105,6 +109,11 @@ abstract contract BondLock is IBondLock, Initializable {
             until: until.toUint128()
         });
         emit BondLockChanged(nodeOperatorId, amount, until);
+    }
+
+    function _unlockExpiredLock(uint256 nodeOperatorId) internal {
+        if (!isLockExpired(nodeOperatorId)) revert BondLockNotExpired();
+        _changeBondLock(nodeOperatorId, 0, 0);
     }
 
     // solhint-disable-next-line func-name-mixedcase

--- a/src/interfaces/IAccounting.sol
+++ b/src/interfaces/IAccounting.sol
@@ -278,7 +278,8 @@ interface IAccounting is IBondCore, IBondCurve, IBondLock, IFeeSplits, IAssetRec
     /// @dev Called by staking module exclusively
     /// @param nodeOperatorId ID of the Node Operator
     /// @param amount Amount to release in ETH (stETH)
-    function releaseLockedBond(uint256 nodeOperatorId, uint256 amount) external;
+    /// @return True if the bond was released, false if the lock was expired and bond was unlocked instead
+    function releaseLockedBond(uint256 nodeOperatorId, uint256 amount) external returns (bool);
 
     /// @notice Unlock expired locked bond for the given Node Operator
     /// @param nodeOperatorId ID of the Node Operator

--- a/src/interfaces/IAccounting.sol
+++ b/src/interfaces/IAccounting.sol
@@ -280,6 +280,10 @@ interface IAccounting is IBondCore, IBondCurve, IBondLock, IFeeSplits, IAssetRec
     /// @param amount Amount to release in ETH (stETH)
     function releaseLockedBond(uint256 nodeOperatorId, uint256 amount) external;
 
+    /// @notice Unlock expired locked bond for the given Node Operator
+    /// @param nodeOperatorId ID of the Node Operator
+    function unlockExpiredLock(uint256 nodeOperatorId) external;
+
     /// @notice Settle locked bond ETH for the given Node Operator
     /// @dev Called by staking module exclusively
     /// @param nodeOperatorId ID of the Node Operator

--- a/src/interfaces/IBaseModule.sol
+++ b/src/interfaces/IBaseModule.sol
@@ -123,7 +123,6 @@ interface IBaseModule is IStakingModule, IAccessControlEnumerable, INOAddresses,
     error ZeroParametersRegistryAddress();
     error ZeroModuleType();
     error ZeroPenaltyType();
-    error NothingCompensated();
     error DepositInfoIsNotUpToDate();
 
     function STAKING_ROUTER_ROLE() external view returns (bytes32);

--- a/src/interfaces/IBondLock.sol
+++ b/src/interfaces/IBondLock.sol
@@ -20,6 +20,7 @@ interface IBondLock {
 
     error InvalidBondLockPeriod();
     error InvalidBondLockAmount();
+    error BondLockNotExpired();
 
     function MIN_BOND_LOCK_PERIOD() external view returns (uint256);
 
@@ -37,5 +38,10 @@ interface IBondLock {
     /// @notice Get amount of the locked bond in ETH (stETH) by the given Node Operator
     /// @param nodeOperatorId ID of the Node Operator
     /// @return Amount of the actual locked bond
-    function getActualLockedBond(uint256 nodeOperatorId) external view returns (uint256);
+    function getLockedBond(uint256 nodeOperatorId) external view returns (uint256);
+
+    /// @notice Check if the bond lock for the given Node Operator has expired
+    /// @param nodeOperatorId ID of the Node Operator
+    /// @return True if the bond lock has expired or there is no lock, false otherwise
+    function isLockExpired(uint256 nodeOperatorId) external view returns (bool);
 }

--- a/src/lib/GeneralPenaltyLib.sol
+++ b/src/lib/GeneralPenaltyLib.sol
@@ -43,7 +43,7 @@ library GeneralPenalty {
         IBaseModule module = IBaseModule(address(this));
         IAccounting accounting = module.ACCOUNTING();
 
-        accounting.releaseLockedBond(nodeOperatorId, amount);
+        if (!accounting.releaseLockedBond(nodeOperatorId, amount)) return;
 
         emit IBaseModule.GeneralDelayedPenaltyCancelled(nodeOperatorId, amount);
 

--- a/src/lib/GeneralPenaltyLib.sol
+++ b/src/lib/GeneralPenaltyLib.sol
@@ -67,7 +67,7 @@ library GeneralPenalty {
 
         uint256 compensatedAmount = accounting.compensateLockedBond(nodeOperatorId);
 
-        if (compensatedAmount == 0) revert IBaseModule.NothingCompensated();
+        if (compensatedAmount == 0) return;
 
         emit IBaseModule.GeneralDelayedPenaltyCompensated(nodeOperatorId, compensatedAmount);
 

--- a/test/helpers/mocks/AccountingMock.sol
+++ b/test/helpers/mocks/AccountingMock.sol
@@ -101,10 +101,15 @@ contract AccountingMock {
         bondLock[nodeOperatorId].until = unlockAt;
     }
 
-    function releaseLockedBond(uint256 nodeOperatorId, uint256 amount) external {
+    function releaseLockedBond(uint256 nodeOperatorId, uint256 amount) external returns (bool) {
+        if (bondLock[nodeOperatorId].until <= block.timestamp) {
+            unlockExpiredLock(nodeOperatorId);
+            return false;
+        }
         // Bond lock amounts mirror production's uint128 slot, so truncation cannot happen.
         // forge-lint: disable-next-line(unsafe-typecast)
         bondLock[nodeOperatorId].amount -= uint128(amount);
+        return true;
     }
 
     function unlockExpiredLock(uint256 nodeOperatorId) public {

--- a/test/helpers/mocks/AccountingMock.sol
+++ b/test/helpers/mocks/AccountingMock.sol
@@ -19,6 +19,7 @@ contract AccountingMock {
 
     error BondLockAmountTooLarge();
     error BondLockUnlockTimeTooLarge();
+    error BondLockNotExpired();
 
     ILido public immutable LIDO;
 
@@ -106,8 +107,18 @@ contract AccountingMock {
         bondLock[nodeOperatorId].amount -= uint128(amount);
     }
 
+    function unlockExpiredLock(uint256 nodeOperatorId) public {
+        if (bondLock[nodeOperatorId].until > block.timestamp) revert BondLockNotExpired();
+        delete bondLock[nodeOperatorId];
+        MODULE.updateDepositableValidatorsCount(nodeOperatorId);
+    }
+
     function settleLockedBond(uint256 nodeOperatorId, uint256 maxAmount) external returns (uint256 settledAmount) {
-        uint256 lockedBond = getActualLockedBond(nodeOperatorId);
+        if (bondLock[nodeOperatorId].until <= block.timestamp) {
+            unlockExpiredLock(nodeOperatorId);
+            return 0;
+        }
+        uint256 lockedBond = getLockedBond(nodeOperatorId);
         settledAmount = Math.min(lockedBond, maxAmount);
         if (settledAmount > bond[nodeOperatorId]) {
             bond[nodeOperatorId] = 0;
@@ -124,7 +135,11 @@ contract AccountingMock {
     }
 
     function compensateLockedBond(uint256 nodeOperatorId) external returns (uint256 compensatedAmount) {
-        uint256 lockedAmount = getActualLockedBond(nodeOperatorId);
+        if (bondLock[nodeOperatorId].until <= block.timestamp) {
+            unlockExpiredLock(nodeOperatorId);
+            return 0;
+        }
+        uint256 lockedAmount = getLockedBond(nodeOperatorId);
         if (lockedAmount == 0) return 0;
 
         (uint256 currentBond, uint256 requiredBond) = getBondSummary(nodeOperatorId);
@@ -195,7 +210,7 @@ contract AccountingMock {
             getBondAmountByKeysCount(
                 MODULE.getNodeOperatorNonWithdrawnKeys(nodeOperatorId),
                 operatorBondCurveId[nodeOperatorId]
-            ) + getActualLockedBond(nodeOperatorId)
+            ) + getLockedBond(nodeOperatorId)
         );
     }
 
@@ -205,7 +220,7 @@ contract AccountingMock {
             MODULE.getNodeOperatorNonWithdrawnKeys(nodeOperatorId) + additionalKeys,
             operatorBondCurveId[nodeOperatorId]
         );
-        uint256 totalRequired = requiredForNewTotalKeys + getActualLockedBond(nodeOperatorId);
+        uint256 totalRequired = requiredForNewTotalKeys + getLockedBond(nodeOperatorId);
 
         unchecked {
             return totalRequired > current ? totalRequired - current : 0;
@@ -219,8 +234,7 @@ contract AccountingMock {
         return wstETH.getWstETHByStETH(getRequiredBondForNextKeys(nodeOperatorId, additionalKeys));
     }
 
-    function getActualLockedBond(uint256 nodeOperatorId) public view returns (uint256) {
-        if (bondLock[nodeOperatorId].until <= block.timestamp) return 0;
+    function getLockedBond(uint256 nodeOperatorId) public view returns (uint256) {
         return bondLock[nodeOperatorId].amount;
     }
 
@@ -246,7 +260,7 @@ contract AccountingMock {
     function getUnbondedKeysCountToEject(uint256 nodeOperatorId) external view returns (uint256) {
         (uint256 current, uint256 required) = getBondSummary(nodeOperatorId);
         current += 10 wei;
-        required -= getActualLockedBond(nodeOperatorId);
+        required -= getLockedBond(nodeOperatorId);
         if (current >= required) return 0;
         return (required - current) / bondCurves[operatorBondCurveId[nodeOperatorId]] + 1;
     }

--- a/test/unit/Accounting/BondCalculations.t.sol
+++ b/test/unit/Accounting/BondCalculations.t.sol
@@ -6,6 +6,7 @@ pragma solidity 0.8.33;
 import { BaseTest, BondStateBaseTest, GetRequiredBondBaseTest, GetRequiredBondForKeysBaseTest, RewardsBaseTest } from "./_Base.t.sol";
 import { Accounting } from "src/Accounting.sol";
 import { IBondCurve } from "src/interfaces/IBondCurve.sol";
+import { IBondLock } from "src/interfaces/IBondLock.sol";
 import { IBaseModule } from "src/interfaces/IBaseModule.sol";
 import { IBurner } from "src/interfaces/IBurner.sol";
 import { IAccounting } from "src/interfaces/IAccounting.sol";
@@ -281,7 +282,7 @@ contract LockBondTest is BaseTest {
 
         vm.prank(address(stakingModule));
         accounting.lockBond(0, 1 ether);
-        assertEq(accounting.getActualLockedBond(0), 1 ether);
+        assertEq(accounting.getLockedBond(0), 1 ether);
     }
 
     function test_lockBond_RevertWhen_SenderIsNotModule() public {
@@ -297,7 +298,7 @@ contract LockBondTest is BaseTest {
 
         vm.prank(address(stakingModule));
         accounting.lockBond(0, 1 ether);
-        assertEq(accounting.getActualLockedBond(0), 1 ether);
+        assertEq(accounting.getLockedBond(0), 1 ether);
 
         vm.expectRevert();
         vm.prank(address(stakingModule));
@@ -313,7 +314,7 @@ contract LockBondTest is BaseTest {
         vm.prank(address(stakingModule));
         accounting.releaseLockedBond(0, 0.4 ether);
 
-        assertEq(accounting.getActualLockedBond(0), 0.6 ether);
+        assertEq(accounting.getLockedBond(0), 0.6 ether);
     }
 
     function test_releaseLockedBond_RevertWhen_SenderIsNotModule() public {
@@ -332,7 +333,7 @@ contract LockBondTest is BaseTest {
         vm.prank(address(stakingModule));
         accounting.lockBond(0, amountToLock);
 
-        assertEq(accounting.getActualLockedBond(0), amountToLock);
+        assertEq(accounting.getLockedBond(0), amountToLock);
 
         uint256 amountToCompensate = 0.4 ether;
         addBond(0, amountToCompensate);
@@ -343,18 +344,37 @@ contract LockBondTest is BaseTest {
         vm.prank(address(stakingModule));
         accounting.compensateLockedBond(0);
 
-        assertEq(accounting.getActualLockedBond(0), amountToLock - ethToSharesToEth(amountToCompensate));
+        assertEq(accounting.getLockedBond(0), amountToLock - ethToSharesToEth(amountToCompensate));
     }
 
     function test_compensateLockedBond_notingLocked() public assertInvariants {
         mock_getNodeOperatorsCount(1);
 
-        assertEq(accounting.getActualLockedBond(0), 0);
+        assertEq(accounting.getLockedBond(0), 0);
 
         vm.prank(address(stakingModule));
         accounting.compensateLockedBond(0);
 
-        assertEq(accounting.getActualLockedBond(0), 0);
+        assertEq(accounting.getLockedBond(0), 0);
+    }
+
+    function test_compensateLockedBond_unlockExpiredLock() public assertInvariants {
+        mock_getNodeOperatorsCount(1);
+
+        assertEq(accounting.getLockedBond(0), 0);
+
+        uint256 amountToLock = 1 ether;
+        vm.prank(address(stakingModule));
+        accounting.lockBond(0, amountToLock);
+
+        assertEq(accounting.getLockedBond(0), amountToLock);
+
+        vm.warp(block.timestamp + accounting.getBondLockPeriod() + 1 seconds);
+
+        vm.prank(address(stakingModule));
+        accounting.compensateLockedBond(0);
+
+        assertEq(accounting.getLockedBond(0), 0);
     }
 
     function test_compensateLockedBond_requiredWithoutLockIsMoreThanCurrent() public assertInvariants {
@@ -365,7 +385,7 @@ contract LockBondTest is BaseTest {
         vm.prank(address(stakingModule));
         accounting.lockBond(0, amountToLock);
 
-        assertEq(accounting.getActualLockedBond(0), amountToLock);
+        assertEq(accounting.getLockedBond(0), amountToLock);
 
         uint256 amountToCompensate = 1 ether;
         addBond(0, amountToCompensate);
@@ -373,7 +393,7 @@ contract LockBondTest is BaseTest {
         vm.prank(address(stakingModule));
         accounting.compensateLockedBond(0);
 
-        assertEq(accounting.getActualLockedBond(0), amountToLock);
+        assertEq(accounting.getLockedBond(0), amountToLock);
     }
 
     function test_compensateLockedBond_FullCompensation() public assertInvariants {
@@ -393,7 +413,7 @@ contract LockBondTest is BaseTest {
         vm.prank(address(stakingModule));
         accounting.compensateLockedBond(0);
 
-        assertEq(accounting.getActualLockedBond(0), 0);
+        assertEq(accounting.getLockedBond(0), 0);
     }
 
     function test_compensateLockedBond_RevertWhen_SenderIsNotModule() public {
@@ -419,12 +439,12 @@ contract LockBondTest is BaseTest {
 
         vm.prank(address(stakingModule));
         accounting.lockBond(noId, amount);
-        assertEq(accounting.getActualLockedBond(noId), amount);
+        assertEq(accounting.getLockedBond(noId), amount);
 
         vm.prank(address(stakingModule));
         uint256 settled = accounting.settleLockedBond(noId, amount);
         assertEq(settled, amount);
-        assertEq(accounting.getActualLockedBond(noId), 0);
+        assertEq(accounting.getLockedBond(noId), 0);
     }
 
     function test_settleLockedBond_noLocked() public assertInvariants {
@@ -437,8 +457,26 @@ contract LockBondTest is BaseTest {
 
         vm.prank(address(stakingModule));
         accounting.settleLockedBond(noId, 1 ether);
-        assertEq(accounting.getActualLockedBond(noId), 0);
+        assertEq(accounting.getLockedBond(noId), 0);
         assertEq(accounting.getBondShares(noId), bond);
+    }
+
+    function test_settleLockedBond_unlockExpiredLock() public assertInvariants {
+        mock_getNodeOperatorsCount(1);
+        uint256 noId = 0;
+        uint256 amount = 1 ether;
+        addBond(noId, amount);
+
+        vm.prank(address(stakingModule));
+        accounting.lockBond(noId, amount);
+        assertEq(accounting.getLockedBond(noId), amount);
+
+        vm.warp(block.timestamp + accounting.getBondLockPeriod() + 1 seconds);
+
+        vm.prank(address(stakingModule));
+        uint256 settled = accounting.settleLockedBond(noId, amount);
+        assertEq(settled, 0);
+        assertEq(accounting.getLockedBond(noId), 0);
     }
 
     function test_settleLockedBond_maxGreaterThanLocked() public assertInvariants {
@@ -449,12 +487,12 @@ contract LockBondTest is BaseTest {
 
         vm.prank(address(stakingModule));
         accounting.lockBond(noId, amount);
-        assertEq(accounting.getActualLockedBond(noId), amount);
+        assertEq(accounting.getLockedBond(noId), amount);
 
         vm.prank(address(stakingModule));
         uint256 settled = accounting.settleLockedBond(noId, amount + 0.4 ether);
         assertEq(settled, amount);
-        assertEq(accounting.getActualLockedBond(noId), 0);
+        assertEq(accounting.getLockedBond(noId), 0);
     }
 
     function test_settleLockedBond_maxLessThanLocked() public assertInvariants {
@@ -465,12 +503,12 @@ contract LockBondTest is BaseTest {
 
         vm.prank(address(stakingModule));
         accounting.lockBond(noId, amount);
-        assertEq(accounting.getActualLockedBond(noId), amount);
+        assertEq(accounting.getLockedBond(noId), amount);
 
         vm.prank(address(stakingModule));
         uint256 settled = accounting.settleLockedBond(noId, amount - 0.4 ether);
         assertEq(settled, amount - 0.4 ether);
-        assertEq(accounting.getActualLockedBond(noId), 0.4 ether);
+        assertEq(accounting.getLockedBond(noId), 0.4 ether);
     }
 
     function test_settleLockedBond_noBond() public assertInvariants {
@@ -532,7 +570,42 @@ contract LockBondTest is BaseTest {
         Accounting.BondLockData memory lockAfter = accounting.getLockedBondInfo(noId);
         assertEq(lockAfter.amount, 0);
         assertEq(lockAfter.until, 0);
-        assertEq(accounting.getActualLockedBond(noId), 0);
+        assertEq(accounting.getLockedBond(noId), 0);
+    }
+
+    function test_unlockExpiredLock() public assertInvariants {
+        mock_getNodeOperatorsCount(1);
+        uint256 noId = 0;
+        uint256 amount = 1 ether;
+
+        vm.prank(address(stakingModule));
+        accounting.lockBond(noId, amount);
+
+        vm.warp(block.timestamp + accounting.getBondLockPeriod() + 1 seconds);
+
+        vm.expectCall(
+            address(accounting.MODULE()),
+            abi.encodeWithSelector(IBaseModule.updateDepositableValidatorsCount.selector, noId)
+        );
+        vm.prank(address(stakingModule));
+        accounting.unlockExpiredLock(noId);
+
+        Accounting.BondLockData memory lockAfter = accounting.getLockedBondInfo(noId);
+        assertEq(lockAfter.amount, 0);
+        assertEq(lockAfter.until, 0);
+    }
+
+    function test_unlockExpiredLock_lockIsNotExpired() public assertInvariants {
+        mock_getNodeOperatorsCount(1);
+        uint256 noId = 0;
+        uint256 amount = 1 ether;
+
+        vm.prank(address(stakingModule));
+        accounting.lockBond(noId, amount);
+
+        vm.expectRevert(IBondLock.BondLockNotExpired.selector);
+        vm.prank(address(stakingModule));
+        accounting.unlockExpiredLock(noId);
     }
 }
 

--- a/test/unit/Accounting/BondCalculations.t.sol
+++ b/test/unit/Accounting/BondCalculations.t.sol
@@ -318,6 +318,18 @@ contract LockBondTest is BaseTest {
         assertEq(accounting.getLockedBond(0), 0.6 ether);
     }
 
+    function test_releaseLockedBond_NoLock() public assertInvariants {
+        mock_getNodeOperatorsCount(1);
+
+        assertEq(accounting.getLockedBond(0), 0);
+
+        vm.prank(address(stakingModule));
+        bool released = accounting.releaseLockedBond(0, 0.4 ether);
+
+        assertFalse(released, "release should return false when bond is released");
+        assertEq(accounting.getLockedBond(0), 0);
+    }
+
     function test_releaseLockedBond_ExpiredLock() public assertInvariants {
         mock_getNodeOperatorsCount(1);
 

--- a/test/unit/Accounting/BondCalculations.t.sol
+++ b/test/unit/Accounting/BondCalculations.t.sol
@@ -312,9 +312,29 @@ contract LockBondTest is BaseTest {
         accounting.lockBond(0, 1 ether);
 
         vm.prank(address(stakingModule));
-        accounting.releaseLockedBond(0, 0.4 ether);
+        bool released = accounting.releaseLockedBond(0, 0.4 ether);
 
+        assertTrue(released, "release should return true when bond is released");
         assertEq(accounting.getLockedBond(0), 0.6 ether);
+    }
+
+    function test_releaseLockedBond_ExpiredLock() public assertInvariants {
+        mock_getNodeOperatorsCount(1);
+
+        vm.prank(address(stakingModule));
+        accounting.lockBond(0, 1 ether);
+
+        vm.warp(block.timestamp + accounting.getBondLockPeriod() + 1 seconds);
+
+        vm.expectCall(
+            address(accounting.MODULE()),
+            abi.encodeWithSelector(IBaseModule.updateDepositableValidatorsCount.selector, 0)
+        );
+        vm.prank(address(stakingModule));
+        bool released = accounting.releaseLockedBond(0, 0.4 ether);
+
+        assertFalse(released, "release should return false when lock is expired");
+        assertEq(accounting.getLockedBond(0), 0);
     }
 
     function test_releaseLockedBond_RevertWhen_SenderIsNotModule() public {
@@ -371,6 +391,10 @@ contract LockBondTest is BaseTest {
 
         vm.warp(block.timestamp + accounting.getBondLockPeriod() + 1 seconds);
 
+        vm.expectCall(
+            address(accounting.MODULE()),
+            abi.encodeWithSelector(IBaseModule.updateDepositableValidatorsCount.selector, 0)
+        );
         vm.prank(address(stakingModule));
         accounting.compensateLockedBond(0);
 
@@ -473,8 +497,13 @@ contract LockBondTest is BaseTest {
 
         vm.warp(block.timestamp + accounting.getBondLockPeriod() + 1 seconds);
 
+        vm.expectCall(
+            address(accounting.MODULE()),
+            abi.encodeWithSelector(IBaseModule.updateDepositableValidatorsCount.selector, noId)
+        );
         vm.prank(address(stakingModule));
         uint256 settled = accounting.settleLockedBond(noId, amount);
+
         assertEq(settled, 0);
         assertEq(accounting.getLockedBond(noId), 0);
     }

--- a/test/unit/Accounting/Operations.t.sol
+++ b/test/unit/Accounting/Operations.t.sol
@@ -592,7 +592,7 @@ contract PenalizeTest is BaseTest {
         vm.prank(address(stakingModule));
         accounting.lockBond(0, 2 ether);
         Accounting.BondLockData memory lockBefore = accounting.getLockedBondInfo(0);
-        assertEq(accounting.getActualLockedBond(0), 2 ether);
+        assertEq(accounting.getLockedBond(0), 2 ether);
 
         uint256 amountToBurn = accounting.getBond(0) / 2;
 
@@ -1158,7 +1158,8 @@ contract PullFeeRewardsTest is BaseTest {
         // Let the lock expire
         Accounting.BondLockData memory lockInfo = accounting.getLockedBondInfo(0);
         vm.warp(lockInfo.until);
-        assertEq(accounting.getActualLockedBond(0), 0);
+        accounting.unlockExpiredLock(0);
+        assertEq(accounting.getLockedBond(0), 0);
 
         // One more pull should process all accumulated pending
         uint256 third = 8;

--- a/test/unit/CSModule.t.sol
+++ b/test/unit/CSModule.t.sol
@@ -1868,7 +1868,7 @@ contract CSMUpdateExitedValidatorsCount is ModuleUpdateExitedValidatorsCount, CS
 contract CSMUnsafeUpdateValidatorsCount is ModuleUnsafeUpdateValidatorsCount, CSMCommon {}
 
 contract CSMReportGeneralDelayedPenalty is ModuleReportGeneralDelayedPenalty, CSMCommon {
-    function test_reportGeneralDelayedPenalty_UpdateDepositableAfterUnlock_EmitsBatchEnqueued()
+    function test_reportGeneralDelayedPenalty_UpdatesDepositableAfterUnlock_EmitsBatchEnqueued()
         public
         assertInvariants
     {
@@ -1884,7 +1884,7 @@ contract CSMReportGeneralDelayedPenalty is ModuleReportGeneralDelayedPenalty, CS
 
         vm.expectEmit(address(csm));
         emit ICSModule.BatchEnqueued(parametersRegistry.QUEUE_LOWEST_PRIORITY(), noId, 1);
-        csm.updateDepositableValidatorsCount(noId);
+        accounting.unlockExpiredLock(noId);
 
         no = csm.getNodeOperator(noId);
         assertEq(no.enqueuedCount, 1);

--- a/test/unit/ModuleAbstract/PenaltiesGeneral.t.sol
+++ b/test/unit/ModuleAbstract/PenaltiesGeneral.t.sol
@@ -26,7 +26,7 @@ abstract contract ModuleReportGeneralDelayedPenalty is ModuleFixtures {
         );
         module.reportGeneralDelayedPenalty(noId, bytes32(abi.encode(1)), BOND_SIZE / 2, "Test penalty");
 
-        uint256 lockedBond = accounting.getActualLockedBond(noId);
+        uint256 lockedBond = accounting.getLockedBond(noId);
         assertEq(lockedBond, BOND_SIZE / 2 + module.PARAMETERS_REGISTRY().getGeneralDelayedPenaltyAdditionalFine(0));
         assertEq(module.getNonce(), nonce + 1);
         NodeOperator memory no = module.getNodeOperator(noId);
@@ -55,7 +55,7 @@ abstract contract ModuleReportGeneralDelayedPenalty is ModuleFixtures {
         emit IBaseModule.GeneralDelayedPenaltyReported(noId, bytes32(abi.encode(1)), 0, fine, "Test penalty");
         module.reportGeneralDelayedPenalty(noId, bytes32(abi.encode(1)), 0, "Test penalty");
 
-        uint256 lockedBond = accounting.getActualLockedBond(noId);
+        uint256 lockedBond = accounting.getLockedBond(noId);
         assertEq(lockedBond, fine);
     }
 
@@ -79,13 +79,13 @@ abstract contract ModuleReportGeneralDelayedPenalty is ModuleFixtures {
         assertEq(module.getNonce(), nonce);
     }
 
-    function test_reportGeneralDelayedPenalty_UpdateDepositableAfterUnlock() public assertInvariants {
+    function test_reportGeneralDelayedPenalty_UpdatesDepositableAfterUnlock() public assertInvariants {
         uint256 noId = createNodeOperator();
         uint256 nonce = module.getNonce();
 
         module.reportGeneralDelayedPenalty(noId, bytes32(abi.encode(1)), BOND_SIZE / 2, "Test penalty");
 
-        uint256 lockedBond = accounting.getActualLockedBond(noId);
+        uint256 lockedBond = accounting.getLockedBond(noId);
         assertEq(lockedBond, BOND_SIZE / 2 + module.PARAMETERS_REGISTRY().getGeneralDelayedPenaltyAdditionalFine(0));
         assertEq(module.getNonce(), nonce + 1);
         NodeOperator memory no = module.getNodeOperator(noId);
@@ -95,8 +95,7 @@ abstract contract ModuleReportGeneralDelayedPenalty is ModuleFixtures {
         module.obtainDepositData(1, "");
 
         vm.warp(accounting.getBondLockPeriod() + 1);
-
-        module.updateDepositableValidatorsCount(noId);
+        accounting.unlockExpiredLock(noId);
 
         no = module.getNodeOperator(noId);
         assertEq(no.depositableValidatorsCount, 1);
@@ -121,7 +120,7 @@ abstract contract ModuleCancelGeneralDelayedPenalty is ModuleFixtures {
             BOND_SIZE / 2 + module.PARAMETERS_REGISTRY().getGeneralDelayedPenaltyAdditionalFine(0)
         );
 
-        uint256 lockedBond = accounting.getActualLockedBond(noId);
+        uint256 lockedBond = accounting.getLockedBond(noId);
         assertEq(lockedBond, 0);
         assertEq(module.getNonce(), nonce + 1);
     }
@@ -137,7 +136,7 @@ abstract contract ModuleCancelGeneralDelayedPenalty is ModuleFixtures {
         emit IBaseModule.GeneralDelayedPenaltyCancelled(noId, BOND_SIZE / 2);
         module.cancelGeneralDelayedPenalty(noId, BOND_SIZE / 2);
 
-        uint256 lockedBond = accounting.getActualLockedBond(noId);
+        uint256 lockedBond = accounting.getLockedBond(noId);
         assertEq(lockedBond, module.PARAMETERS_REGISTRY().getGeneralDelayedPenaltyAdditionalFine(0));
         // nonce should not change due to no changes in the depositable validators
         assertEq(module.getNonce(), nonce);
@@ -399,18 +398,25 @@ abstract contract ModuleSettleGeneralDelayedPenaltyBasic is ModuleFixtures {
 }
 
 abstract contract ModuleSettleGeneralDelayedPenaltyAdvanced is ModuleFixtures {
-    function test_settleGeneralDelayedPenalty_PeriodIsExpired() public {
-        uint256 noId = createNodeOperator();
+    function test_settleGeneralDelayedPenalty_PeriodIsExpired_depositableValidatorsChanged() public {
+        uint256 noId = createNodeOperator(5);
         uint256 period = accounting.getBondLockPeriod();
         uint256 amount = 1 ether;
 
         module.reportGeneralDelayedPenalty(noId, bytes32(abi.encode(1)), amount, "Test penalty");
 
+        uint256 depositableBefore = module.getNodeOperator(noId).depositableValidatorsCount;
+        assertEq(depositableBefore, 4);
+
+        uint256 nonce = module.getNonce();
+
         vm.warp(block.timestamp + period + 1 seconds);
 
         module.settleGeneralDelayedPenalty(UintArr(noId), UintArr(type(uint256).max));
 
-        assertEq(accounting.getActualLockedBond(noId), 0);
+        assertEq(accounting.getLockedBond(noId), 0);
+        assertEq(module.getNodeOperator(noId).depositableValidatorsCount, 5);
+        assertEq(module.getNonce(), nonce + 1);
     }
 
     function test_settleGeneralDelayedPenalty_multipleNOs_oneExpired() public {
@@ -430,7 +436,7 @@ abstract contract ModuleSettleGeneralDelayedPenaltyAdvanced is ModuleFixtures {
             UintArr(type(uint256).max, type(uint256).max)
         );
 
-        assertEq(accounting.getActualLockedBond(firstNoId), 0);
+        assertEq(accounting.getLockedBond(firstNoId), 0);
 
         lock = accounting.getLockedBondInfo(secondNoId);
         assertEq(lock.amount, 0 ether);
@@ -499,21 +505,48 @@ abstract contract ModuleCompensateGeneralDelayedPenalty is ModuleFixtures {
         assertEq(module.getNonce(), nonce);
     }
 
-    function test_compensateGeneralDelayedPenalty_revertWhen_NothingCompensated() public assertInvariants {
+    function test_compensateGeneralDelayedPenalty_NothingCompensatedDueToNoLock() public assertInvariants {
         uint256 noId = createNodeOperator();
+
+        uint256 nonce = module.getNonce();
+
+        vm.recordLogs();
+        vm.prank(nodeOperator);
+        module.compensateGeneralDelayedPenalty(noId);
+
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+        assertEq(logs.length, 0);
+
+        BondLock.BondLockData memory lock = accounting.getLockedBondInfo(noId);
+        assertEq(lock.amount, 0);
+        assertEq(module.getNonce(), nonce);
+    }
+
+    function test_compensateGeneralDelayedPenalty_NothingCompensatedDueToLockExpiry_depositableValidatorsChanged()
+        public
+        assertInvariants
+    {
+        uint256 noId = createNodeOperator(5);
         uint256 amount = 1 ether;
         uint256 fine = module.PARAMETERS_REGISTRY().getGeneralDelayedPenaltyAdditionalFine(0);
         module.reportGeneralDelayedPenalty(noId, bytes32(abi.encode(1)), amount, "Test penalty");
 
+        uint256 depositableBefore = module.getNodeOperator(noId).depositableValidatorsCount;
+        assertEq(depositableBefore, 4);
+
         uint256 nonce = module.getNonce();
 
-        vm.expectRevert(IBaseModule.NothingCompensated.selector);
+        vm.warp(block.timestamp + accounting.getBondLockPeriod() + 1);
+
         vm.prank(nodeOperator);
         module.compensateGeneralDelayedPenalty(noId);
 
         BondLock.BondLockData memory lock = accounting.getLockedBondInfo(noId);
-        assertEq(lock.amount, fine + amount);
-        assertEq(module.getNonce(), nonce);
+        assertEq(lock.amount, 0);
+        assertEq(module.getNonce(), nonce + 1);
+
+        uint256 depositableAfter = module.getNodeOperator(noId).depositableValidatorsCount;
+        assertEq(depositableAfter, 5);
     }
 
     function test_compensateGeneralDelayedPenalty_depositableValidatorsChanged() public {

--- a/test/unit/ModuleAbstract/PenaltiesGeneral.t.sol
+++ b/test/unit/ModuleAbstract/PenaltiesGeneral.t.sol
@@ -142,6 +142,27 @@ abstract contract ModuleCancelGeneralDelayedPenalty is ModuleFixtures {
         assertEq(module.getNonce(), nonce);
     }
 
+    function test_cancelGeneralDelayedPenalty_ExpiredLock_depositableValidatorsChanged() public assertInvariants {
+        uint256 noId = createNodeOperator(5);
+
+        module.reportGeneralDelayedPenalty(noId, bytes32(abi.encode(1)), BOND_SIZE / 2, "Test penalty");
+
+        uint256 nonce = module.getNonce();
+        uint256 depositableBefore = module.getNodeOperator(noId).depositableValidatorsCount;
+        assertEq(depositableBefore, 4);
+
+        vm.warp(block.timestamp + accounting.getBondLockPeriod() + 1 seconds);
+
+        module.cancelGeneralDelayedPenalty(noId, BOND_SIZE / 2);
+
+        uint256 lockedBond = accounting.getLockedBond(noId);
+        assertEq(lockedBond, 0);
+        assertEq(module.getNonce(), nonce + 1);
+
+        uint256 depositableAfter = module.getNodeOperator(noId).depositableValidatorsCount;
+        assertEq(depositableAfter, 5);
+    }
+
     function test_cancelGeneralDelayedPenalty_RevertWhen_NoNodeOperator() public {
         vm.expectRevert(IBaseModule.NodeOperatorDoesNotExist.selector);
         module.cancelGeneralDelayedPenalty(0, 1 ether);

--- a/test/unit/abstract/BondLock.t.sol
+++ b/test/unit/abstract/BondLock.t.sol
@@ -27,6 +27,10 @@ contract BondLockTestable is BondLock(4 weeks, 365 days) {
         _unlock(nodeOperatorId, amount);
     }
 
+    function unlockExpiredLock(uint256 nodeOperatorId) external {
+        _unlockExpiredLock(nodeOperatorId);
+    }
+
     function remove(uint256 nodeOperatorId) external {
         _changeBondLock(nodeOperatorId, 0, 0);
     }
@@ -78,16 +82,16 @@ contract BondLockTest is Test {
         bondLock.setBondLockPeriod(max + 1 seconds);
     }
 
-    function test_getActualLockedBond() public {
+    function test_getLockedBond() public {
         uint256 noId = 0;
         uint256 amount = 1 ether;
         bondLock.lock(noId, amount);
 
-        uint256 value = bondLock.getActualLockedBond(noId);
+        uint256 value = bondLock.getLockedBond(noId);
         assertEq(value, amount);
     }
 
-    function test_getActualLockedBond_WhenOnUntil() public {
+    function test_getLockedBond_WhenOnUntil() public {
         uint256 noId = 0;
         uint256 amount = 1 ether;
         bondLock.lock(noId, amount);
@@ -95,11 +99,11 @@ contract BondLockTest is Test {
         BondLock.BondLockData memory lock = bondLock.getLockedBondInfo(noId);
         vm.warp(lock.until);
 
-        uint256 value = bondLock.getActualLockedBond(noId);
-        assertEq(value, 0);
+        uint256 value = bondLock.getLockedBond(noId);
+        assertEq(value, amount);
     }
 
-    function test_getActualLockedBond_WhenPeriodIsPassed() public {
+    function test_getLockedBond_WhenPeriodIsPassed() public {
         uint256 period = bondLock.getBondLockPeriod();
         uint256 noId = 0;
         uint256 amount = 1 ether;
@@ -107,8 +111,23 @@ contract BondLockTest is Test {
 
         vm.warp(block.timestamp + period + 1 seconds);
 
-        uint256 value = bondLock.getActualLockedBond(noId);
-        assertEq(value, 0);
+        uint256 value = bondLock.getLockedBond(noId);
+        assertEq(value, amount);
+    }
+
+    function test_isLockExpired() public {
+        uint256 period = bondLock.getBondLockPeriod();
+        uint256 noId = 0;
+        uint256 amount = 1 ether;
+        bondLock.lock(noId, amount);
+
+        bool expired = bondLock.isLockExpired(noId);
+        assertFalse(expired);
+
+        vm.warp(block.timestamp + period + 1 seconds);
+
+        expired = bondLock.isLockExpired(noId);
+        assertTrue(expired);
     }
 
     function test_lock() public {
@@ -247,6 +266,41 @@ contract BondLockTest is Test {
 
         vm.expectRevert(IBondLock.InvalidBondLockAmount.selector);
         bondLock.unlock(noId, amount + 1 ether);
+    }
+
+    function test_unlockExpiredLock() public {
+        uint256 period = bondLock.getBondLockPeriod();
+        uint256 noId = 0;
+        uint256 amount = 100 ether;
+
+        bondLock.lock(noId, amount);
+
+        vm.expectEmit(address(bondLock));
+        emit IBondLock.BondLockRemoved(noId);
+
+        vm.warp(block.timestamp + period + 1 seconds);
+
+        bondLock.unlockExpiredLock(noId);
+
+        BondLock.BondLockData memory lock = bondLock.getLockedBondInfo(0);
+        assertEq(lock.amount, 0);
+        assertEq(lock.until, 0);
+    }
+
+    function test_unlockExpiredLock_RevertWhenNotExpired() public {
+        uint256 period = bondLock.getBondLockPeriod();
+        uint256 noId = 0;
+        uint256 amount = 100 ether;
+
+        bondLock.lock(noId, amount);
+
+        vm.expectRevert(IBondLock.BondLockNotExpired.selector);
+        bondLock.unlockExpiredLock(noId);
+
+        vm.warp(block.timestamp + period + 1 seconds);
+
+        // Should work after the lock is expired
+        bondLock.unlockExpiredLock(noId);
     }
 
     function test_remove() public {


### PR DESCRIPTION
## Description

Now, the expired lock is not removed automatically, but should be removed manually. That solves the issue for stale depositable validator count after bond lock expiry 

## Checklist

- [x] Appropriate PR labels applied
- [x] Test coverage maintained (`just coverage`)
  - [x] Tests are added/updated
- [x] Documentation maintained
  - [x] Updated
