### PR TITLE
fix: revert in syncKeyAddedBalance for CSM 0x01

### DIFF
--- a/src/CSModule.sol
+++ b/src/CSModule.sol
@@ -237,6 +237,16 @@ contract CSModule is ICSModule, BaseModule {
         _incrementModuleNonce();
     }
 
+    /// @inheritdoc IBaseModule
+    function syncKeyAddedBalance(
+        uint256 nodeOperatorId,
+        uint256 keyIndex,
+        uint256 currentBalanceWei
+    ) public virtual override(BaseModule, IBaseModule) {
+        _onlyEnabledTopUpQueue();
+        super.syncKeyAddedBalance(nodeOperatorId, keyIndex, currentBalanceWei);
+    }
+
     /// @inheritdoc ICSModule
     function setTopUpQueueLimit(uint256 limit) external {
         _checkRole(MANAGE_TOP_UP_QUEUE_ROLE);

--- a/src/abstract/BaseModule.sol
+++ b/src/abstract/BaseModule.sol
@@ -332,7 +332,7 @@ abstract contract BaseModule is
     }
 
     /// @inheritdoc IBaseModule
-    function syncKeyAddedBalance(uint256 nodeOperatorId, uint256 keyIndex, uint256 currentBalanceWei) external {
+    function syncKeyAddedBalance(uint256 nodeOperatorId, uint256 keyIndex, uint256 currentBalanceWei) public virtual {
         _checkVerifierRole();
 
         NodeOperatorOps.syncKeyAddedBalance({

--- a/test/unit/CSModule.t.sol
+++ b/test/unit/CSModule.t.sol
@@ -1313,6 +1313,23 @@ contract CSMTopUpQueue is CSMCommon {
         vm.expectRevert(ICSModule.TopUpQueueDisabled.selector);
         csm.rewindTopUpQueue(0);
     }
+
+    function test_syncKeyAddedBalance_RevertWhenTopUpQueueDisabled() public {
+        csm = new CSModule({
+            moduleType: "community-staking-module",
+            lidoLocator: address(locator),
+            parametersRegistry: address(parametersRegistry),
+            accounting: address(accounting),
+            exitPenalties: address(exitPenalties)
+        });
+
+        _enableInitializers(address(csm));
+        csm.initialize({ admin: address(this), topUpQueueLimit: 0 });
+
+        csm.grantRole(csm.VERIFIER_ROLE(), address(this));
+        vm.expectRevert(ICSModule.TopUpQueueDisabled.selector);
+        csm.syncKeyAddedBalance(0, 0, WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE + 1 ether);
+    }
 }
 
 contract CSMProposeNodeOperatorManagerAddressChange is ModuleProposeNodeOperatorManagerAddressChange, CSMCommon {}
@@ -1899,11 +1916,29 @@ contract CSMSettleGeneralDelayedPenaltyAdvanced is ModuleSettleGeneralDelayedPen
 
 contract CSMCompensateGeneralDelayedPenalty is ModuleCompensateGeneralDelayedPenalty, CSMCommon {}
 
-contract CSMReportWithdrawnValidators is ModuleReportWithdrawnValidators, CSMCommon {}
+contract CSMReportWithdrawnValidators is ModuleReportWithdrawnValidators, CSMCommon {
+    function setUp() public override {
+        topUpQueueLimit = 32;
 
-contract CSMKeyAddedBalance is ModuleKeyAddedBalance, CSMCommon {}
+        super.setUp();
+    }
+}
 
-contract CSMSyncKeyAddedBalance is ModuleSyncKeyAddedBalance, CSMCommon {}
+contract CSMKeyAddedBalance is ModuleKeyAddedBalance, CSMCommon {
+    function setUp() public override {
+        topUpQueueLimit = 32;
+
+        super.setUp();
+    }
+}
+
+contract CSMSyncKeyAddedBalance is ModuleSyncKeyAddedBalance, CSMCommon {
+    function setUp() public override {
+        topUpQueueLimit = 32;
+
+        super.setUp();
+    }
+}
 
 contract CSMGetStakingModuleSummary is ModuleGetStakingModuleSummary, CSMCommon {}
 


### PR DESCRIPTION
## Description

Restrict `syncKeyAddedBalance` in CSM to only work when the top-up queue is enabled.

## Checklist

- [x] Appropriate PR labels applied
- [x] Test coverage maintained (`just coverage`)
  - [ ] No need to add/update tests
  - [x] Tests are added/updated
- [x] Documentation maintained
  - [x] No need to update
  - [ ] Updated
