### PR TITLE
feat: Remove force targetLimit setting on uncompensated penalties

### DIFF
--- a/src/abstract/BaseModule.sol
+++ b/src/abstract/BaseModule.sol
@@ -5,7 +5,7 @@ pragma solidity 0.8.33;
 
 import { AccessControlEnumerableUpgradeable } from "@openzeppelin/contracts-upgradeable/access/extensions/AccessControlEnumerableUpgradeable.sol";
 
-import { IStakingModule, FORCED_TARGET_LIMIT_MODE_ID } from "../interfaces/IStakingModule.sol";
+import { IStakingModule } from "../interfaces/IStakingModule.sol";
 import { ILidoLocator } from "../interfaces/ILidoLocator.sol";
 import { IStETH } from "../interfaces/IStETH.sol";
 import { IParametersRegistry } from "../interfaces/IParametersRegistry.sol";
@@ -234,7 +234,8 @@ abstract contract BaseModule is
         uint256 targetLimit
     ) external {
         _checkStakingRouterRole();
-        _setTargetLimit(nodeOperatorId, targetLimitMode, targetLimit);
+
+        NodeOperatorOps.setTargetLimit(_nodeOperators, nodeOperatorId, targetLimitMode, targetLimit);
 
         _updateDepositableValidatorsCount({ nodeOperatorId: nodeOperatorId, incrementNonceIfUpdated: false });
         _incrementModuleNonce();
@@ -299,11 +300,6 @@ abstract contract BaseModule is
             bool settled = GeneralPenalty.settleGeneralDelayedPenalty(nodeOperatorId, maxAmounts[i]);
 
             if (!settled) continue;
-
-            // If general delayed penalty was not compensated using `compensateGeneralDelayedPenalty`,
-            // we treat it the same way as when bond is not sufficient to cover the penalty.
-            // TODO: do we need to set target limit yet?
-            _onUncompensatedPenalty(nodeOperatorId);
 
             // Nonce should be updated if depositableValidators change
             _updateDepositableValidatorsCount({ nodeOperatorId: nodeOperatorId, incrementNonceIfUpdated: true });
@@ -636,9 +632,7 @@ abstract contract BaseModule is
             if (info.isSlashed && !_isValidatorSlashed[pointer]) revert SlashingPenaltyIsNotApplicable();
 
             NodeOperator storage no = _nodeOperators[info.nodeOperatorId];
-            bool penaltyCovered = WithdrawnValidatorLib.process(no, info, _keyAddedBalances[pointer]);
-            // TODO: do we really need to set target limit?
-            if (!penaltyCovered) _onUncompensatedPenalty(info.nodeOperatorId);
+            WithdrawnValidatorLib.process(no, info, _keyAddedBalances[pointer]);
 
             _updateDepositableValidatorsCount({ nodeOperatorId: info.nodeOperatorId, incrementNonceIfUpdated: false });
 
@@ -656,13 +650,6 @@ abstract contract BaseModule is
         unchecked {
             emit NonceChanged(++_nonce);
         }
-    }
-
-    /// @dev Prevents reactivation of a Node Operator after an uncovered penalty by
-    ///      forcing its target limit to zero. Uncovered charges are not considered penalties, hence this method
-    ///      is not called in such cases.
-    function _onUncompensatedPenalty(uint256 nodeOperatorId) internal {
-        _setTargetLimit(nodeOperatorId, FORCED_TARGET_LIMIT_MODE_ID, 0);
     }
 
     function _addKeysAndUpdateDepositableValidatorsCount(
@@ -724,10 +711,6 @@ abstract contract BaseModule is
         if (incrementNonceIfUpdated) _incrementModuleNonce();
 
         return true;
-    }
-
-    function _setTargetLimit(uint256 nodeOperatorId, uint256 targetLimitMode, uint256 targetLimit) internal {
-        NodeOperatorOps.setTargetLimit(_nodeOperators, nodeOperatorId, targetLimitMode, targetLimit);
     }
 
     function _checkCanAddKeys(uint256 nodeOperatorId, address who) internal view {

--- a/src/interfaces/IBaseModule.sol
+++ b/src/interfaces/IBaseModule.sol
@@ -246,7 +246,7 @@ interface IBaseModule is IStakingModule, IAccessControlEnumerable, INOAddresses,
     /// @param amount Amount of penalty to cancel
     function cancelGeneralDelayedPenalty(uint256 nodeOperatorId, uint256 amount) external;
 
-    /// @notice Settles locked bond for eligible Node Operators and sets target limit to 0 only for settled ones
+    /// @notice Settles locked bond for eligible Node Operators
     /// @dev SETTLE_GENERAL_DELAYED_PENALTY_ROLE role is expected to be assigned to Easy Track
     /// @param nodeOperatorIds IDs of the Node Operators
     /// @param maxAmounts Maximum amounts to settle for each Node Operator

--- a/src/lib/WithdrawnValidatorLib.sol
+++ b/src/lib/WithdrawnValidatorLib.sol
@@ -24,7 +24,7 @@ library WithdrawnValidatorLib {
         NodeOperator storage no,
         WithdrawnValidatorInfo calldata validatorInfo,
         uint256 keyAddedBalance
-    ) external returns (bool penaltyCovered) {
+    ) external {
         if (validatorInfo.slashingPenalty > 0 && !validatorInfo.isSlashed) {
             revert IBaseModule.InvalidWithdrawnValidatorInfo();
         }
@@ -45,7 +45,7 @@ library WithdrawnValidatorLib {
             pubkey
         );
 
-        penaltyCovered = _fulfillExitObligations(validatorInfo, penaltyInfo, keyAddedBalance);
+        _fulfillExitObligations(validatorInfo, penaltyInfo, keyAddedBalance);
 
         emit IBaseModule.ValidatorWithdrawn({
             nodeOperatorId: validatorInfo.nodeOperatorId,
@@ -62,7 +62,7 @@ library WithdrawnValidatorLib {
         WithdrawnValidatorInfo calldata validatorInfo,
         ExitPenaltyInfo memory penaltyInfo,
         uint256 keyAddedBalance
-    ) internal returns (bool penaltyCovered) {
+    ) internal {
         bool chargeElWithdrawalRequestFee = false;
 
         // TODO: calculate multiplier by `max(minExpectedBalance, exitBalance)`
@@ -98,7 +98,7 @@ library WithdrawnValidatorLib {
 
         IAccounting accounting = IBaseModule(address(this)).ACCOUNTING();
 
-        penaltyCovered = true;
+        bool penaltyCovered = true;
 
         // Confiscate penalties first to prioritize compensations for the stETH holders.
         if (penaltySum > 0) {

--- a/test/fork/deployment/PostDeploymentCSM.t.sol
+++ b/test/fork/deployment/PostDeploymentCSM.t.sol
@@ -11,7 +11,6 @@ import { DeployParams } from "script/csm/DeployBase.s.sol";
 import { ICSModule } from "src/interfaces/ICSModule.sol";
 import { IParametersRegistry } from "src/interfaces/IParametersRegistry.sol";
 import { OssifiableProxy } from "src/lib/proxy/OssifiableProxy.sol";
-import { ParametersRegistry } from "src/ParametersRegistry.sol";
 import { VettedGate } from "src/VettedGate.sol";
 
 import { Utilities } from "../../helpers/Utilities.sol";

--- a/test/unit/ModuleAbstract/Core.t.sol
+++ b/test/unit/ModuleAbstract/Core.t.sol
@@ -3,8 +3,6 @@
 
 pragma solidity 0.8.33;
 
-import { Vm } from "forge-std/Test.sol";
-
 import { BaseModule } from "src/abstract/BaseModule.sol";
 import { IBaseModule } from "src/interfaces/IBaseModule.sol";
 import { IAssetRecovererLib } from "src/lib/AssetRecovererLib.sol";

--- a/test/unit/ModuleAbstract/PenaltiesGeneral.t.sol
+++ b/test/unit/ModuleAbstract/PenaltiesGeneral.t.sol
@@ -171,7 +171,7 @@ abstract contract ModuleCancelGeneralDelayedPenalty is ModuleFixtures {
 
 abstract contract ModuleSettleGeneralDelayedPenaltyBasic is ModuleFixtures {
     function test_settleGeneralDelayedPenalty() public assertInvariants {
-        uint256 noId = createNodeOperator();
+        uint256 noId = createNodeOperator(3);
         uint256 amount = 1 ether;
         module.reportGeneralDelayedPenalty(noId, bytes32(abi.encode(1)), amount, "Test penalty");
 
@@ -185,11 +185,10 @@ abstract contract ModuleSettleGeneralDelayedPenaltyBasic is ModuleFixtures {
         assertEq(lock.amount, 0 ether);
         assertEq(lock.until, 0);
 
-        // If the penalty is settled the targetValidatorsCount should be 0
         NodeOperatorSummary memory summary = getNodeOperatorSummary(noId);
         assertEq(summary.targetValidatorsCount, 0, "targetValidatorsCount mismatch");
-        assertEq(summary.targetLimitMode, 2, "targetLimitMode mismatch");
-        assertEq(summary.depositableValidatorsCount, 0, "depositableValidatorsCount mismatch");
+        assertEq(summary.targetLimitMode, 0, "targetLimitMode mismatch");
+        assertEq(summary.depositableValidatorsCount, 2, "depositableValidatorsCount mismatch");
     }
 
     function test_settleGeneralDelayedPenalty_revertWhen_InvalidInput() public assertInvariants {
@@ -219,8 +218,8 @@ abstract contract ModuleSettleGeneralDelayedPenaltyBasic is ModuleFixtures {
 
         summary = getNodeOperatorSummary(noId);
         assertEq(summary.targetValidatorsCount, 0, "targetValidatorsCount mismatch");
-        assertEq(summary.targetLimitMode, 2, "targetLimitMode mismatch");
-        assertEq(summary.depositableValidatorsCount, 0, "depositableValidatorsCount mismatch");
+        assertEq(summary.targetLimitMode, 0, "targetLimitMode mismatch");
+        assertEq(summary.depositableValidatorsCount, 2, "depositableValidatorsCount mismatch");
     }
 
     function test_settleGeneralDelayedPenalty_multipleNOs() public assertInvariants {

--- a/test/unit/ModuleAbstract/PenaltiesWithdrawn.t.sol
+++ b/test/unit/ModuleAbstract/PenaltiesWithdrawn.t.sol
@@ -137,7 +137,7 @@ abstract contract ModuleReportWithdrawnValidators is ModuleFixtures {
         assertEq(no.totalWithdrawnKeys, 1);
         // There should be target limit if the penalty is not covered by the bond.
         assertEq(no.targetLimit, 0);
-        assertEq(no.targetLimitMode, 2);
+        assertEq(no.targetLimitMode, 0);
     }
 
     function test_reportRegularWithdrawnValidators_exitDelayFee() public assertInvariants {
@@ -314,9 +314,8 @@ abstract contract ModuleReportWithdrawnValidators is ModuleFixtures {
 
         NodeOperator memory no = module.getNodeOperator(noId);
         assertEq(no.totalWithdrawnKeys, 1);
-        // There should be target limit if the penalty is not covered by the bond.
         assertEq(no.targetLimit, 0);
-        assertEq(no.targetLimitMode, 2);
+        assertEq(no.targetLimitMode, 0);
     }
 
     function test_reportRegularWithdrawnValidators_strikesPenaltyWithMultiplier() public assertInvariants {
@@ -647,9 +646,8 @@ abstract contract ModuleReportWithdrawnValidators is ModuleFixtures {
 
         NodeOperator memory no = module.getNodeOperator(noId);
         assertEq(no.totalWithdrawnKeys, 1);
-        // There should be target limit if the charges are covered by the bond but the penalties are not.
         assertEq(no.targetLimit, 0);
-        assertEq(no.targetLimitMode, 2);
+        assertEq(no.targetLimitMode, 0);
     }
 
     function test_reportRegularWithdrawnValidators_chargeHugeWithdrawalFee_StrikesPenalty() public assertInvariants {
@@ -780,9 +778,8 @@ abstract contract ModuleReportWithdrawnValidators is ModuleFixtures {
 
         NodeOperator memory no = module.getNodeOperator(noId);
         assertEq(no.totalWithdrawnKeys, 1);
-        // There should be target limit if the charges or penalties are not covered by the bond.
         assertEq(no.targetLimit, 0);
-        assertEq(no.targetLimitMode, 2);
+        assertEq(no.targetLimitMode, 0);
     }
 
     function test_reportRegularWithdrawnValidators_chargeWithdrawalFee_zeroPenaltyValue() public assertInvariants {


### PR DESCRIPTION
## Description

Due to the presence of BondDebt in the latest versions of contracts, setting targetLimit to force in case of non-compensated penalties, is no longer needed.

## Checklist

- [x] Appropriate PR labels applied
- [x] Test coverage maintained (`just coverage`)
  - [x] Tests are added/updated
- [x] Documentation maintained
  - [x] Updated
