### PR TITLE
feat: use 90% value of key balance as a full withdrawal threshold

### DIFF
--- a/src/Verifier.sol
+++ b/src/Verifier.sol
@@ -7,6 +7,7 @@ import { AccessControlEnumerable } from "@openzeppelin/contracts/access/extensio
 
 import { BeaconBlockHeader, Slot, Validator, Withdrawal } from "./lib/Types.sol";
 import { PausableWithRoles } from "./abstract/PausableWithRoles.sol";
+import { WithdrawnValidatorLib } from "./lib/WithdrawnValidatorLib.sol";
 import { GIndex } from "./lib/GIndex.sol";
 import { SSZ } from "./lib/SSZ.sol";
 
@@ -34,6 +35,15 @@ contract Verifier is IVerifier, AccessControlEnumerable, PausableWithRoles {
 
     // See `BEACON_ROOTS_ADDRESS` constant in the EIP-4788.
     address public constant BEACON_ROOTS = 0x000F3df6D732807Ef1319fB7B8bB8522d0Beac02;
+
+    uint256 internal constant MAX_BP = 10_000;
+
+    /// @dev Minimum withdrawal amount as a ratio of total ether deposited to the validator,
+    ///      expressed in basis points (10 000 = 100%). At ~3% top APY, losing >10% of balance
+    ///      requires ~3 years offline — implausible for any legitimately run validator.
+    ///      We do not accept slashed validators in normal withdrawal processing, so we do not need to account for slashing penalties here.
+    ///      In case of unexpected network conditions, the DAO can always replace the verifier contract with one having a different threshold.
+    uint256 internal constant MIN_WITHDRAWAL_RATIO = 9000;
 
     uint64 public immutable SLOTS_PER_EPOCH;
 
@@ -178,11 +188,13 @@ contract Verifier is IVerifier, AccessControlEnumerable, PausableWithRoles {
             if (keccak256(pubkey) != keccak256(data.validator.object.pubkey)) revert InvalidPublicKey();
         }
 
-        uint256 withdrawalAmount = _processWithdrawalProof(
-            data.withdrawal,
-            data.validator,
-            data.withdrawalBlock.header
-        );
+        uint256 withdrawalAmount = _processWithdrawalProof({
+            withdrawal: data.withdrawal,
+            validator: data.validator,
+            header: data.withdrawalBlock.header,
+            nodeOperatorId: data.validator.nodeOperatorId,
+            keyIndex: data.validator.keyIndex
+        });
 
         _reportSingleValidator(
             WithdrawnValidatorInfo({
@@ -221,11 +233,13 @@ contract Verifier is IVerifier, AccessControlEnumerable, PausableWithRoles {
             gI: _getHistoricalBlockRootGI(data.recentBlock.header.slot, data.withdrawalBlock.header.slot)
         });
 
-        uint256 withdrawalAmount = _processWithdrawalProof(
-            data.withdrawal,
-            data.validator,
-            data.withdrawalBlock.header
-        );
+        uint256 withdrawalAmount = _processWithdrawalProof({
+            withdrawal: data.withdrawal,
+            validator: data.validator,
+            header: data.withdrawalBlock.header,
+            nodeOperatorId: data.validator.nodeOperatorId,
+            keyIndex: data.validator.keyIndex
+        });
 
         _reportSingleValidator(
             WithdrawnValidatorInfo({
@@ -306,43 +320,26 @@ contract Verifier is IVerifier, AccessControlEnumerable, PausableWithRoles {
     function _processWithdrawalProof(
         WithdrawalWitness calldata withdrawal,
         ValidatorWitness calldata validator,
-        BeaconBlockHeader calldata header
+        BeaconBlockHeader calldata header,
+        uint256 nodeOperatorId,
+        uint256 keyIndex
     ) internal view returns (uint256 withdrawalAmount) {
         if (address(uint160(uint256(validator.object.withdrawalCredentials))) != WITHDRAWAL_ADDRESS) {
             revert InvalidWithdrawalAddress();
         }
         if (withdrawal.object.withdrawalAddress != WITHDRAWAL_ADDRESS) revert InvalidWithdrawalAddress();
 
-        // The methods in this contract do not accept proofs of withdrawals from slashed validators. It is proposed that
-        // such withdrawals be processed off-chain and reported directly to the CSModule using EasyTracks.
         if (validator.object.slashed) revert ValidatorIsSlashed();
         if (_computeEpochAtSlot(header.slot) < validator.object.withdrawableEpoch) revert ValidatorIsNotWithdrawable();
         if (withdrawal.object.validatorIndex != validator.index) revert InvalidValidatorIndex();
 
-        // See https://hackmd.io/1wM8vqeNTjqt4pC3XoCUKQ
-        //
-        // ISSUE:
-        // There is a possible way to bypass this check:
-        // - wait for full withdrawal & sweep
-        // - be lucky enough that no one provides proof for this withdrawal for at least 1 sweep cycle
-        //  (~8 days with the network of 1M active validators)
-        // - deposit 15 ETH for non-slashed validator
-        // - wait for a sweep of this deposit
-        // - provide proof of the last withdrawal
-        // As a result, the Node Operator's bond will be penalized for 32 ETH - additional deposit value
-        // However, all ETH involved,
-        // including 15 ETH deposited by the attacker will remain in the Lido on Ethereum protocol
-        // Hence, the only consequence of the attack is an inconsistency in the bond accounting that can be resolved
-        // through the bond deposit approved by the corresponding DAO decision
-        //
-        // Resolution:
-        // Given no losses for the protocol,
-        // significant cost of attack (15 ETH),
-        // and lack of feasible ways to mitigate it in the smart contract's code,
-        // it is proposed to acknowledge possibility of the attack
-        // and be ready to propose a corresponding vote to the DAO if it will ever happen
+        // The full withdrawal threshold is derived from the total ether deposited to the validator (activation balance
+        // + tracked top-ups/consolidations). The ratio (MIN_WITHDRAWAL_RATIO / MAX_BP) accounts for possible CL losses
+        // such as inactivity penalties.
+        uint256 totalDepositedEther = WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE +
+            MODULE.getKeyAddedBalance(nodeOperatorId, keyIndex);
         withdrawalAmount = withdrawal.object.amountWei();
-        if (withdrawalAmount < 15 ether) revert PartialWithdrawal();
+        if (withdrawalAmount < (totalDepositedEther * MIN_WITHDRAWAL_RATIO) / MAX_BP) revert PartialWithdrawal();
 
         SSZ.verifyProof({
             proof: validator.proof,

--- a/test/fixtures/Verifier/withdrawal.mjs
+++ b/test/fixtures/Verifier/withdrawal.mjs
@@ -1,4 +1,4 @@
-// Usage: node withdrawal.mjs [withdrawal_offset=0]
+// Usage: node withdrawal.mjs [withdrawal_offset=0] [amount_gwei=32e9]
 
 "use strict";
 
@@ -184,5 +184,5 @@ main({
   address: "b3e29c46ee1745724417c0c51eb2351a1c01cf36",
   withdrawableEpoch: 100_500,
   withdrawalOffset: parseInt(process.argv[2]) || 0,
-  amount: 32e9,
+  amount: Number(process.argv[3]) || 32e9,
 });

--- a/test/unit/Verifier.t.sol
+++ b/test/unit/Verifier.t.sol
@@ -301,6 +301,7 @@ contract VerifierTestConstructor is VerifierTestBase {
 
 contract VerifierWithdrawalTest is VerifierTestBase {
     using Strings for uint8;
+    using Strings for uint256;
 
     struct Fixture {
         bytes32 blockRoot;
@@ -446,8 +447,111 @@ contract VerifierWithdrawalTest is VerifierTestBase {
         verifier.processWithdrawalProof(fixture.data);
     }
 
+    function test_processWithdrawalProof_HappyPath_WithAddedBalance() public {
+        // Use a small added balance so the threshold stays below the fixture's 32 ETH withdrawal.
+        // threshold = (32 + 3) * 9000 / 10000 = 31.5 ETH < 32 ETH
+        vm.mockCall(
+            address(module),
+            abi.encodeWithSelector(
+                IBaseModule.getKeyAddedBalance.selector,
+                fixture.data.validator.nodeOperatorId,
+                fixture.data.validator.keyIndex
+            ),
+            abi.encode(3 ether)
+        );
+
+        WithdrawnValidatorInfo[] memory withdrawals = new WithdrawnValidatorInfo[](1);
+        withdrawals[0] = WithdrawnValidatorInfo({
+            nodeOperatorId: 0,
+            keyIndex: 0,
+            exitBalance: uint256(fixture.data.withdrawal.object.amount) * 1e9,
+            slashingPenalty: 0,
+            isSlashed: false
+        });
+
+        vm.expectCall(
+            address(module),
+            abi.encodeWithSelector(IBaseModule.reportRegularWithdrawnValidators.selector, withdrawals)
+        );
+
+        verifier.processWithdrawalProof(fixture.data);
+    }
+
+    function test_processWithdrawalProof_HappyPath_MaxEffectiveBalance() public {
+        // threshold = (32 + 2016) * 9000 / 10000 = 1843.2 ETH = 1_843_200_000_000 gwei
+        // Reload fixture with the minimal expected withdrawal amount.
+        _loadFixtureWithAmount({ offset: 11, amountGwei: 1_843_200_000_000 });
+        _setMocks();
+
+        // Mock keyAddedBalance for a fully consolidated validator (2048 - 32 = 2016 ETH added).
+        vm.mockCall(
+            address(module),
+            abi.encodeWithSelector(
+                IBaseModule.getKeyAddedBalance.selector,
+                fixture.data.validator.nodeOperatorId,
+                fixture.data.validator.keyIndex
+            ),
+            abi.encode(2016 ether)
+        );
+
+        WithdrawnValidatorInfo[] memory withdrawals = new WithdrawnValidatorInfo[](1);
+        withdrawals[0] = WithdrawnValidatorInfo({
+            nodeOperatorId: 0,
+            keyIndex: 0,
+            exitBalance: uint256(fixture.data.withdrawal.object.amount) * 1e9,
+            slashingPenalty: 0,
+            isSlashed: false
+        });
+
+        vm.expectCall(
+            address(module),
+            abi.encodeWithSelector(IBaseModule.reportRegularWithdrawnValidators.selector, withdrawals)
+        );
+
+        verifier.processWithdrawalProof(fixture.data);
+    }
+
     function test_processWithdrawalProof_RevertWhen_PartialWithdrawal() public {
-        fixture.data.withdrawal.object.amount = 15e9 - 1;
+        // 32 ether in gwei * 9000 / 10000 = 28_800_000_000 gwei = 28.8 ether
+        fixture.data.withdrawal.object.amount = 28_800_000_000 - 1;
+
+        vm.expectRevert(IVerifier.PartialWithdrawal.selector);
+        verifier.processWithdrawalProof(fixture.data);
+    }
+
+    function test_processWithdrawalProof_RevertWhen_PartialWithdrawal_WithAddedBalance() public {
+        vm.mockCall(
+            address(module),
+            abi.encodeWithSelector(
+                IBaseModule.getKeyAddedBalance.selector,
+                fixture.data.validator.nodeOperatorId,
+                fixture.data.validator.keyIndex
+            ),
+            abi.encode(100 ether)
+        );
+
+        // (32 + 100) ether in gwei * 9000 / 10000 = 118_800_000_000 gwei = 118.8 ether
+        fixture.data.withdrawal.object.amount = 118_800_000_000 - 1;
+
+        vm.expectRevert(IVerifier.PartialWithdrawal.selector);
+        verifier.processWithdrawalProof(fixture.data);
+    }
+
+    function test_processWithdrawalProof_RevertWhen_PartialWithdrawal_MaxEffectiveBalance() public {
+        // Mock keyAddedBalance for a fully consolidated validator (2048 - 32 = 2016 ETH added).
+        vm.mockCall(
+            address(module),
+            abi.encodeWithSelector(
+                IBaseModule.getKeyAddedBalance.selector,
+                fixture.data.validator.nodeOperatorId,
+                fixture.data.validator.keyIndex
+            ),
+            abi.encode(2016 ether)
+        );
+
+        // threshold = (32 + 2016) * 9000 / 10000 = 1843.2 ETH = 1_843_200_000_000 gwei
+        // Reverts before SSZ proof check, so modifying amount is safe.
+        fixture.data.withdrawal.object.amount = 1_843_200_000_000 - 1;
 
         vm.expectRevert(IVerifier.PartialWithdrawal.selector);
         verifier.processWithdrawalProof(fixture.data);
@@ -547,6 +651,16 @@ contract VerifierWithdrawalTest is VerifierTestBase {
             abi.encode(fixture.data.validator.object.pubkey)
         );
 
+        vm.mockCall(
+            address(module),
+            abi.encodeWithSelector(
+                IBaseModule.getKeyAddedBalance.selector,
+                fixture.data.validator.nodeOperatorId,
+                fixture.data.validator.keyIndex
+            ),
+            abi.encode(uint256(0))
+        );
+
         vm.mockCall(address(module), abi.encodeWithSelector(IBaseModule.reportRegularWithdrawnValidators.selector), "");
     }
 
@@ -560,6 +674,17 @@ contract VerifierWithdrawalTest is VerifierTestBase {
         cmd[1] = "--no-warnings";
         cmd[2] = "test/fixtures/Verifier/withdrawal.mjs";
         cmd[3] = offset.toString();
+        bytes memory res = vm.ffi(cmd);
+        fixture = abi.decode(res, (Fixture));
+    }
+
+    function _loadFixtureWithAmount(uint8 offset, uint256 amountGwei) internal {
+        string[] memory cmd = new string[](5);
+        cmd[0] = "node";
+        cmd[1] = "--no-warnings";
+        cmd[2] = "test/fixtures/Verifier/withdrawal.mjs";
+        cmd[3] = offset.toString();
+        cmd[4] = Strings.toString(amountGwei);
         bytes memory res = vm.ffi(cmd);
         fixture = abi.decode(res, (Fixture));
     }

--- a/test/unit/VerifierHistorical.t.sol
+++ b/test/unit/VerifierHistorical.t.sol
@@ -71,6 +71,16 @@ contract VerifierHistoricalBase is Test, Utilities {
             abi.encode(fixture.data.validator.object.pubkey)
         );
 
+        vm.mockCall(
+            address(module),
+            abi.encodeWithSelector(
+                IBaseModule.getKeyAddedBalance.selector,
+                fixture.data.validator.nodeOperatorId,
+                fixture.data.validator.keyIndex
+            ),
+            abi.encode(uint256(0))
+        );
+
         vm.mockCall(address(module), abi.encodeWithSelector(IBaseModule.reportRegularWithdrawnValidators.selector), "");
     }
 
@@ -216,7 +226,8 @@ contract VerifierHistoricalTest is VerifierHistoricalBase {
     }
 
     function test_processHistoricalWithdrawalProof_RevertWhen_PartialWithdrawal() public {
-        fixture.data.withdrawal.object.amount = 15e9 - 1;
+        // 32 ether in gwei * 9000 / 10000 = 28_800_000_000 gwei = 28.8 ether
+        fixture.data.withdrawal.object.amount = 28_800_000_000 - 1;
 
         vm.expectRevert(IVerifier.PartialWithdrawal.selector);
         verifier.processHistoricalWithdrawalProof(fixture.data);


### PR DESCRIPTION
## Description

Replace hardcoded `15 ether` partial withdrawal threshold with 90% of total deposited ether (activation balance + key added balance).

## Checklist

- [x] Appropriate PR labels applied
- [x] Test coverage maintained (`just coverage`)
  - [ ] No need to add/update tests
  - [x] Tests are added/updated
- [x] Documentation maintained
  - [x] No need to update
  - [ ] Updated
