### PR TITLE
feat: add curve-parameters role flow for one-shot setup

### DIFF
--- a/src/ParametersRegistry.sol
+++ b/src/ParametersRegistry.sol
@@ -24,6 +24,7 @@ contract ParametersRegistry is IParametersRegistry, Initializable, AccessControl
     bytes32 public constant MANAGE_PERFORMANCE_PARAMETERS_ROLE = keccak256("MANAGE_PERFORMANCE_PARAMETERS_ROLE");
     bytes32 public constant MANAGE_REWARD_SHARE_ROLE = keccak256("MANAGE_REWARD_SHARE_ROLE");
     bytes32 public constant MANAGE_VALIDATOR_EXIT_PARAMETERS_ROLE = keccak256("MANAGE_VALIDATOR_EXIT_PARAMETERS_ROLE");
+    bytes32 public constant MANAGE_CURVE_PARAMETERS_ROLE = keccak256("MANAGE_CURVE_PARAMETERS_ROLE");
 
     /// @dev Maximal value for basis points (BP)
     ///      1 BP = 0.01%
@@ -81,6 +82,11 @@ contract ParametersRegistry is IParametersRegistry, Initializable, AccessControl
 
     modifier onlyRoleMemberOrAdmin(bytes32 role) {
         _onlyRoleMemberOrAdmin(role);
+        _;
+    }
+
+    modifier onlyRoleMemberOrCurveParametersRoleOrAdmin(bytes32 role) {
+        _onlyRoleMemberOrCurveParametersRoleOrAdmin(role);
         _;
     }
 
@@ -219,7 +225,7 @@ contract ParametersRegistry is IParametersRegistry, Initializable, AccessControl
     function setKeyRemovalCharge(
         uint256 curveId,
         uint256 keyRemovalCharge
-    ) external onlyRoleMemberOrAdmin(MANAGE_GENERAL_PENALTIES_AND_CHARGES_ROLE) {
+    ) external onlyRoleMemberOrCurveParametersRoleOrAdmin(MANAGE_GENERAL_PENALTIES_AND_CHARGES_ROLE) {
         _keyRemovalCharges[curveId] = MarkedUint248(keyRemovalCharge.toUint248(), true);
         emit KeyRemovalChargeSet(curveId, keyRemovalCharge);
     }
@@ -228,13 +234,16 @@ contract ParametersRegistry is IParametersRegistry, Initializable, AccessControl
     function setGeneralDelayedPenaltyAdditionalFine(
         uint256 curveId,
         uint256 fine
-    ) external onlyRoleMemberOrAdmin(MANAGE_GENERAL_PENALTIES_AND_CHARGES_ROLE) {
+    ) external onlyRoleMemberOrCurveParametersRoleOrAdmin(MANAGE_GENERAL_PENALTIES_AND_CHARGES_ROLE) {
         _generalDelayedPenaltyAdditionalFines[curveId] = MarkedUint248(fine.toUint248(), true);
         emit GeneralDelayedPenaltyAdditionalFineSet(curveId, fine);
     }
 
     /// @inheritdoc IParametersRegistry
-    function setKeysLimit(uint256 curveId, uint256 limit) external onlyRoleMemberOrAdmin(MANAGE_KEYS_LIMIT_ROLE) {
+    function setKeysLimit(
+        uint256 curveId,
+        uint256 limit
+    ) external onlyRoleMemberOrCurveParametersRoleOrAdmin(MANAGE_KEYS_LIMIT_ROLE) {
         _keysLimits[curveId] = MarkedUint248(limit.toUint248(), true);
         emit KeysLimitSet(curveId, limit);
     }
@@ -244,7 +253,7 @@ contract ParametersRegistry is IParametersRegistry, Initializable, AccessControl
         uint256 curveId,
         uint256 priority,
         uint256 maxDeposits
-    ) external onlyRoleMemberOrAdmin(MANAGE_QUEUE_CONFIG_ROLE) {
+    ) external onlyRoleMemberOrCurveParametersRoleOrAdmin(MANAGE_QUEUE_CONFIG_ROLE) {
         _validateQueueConfig(priority, maxDeposits);
         _queueConfigs[curveId] = QueueConfig({ priority: priority.toUint32(), maxDeposits: maxDeposits.toUint32() });
         emit QueueConfigSet(curveId, priority, maxDeposits);
@@ -254,7 +263,7 @@ contract ParametersRegistry is IParametersRegistry, Initializable, AccessControl
     function setRewardShareData(
         uint256 curveId,
         KeyNumberValueInterval[] calldata data
-    ) external onlyRoleMemberOrAdmin(MANAGE_REWARD_SHARE_ROLE) {
+    ) external onlyRoleMemberOrCurveParametersRoleOrAdmin(MANAGE_REWARD_SHARE_ROLE) {
         // NOTE: The shared interval validator enforces `data[0].value > 0`.
         // Zero reward share for the first interval would allow rebate-only oracle reports (`distributed == 0 && rebate > 0`),
         // and those are rejected by FeeDistributor.
@@ -271,7 +280,7 @@ contract ParametersRegistry is IParametersRegistry, Initializable, AccessControl
     function setPerformanceLeewayData(
         uint256 curveId,
         KeyNumberValueInterval[] calldata data
-    ) external onlyRoleMemberOrAdmin(MANAGE_PERFORMANCE_PARAMETERS_ROLE) {
+    ) external onlyRoleMemberOrCurveParametersRoleOrAdmin(MANAGE_PERFORMANCE_PARAMETERS_ROLE) {
         _validateKeyNumberValueIntervals(data);
         KeyNumberValueInterval[] storage intervals = _performanceLeewayData[curveId];
         if (intervals.length > 0) delete _performanceLeewayData[curveId];
@@ -286,7 +295,7 @@ contract ParametersRegistry is IParametersRegistry, Initializable, AccessControl
         uint256 curveId,
         uint256 lifetime,
         uint256 threshold
-    ) external onlyRoleMemberOrAdmin(MANAGE_PERFORMANCE_PARAMETERS_ROLE) {
+    ) external onlyRoleMemberOrCurveParametersRoleOrAdmin(MANAGE_PERFORMANCE_PARAMETERS_ROLE) {
         _validateStrikesParams(lifetime, threshold);
         _strikesParams[curveId] = StrikesParams(lifetime.toUint32(), threshold.toUint32());
         emit StrikesParamsSet(curveId, lifetime, threshold);
@@ -296,7 +305,7 @@ contract ParametersRegistry is IParametersRegistry, Initializable, AccessControl
     function setBadPerformancePenalty(
         uint256 curveId,
         uint256 penalty
-    ) external onlyRoleMemberOrAdmin(MANAGE_PERFORMANCE_PARAMETERS_ROLE) {
+    ) external onlyRoleMemberOrCurveParametersRoleOrAdmin(MANAGE_PERFORMANCE_PARAMETERS_ROLE) {
         _badPerformancePenalties[curveId] = MarkedUint248(penalty.toUint248(), true);
         emit BadPerformancePenaltySet(curveId, penalty);
     }
@@ -307,7 +316,7 @@ contract ParametersRegistry is IParametersRegistry, Initializable, AccessControl
         uint256 attestationsWeight,
         uint256 blocksWeight,
         uint256 syncWeight
-    ) external onlyRoleMemberOrAdmin(MANAGE_PERFORMANCE_PARAMETERS_ROLE) {
+    ) external onlyRoleMemberOrCurveParametersRoleOrAdmin(MANAGE_PERFORMANCE_PARAMETERS_ROLE) {
         _validatePerformanceCoefficients(attestationsWeight, blocksWeight, syncWeight);
         _performanceCoefficients[curveId] = PerformanceCoefficients(
             attestationsWeight.toUint32(),
@@ -321,7 +330,7 @@ contract ParametersRegistry is IParametersRegistry, Initializable, AccessControl
     function setAllowedExitDelay(
         uint256 curveId,
         uint256 delay
-    ) external onlyRoleMemberOrAdmin(MANAGE_VALIDATOR_EXIT_PARAMETERS_ROLE) {
+    ) external onlyRoleMemberOrCurveParametersRoleOrAdmin(MANAGE_VALIDATOR_EXIT_PARAMETERS_ROLE) {
         _validateAllowedExitDelay(delay);
         _allowedExitDelay[curveId] = delay;
         emit AllowedExitDelaySet(curveId, delay);
@@ -331,7 +340,7 @@ contract ParametersRegistry is IParametersRegistry, Initializable, AccessControl
     function setExitDelayFee(
         uint256 curveId,
         uint256 penalty
-    ) external onlyRoleMemberOrAdmin(MANAGE_VALIDATOR_EXIT_PARAMETERS_ROLE) {
+    ) external onlyRoleMemberOrCurveParametersRoleOrAdmin(MANAGE_VALIDATOR_EXIT_PARAMETERS_ROLE) {
         _exitDelayFees[curveId] = MarkedUint248(penalty.toUint248(), true);
         emit ExitDelayFeeSet(curveId, penalty);
     }
@@ -340,7 +349,7 @@ contract ParametersRegistry is IParametersRegistry, Initializable, AccessControl
     function setMaxElWithdrawalRequestFee(
         uint256 curveId,
         uint256 fee
-    ) external onlyRoleMemberOrAdmin(MANAGE_VALIDATOR_EXIT_PARAMETERS_ROLE) {
+    ) external onlyRoleMemberOrCurveParametersRoleOrAdmin(MANAGE_VALIDATOR_EXIT_PARAMETERS_ROLE) {
         _maxElWithdrawalRequestFees[curveId] = MarkedUint248(fee.toUint248(), true);
         emit MaxElWithdrawalRequestFeeSet(curveId, fee);
     }
@@ -352,7 +361,7 @@ contract ParametersRegistry is IParametersRegistry, Initializable, AccessControl
     /// @inheritdoc IParametersRegistry
     function unsetKeyRemovalCharge(
         uint256 curveId
-    ) external onlyRoleMemberOrAdmin(MANAGE_GENERAL_PENALTIES_AND_CHARGES_ROLE) {
+    ) external onlyRoleMemberOrCurveParametersRoleOrAdmin(MANAGE_GENERAL_PENALTIES_AND_CHARGES_ROLE) {
         delete _keyRemovalCharges[curveId];
         emit KeyRemovalChargeUnset(curveId);
     }
@@ -360,25 +369,31 @@ contract ParametersRegistry is IParametersRegistry, Initializable, AccessControl
     /// @inheritdoc IParametersRegistry
     function unsetGeneralDelayedPenaltyAdditionalFine(
         uint256 curveId
-    ) external onlyRoleMemberOrAdmin(MANAGE_GENERAL_PENALTIES_AND_CHARGES_ROLE) {
+    ) external onlyRoleMemberOrCurveParametersRoleOrAdmin(MANAGE_GENERAL_PENALTIES_AND_CHARGES_ROLE) {
         delete _generalDelayedPenaltyAdditionalFines[curveId];
         emit GeneralDelayedPenaltyAdditionalFineUnset(curveId);
     }
 
     /// @inheritdoc IParametersRegistry
-    function unsetKeysLimit(uint256 curveId) external onlyRoleMemberOrAdmin(MANAGE_KEYS_LIMIT_ROLE) {
+    function unsetKeysLimit(
+        uint256 curveId
+    ) external onlyRoleMemberOrCurveParametersRoleOrAdmin(MANAGE_KEYS_LIMIT_ROLE) {
         delete _keysLimits[curveId];
         emit KeysLimitUnset(curveId);
     }
 
     /// @inheritdoc IParametersRegistry
-    function unsetQueueConfig(uint256 curveId) external onlyRoleMemberOrAdmin(MANAGE_QUEUE_CONFIG_ROLE) {
+    function unsetQueueConfig(
+        uint256 curveId
+    ) external onlyRoleMemberOrCurveParametersRoleOrAdmin(MANAGE_QUEUE_CONFIG_ROLE) {
         delete _queueConfigs[curveId];
         emit QueueConfigUnset(curveId);
     }
 
     /// @inheritdoc IParametersRegistry
-    function unsetRewardShareData(uint256 curveId) external onlyRoleMemberOrAdmin(MANAGE_REWARD_SHARE_ROLE) {
+    function unsetRewardShareData(
+        uint256 curveId
+    ) external onlyRoleMemberOrCurveParametersRoleOrAdmin(MANAGE_REWARD_SHARE_ROLE) {
         delete _rewardShareData[curveId];
         emit RewardShareDataUnset(curveId);
     }
@@ -386,13 +401,15 @@ contract ParametersRegistry is IParametersRegistry, Initializable, AccessControl
     /// @inheritdoc IParametersRegistry
     function unsetPerformanceLeewayData(
         uint256 curveId
-    ) external onlyRoleMemberOrAdmin(MANAGE_PERFORMANCE_PARAMETERS_ROLE) {
+    ) external onlyRoleMemberOrCurveParametersRoleOrAdmin(MANAGE_PERFORMANCE_PARAMETERS_ROLE) {
         delete _performanceLeewayData[curveId];
         emit PerformanceLeewayDataUnset(curveId);
     }
 
     /// @inheritdoc IParametersRegistry
-    function unsetStrikesParams(uint256 curveId) external onlyRoleMemberOrAdmin(MANAGE_PERFORMANCE_PARAMETERS_ROLE) {
+    function unsetStrikesParams(
+        uint256 curveId
+    ) external onlyRoleMemberOrCurveParametersRoleOrAdmin(MANAGE_PERFORMANCE_PARAMETERS_ROLE) {
         delete _strikesParams[curveId];
         emit StrikesParamsUnset(curveId);
     }
@@ -400,7 +417,7 @@ contract ParametersRegistry is IParametersRegistry, Initializable, AccessControl
     /// @inheritdoc IParametersRegistry
     function unsetBadPerformancePenalty(
         uint256 curveId
-    ) external onlyRoleMemberOrAdmin(MANAGE_PERFORMANCE_PARAMETERS_ROLE) {
+    ) external onlyRoleMemberOrCurveParametersRoleOrAdmin(MANAGE_PERFORMANCE_PARAMETERS_ROLE) {
         delete _badPerformancePenalties[curveId];
         emit BadPerformancePenaltyUnset(curveId);
     }
@@ -408,7 +425,7 @@ contract ParametersRegistry is IParametersRegistry, Initializable, AccessControl
     /// @inheritdoc IParametersRegistry
     function unsetPerformanceCoefficients(
         uint256 curveId
-    ) external onlyRoleMemberOrAdmin(MANAGE_PERFORMANCE_PARAMETERS_ROLE) {
+    ) external onlyRoleMemberOrCurveParametersRoleOrAdmin(MANAGE_PERFORMANCE_PARAMETERS_ROLE) {
         delete _performanceCoefficients[curveId];
         emit PerformanceCoefficientsUnset(curveId);
     }
@@ -416,13 +433,15 @@ contract ParametersRegistry is IParametersRegistry, Initializable, AccessControl
     /// @inheritdoc IParametersRegistry
     function unsetAllowedExitDelay(
         uint256 curveId
-    ) external onlyRoleMemberOrAdmin(MANAGE_VALIDATOR_EXIT_PARAMETERS_ROLE) {
+    ) external onlyRoleMemberOrCurveParametersRoleOrAdmin(MANAGE_VALIDATOR_EXIT_PARAMETERS_ROLE) {
         delete _allowedExitDelay[curveId];
         emit AllowedExitDelayUnset(curveId);
     }
 
     /// @inheritdoc IParametersRegistry
-    function unsetExitDelayFee(uint256 curveId) external onlyRoleMemberOrAdmin(MANAGE_VALIDATOR_EXIT_PARAMETERS_ROLE) {
+    function unsetExitDelayFee(
+        uint256 curveId
+    ) external onlyRoleMemberOrCurveParametersRoleOrAdmin(MANAGE_VALIDATOR_EXIT_PARAMETERS_ROLE) {
         delete _exitDelayFees[curveId];
         emit ExitDelayFeeUnset(curveId);
     }
@@ -430,7 +449,7 @@ contract ParametersRegistry is IParametersRegistry, Initializable, AccessControl
     /// @inheritdoc IParametersRegistry
     function unsetMaxElWithdrawalRequestFee(
         uint256 curveId
-    ) external onlyRoleMemberOrAdmin(MANAGE_VALIDATOR_EXIT_PARAMETERS_ROLE) {
+    ) external onlyRoleMemberOrCurveParametersRoleOrAdmin(MANAGE_VALIDATOR_EXIT_PARAMETERS_ROLE) {
         delete _maxElWithdrawalRequestFees[curveId];
         emit MaxElWithdrawalRequestFeeUnset(curveId);
     }
@@ -620,6 +639,15 @@ contract ParametersRegistry is IParametersRegistry, Initializable, AccessControl
         if (!(hasRole(role, sender) || hasRole(getRoleAdmin(role), sender))) {
             revert AccessControlUnauthorizedAccount(sender, role);
         }
+    }
+
+    function _onlyRoleMemberOrCurveParametersRoleOrAdmin(bytes32 role) internal view {
+        address sender = msg.sender;
+        if (hasRole(MANAGE_CURVE_PARAMETERS_ROLE, sender)) {
+            return;
+        }
+
+        _onlyRoleMemberOrAdmin(role);
     }
 
     function _validateQueueConfig(uint256 priority, uint256 maxDeposits) internal view {

--- a/src/interfaces/IOneShotCurveSetup.sol
+++ b/src/interfaces/IOneShotCurveSetup.sol
@@ -8,6 +8,11 @@ import { IBondCurve } from "./IBondCurve.sol";
 import { IParametersRegistry } from "./IParametersRegistry.sol";
 
 /// @title One-shot setup helper for a bond curve plus per-curve parameter overrides.
+/// @notice Intended for one-shot execution with temporary permissions only.
+///         Required roles:
+///         - `ACCOUNTING.MANAGE_BOND_CURVES_ROLE()`
+///         - `REGISTRY.MANAGE_CURVE_PARAMETERS_ROLE()`
+///         After `execute()` succeeds, this contract renounces both roles.
 interface IOneShotCurveSetup {
     struct ScalarOverride {
         bool isSet;
@@ -74,7 +79,25 @@ interface IOneShotCurveSetup {
     /// @notice Curve ID created by the successful `execute()` call.
     function deployedCurveId() external view returns (uint256);
 
+    /// @notice Returns the stored bond curve to be deployed by `execute()`.
+    function getBondCurve() external view returns (IBondCurve.BondCurveIntervalInput[] memory bondCurve);
+
+    /// @notice Returns whether reward share override is configured and the configured interval data.
+    function getRewardShareDataOverride()
+        external
+        view
+        returns (bool isSet, IParametersRegistry.KeyNumberValueInterval[] memory data);
+
+    /// @notice Returns whether performance leeway override is configured and the configured interval data.
+    function getPerformanceLeewayDataOverride()
+        external
+        view
+        returns (bool isSet, IParametersRegistry.KeyNumberValueInterval[] memory data);
+
     /// @notice Executes the stored rollout plan, adding the curve and applying the overrides.
+    /// @dev Requires only:
+    ///      `ACCOUNTING.MANAGE_BOND_CURVES_ROLE()` and `REGISTRY.MANAGE_CURVE_PARAMETERS_ROLE()`.
+    ///      On success, both roles are renounced by this contract.
     /// @return curveId Curve ID allocated to the newly deployed bond curve.
     function execute() external returns (uint256 curveId);
 }

--- a/src/interfaces/IParametersRegistry.sol
+++ b/src/interfaces/IParametersRegistry.sol
@@ -126,6 +126,9 @@ interface IParametersRegistry {
     /// @notice Role to manage validator exit related parameters: allowed exit delay, exit delay fee, EL max withdrawal request fee
     function MANAGE_VALIDATOR_EXIT_PARAMETERS_ROLE() external view returns (bytes32);
 
+    /// @notice Role to manage per-curve parameters (setters and unsetters only)
+    function MANAGE_CURVE_PARAMETERS_ROLE() external view returns (bytes32);
+
     /// @notice The lowest priority a deposit queue can be assigned with. This constant is not used in Curated Module
     function QUEUE_LOWEST_PRIORITY() external view returns (uint256);
 

--- a/src/utils/OneShotCurveSetup.sol
+++ b/src/utils/OneShotCurveSetup.sol
@@ -7,10 +7,14 @@ import { IBondCurve } from "../interfaces/IBondCurve.sol";
 import { IAccounting } from "../interfaces/IAccounting.sol";
 import { IParametersRegistry } from "../interfaces/IParametersRegistry.sol";
 import { IOneShotCurveSetup } from "../interfaces/IOneShotCurveSetup.sol";
+import { IAccessControl } from "@openzeppelin/contracts/access/IAccessControl.sol";
 
 /// @notice Helper that atomically deploys a new bond curve together with its parameter overrides.
 /// @dev The contract is intentionally single-use: once `execute` finishes successfully it
 ///      stores the emitted `curveId` for reference.
+///      Permission model: grant only two temporary roles to this contract:
+///      `ACCOUNTING.MANAGE_BOND_CURVES_ROLE()` and `REGISTRY.MANAGE_CURVE_PARAMETERS_ROLE()`.
+///      After successful execution, the contract renounces both roles.
 contract OneShotCurveSetup is IOneShotCurveSetup {
     IAccounting public immutable ACCOUNTING;
     IParametersRegistry public immutable REGISTRY;
@@ -66,7 +70,35 @@ contract OneShotCurveSetup is IOneShotCurveSetup {
         deployedCurveId = curveId;
 
         _applyParameterOverrides(curveId);
+
+        IAccessControl(address(ACCOUNTING)).renounceRole(ACCOUNTING.MANAGE_BOND_CURVES_ROLE(), address(this));
+        IAccessControl(address(REGISTRY)).renounceRole(REGISTRY.MANAGE_CURVE_PARAMETERS_ROLE(), address(this));
+
         emit BondCurveDeployed(curveId);
+    }
+
+    function getBondCurve() external view override returns (IBondCurve.BondCurveIntervalInput[] memory bondCurve_) {
+        bondCurve_ = bondCurve;
+    }
+
+    function getRewardShareDataOverride()
+        external
+        view
+        override
+        returns (bool isSet, IParametersRegistry.KeyNumberValueInterval[] memory data)
+    {
+        isSet = rewardShareDataOverride.isSet;
+        data = rewardShareDataOverride.data;
+    }
+
+    function getPerformanceLeewayDataOverride()
+        external
+        view
+        override
+        returns (bool isSet, IParametersRegistry.KeyNumberValueInterval[] memory data)
+    {
+        isSet = performanceLeewayDataOverride.isSet;
+        data = performanceLeewayDataOverride.data;
     }
 
     function _applyParameterOverrides(uint256 curveId) internal {

--- a/test/unit/OneShotCurveSetup.t.sol
+++ b/test/unit/OneShotCurveSetup.t.sol
@@ -9,17 +9,43 @@ import { OneShotCurveSetup } from "src/utils/OneShotCurveSetup.sol";
 import { IOneShotCurveSetup } from "src/interfaces/IOneShotCurveSetup.sol";
 import { IBondCurve } from "src/interfaces/IBondCurve.sol";
 import { IParametersRegistry } from "src/interfaces/IParametersRegistry.sol";
-import { AccountingMock } from "../helpers/mocks/AccountingMock.sol";
-import { ParametersRegistryMock } from "../helpers/mocks/ParametersRegistryMock.sol";
+import { Accounting } from "src/Accounting.sol";
+import { ParametersRegistry } from "src/ParametersRegistry.sol";
 import { Utilities } from "../helpers/Utilities.sol";
+import { Fixtures } from "../helpers/Fixtures.sol";
+import { DistributorMock } from "../helpers/mocks/DistributorMock.sol";
+import { Stub } from "../helpers/mocks/Stub.sol";
+import { LidoMock } from "../helpers/mocks/LidoMock.sol";
+import { LidoLocatorMock } from "../helpers/mocks/LidoLocatorMock.sol";
 
-contract OneShotCurveSetupTest is Test, Utilities {
-    AccountingMock internal accounting;
-    ParametersRegistryMock internal registry;
+contract OneShotCurveSetupTest is Test, Utilities, Fixtures {
+    Accounting internal accounting;
+    ParametersRegistry internal registry;
+    DistributorMock internal feeDistributor;
+    Stub internal module;
+    LidoMock internal stETH;
+    address internal admin;
 
     function setUp() public {
-        accounting = new AccountingMock(1 ether, address(0), address(0), address(0));
-        registry = new ParametersRegistryMock();
+        admin = nextAddress("ADMIN");
+
+        LidoLocatorMock locator;
+        (locator, , stETH, , ) = initLido();
+
+        module = new Stub();
+        feeDistributor = new DistributorMock(address(stETH));
+
+        accounting = new Accounting(address(locator), address(module), address(feeDistributor), 4 weeks, 365 days);
+        feeDistributor.setAccounting(address(accounting));
+        _enableInitializers(address(accounting));
+
+        IBondCurve.BondCurveIntervalInput[] memory defaultCurve = new IBondCurve.BondCurveIntervalInput[](1);
+        defaultCurve[0] = IBondCurve.BondCurveIntervalInput({ minKeysCount: 1, trend: 2 ether });
+        accounting.initialize(defaultCurve, admin, 8 weeks, nextAddress("CHARGE_PENALTY_RECIPIENT"));
+
+        registry = new ParametersRegistry(5);
+        _enableInitializers(address(registry));
+        registry.initialize(admin, _registryDefaults());
     }
 
     function test_constructor_revertWhen_ZeroAccountingAddress() external {
@@ -47,6 +73,7 @@ contract OneShotCurveSetupTest is Test, Utilities {
     function test_execute() external {
         IOneShotCurveSetup.ConstructorParams memory params = _paramsWithAllOverrides();
         OneShotCurveSetup deployer = new OneShotCurveSetup(address(accounting), address(registry), params);
+        _grantExecuteRoles(deployer);
 
         _expectBondCurveAddition(params.bondCurve);
 
@@ -60,6 +87,8 @@ contract OneShotCurveSetupTest is Test, Utilities {
         assertEq(curveId, expectedCurveId);
         assertEq(deployer.deployedCurveId(), expectedCurveId);
         assertTrue(deployer.executed());
+        assertFalse(accounting.hasRole(accounting.MANAGE_BOND_CURVES_ROLE(), address(deployer)));
+        assertFalse(registry.hasRole(registry.MANAGE_CURVE_PARAMETERS_ROLE(), address(deployer)));
     }
 
     function test_execute_partialOverrides() external {
@@ -75,49 +104,41 @@ contract OneShotCurveSetupTest is Test, Utilities {
         params.maxElWithdrawalRequestFee.isSet = false;
 
         OneShotCurveSetup deployer = new OneShotCurveSetup(address(accounting), address(registry), params);
+        _grantExecuteRoles(deployer);
 
         _expectBondCurveAddition(params.bondCurve);
-        expectNoCall(address(registry), abi.encodeWithSelector(ParametersRegistryMock.setKeyRemovalCharge.selector));
+        expectNoCall(address(registry), abi.encodeWithSelector(ParametersRegistry.setKeyRemovalCharge.selector));
         vm.expectCall(
             address(registry),
             abi.encodeWithSelector(
-                ParametersRegistryMock.setGeneralDelayedPenaltyAdditionalFine.selector,
+                ParametersRegistry.setGeneralDelayedPenaltyAdditionalFine.selector,
                 1,
                 params.generalDelayedPenaltyFine.value
             )
         );
         vm.expectCall(
             address(registry),
-            abi.encodeWithSelector(ParametersRegistryMock.setKeysLimit.selector, 1, params.keysLimit.value)
+            abi.encodeWithSelector(ParametersRegistry.setKeysLimit.selector, 1, params.keysLimit.value)
         );
         vm.expectCall(
             address(registry),
             abi.encodeWithSelector(
-                ParametersRegistryMock.setQueueConfig.selector,
+                ParametersRegistry.setQueueConfig.selector,
                 1,
                 params.queueConfig.priority,
                 params.queueConfig.maxDeposits
             )
         );
-        expectNoCall(address(registry), abi.encodeWithSelector(ParametersRegistryMock.setRewardShareData.selector));
+        expectNoCall(address(registry), abi.encodeWithSelector(ParametersRegistry.setRewardShareData.selector));
+        expectNoCall(address(registry), abi.encodeWithSelector(ParametersRegistry.setPerformanceLeewayData.selector));
+        expectNoCall(address(registry), abi.encodeWithSelector(ParametersRegistry.setStrikesParams.selector));
+        expectNoCall(address(registry), abi.encodeWithSelector(ParametersRegistry.setBadPerformancePenalty.selector));
+        expectNoCall(address(registry), abi.encodeWithSelector(ParametersRegistry.setPerformanceCoefficients.selector));
+        expectNoCall(address(registry), abi.encodeWithSelector(ParametersRegistry.setAllowedExitDelay.selector));
+        expectNoCall(address(registry), abi.encodeWithSelector(ParametersRegistry.setExitDelayFee.selector));
         expectNoCall(
             address(registry),
-            abi.encodeWithSelector(ParametersRegistryMock.setPerformanceLeewayData.selector)
-        );
-        expectNoCall(address(registry), abi.encodeWithSelector(ParametersRegistryMock.setStrikesParams.selector));
-        expectNoCall(
-            address(registry),
-            abi.encodeWithSelector(ParametersRegistryMock.setBadPerformancePenalty.selector)
-        );
-        expectNoCall(
-            address(registry),
-            abi.encodeWithSelector(ParametersRegistryMock.setPerformanceCoefficients.selector)
-        );
-        expectNoCall(address(registry), abi.encodeWithSelector(ParametersRegistryMock.setAllowedExitDelay.selector));
-        expectNoCall(address(registry), abi.encodeWithSelector(ParametersRegistryMock.setExitDelayFee.selector));
-        expectNoCall(
-            address(registry),
-            abi.encodeWithSelector(ParametersRegistryMock.setMaxElWithdrawalRequestFee.selector)
+            abi.encodeWithSelector(ParametersRegistry.setMaxElWithdrawalRequestFee.selector)
         );
 
         deployer.execute();
@@ -128,15 +149,12 @@ contract OneShotCurveSetupTest is Test, Utilities {
         params.keyRemovalCharge = _scalarOverride(11);
 
         OneShotCurveSetup deployer = new OneShotCurveSetup(address(accounting), address(registry), params);
+        _grantExecuteRoles(deployer);
 
         _expectBondCurveAddition(params.bondCurve);
         vm.expectCall(
             address(registry),
-            abi.encodeWithSelector(
-                ParametersRegistryMock.setKeyRemovalCharge.selector,
-                1,
-                params.keyRemovalCharge.value
-            )
+            abi.encodeWithSelector(ParametersRegistry.setKeyRemovalCharge.selector, 1, params.keyRemovalCharge.value)
         );
 
         deployer.execute();
@@ -147,12 +165,13 @@ contract OneShotCurveSetupTest is Test, Utilities {
         params.generalDelayedPenaltyFine = _scalarOverride(12);
 
         OneShotCurveSetup deployer = new OneShotCurveSetup(address(accounting), address(registry), params);
+        _grantExecuteRoles(deployer);
 
         _expectBondCurveAddition(params.bondCurve);
         vm.expectCall(
             address(registry),
             abi.encodeWithSelector(
-                ParametersRegistryMock.setGeneralDelayedPenaltyAdditionalFine.selector,
+                ParametersRegistry.setGeneralDelayedPenaltyAdditionalFine.selector,
                 1,
                 params.generalDelayedPenaltyFine.value
             )
@@ -166,11 +185,12 @@ contract OneShotCurveSetupTest is Test, Utilities {
         params.keysLimit = _scalarOverride(99);
 
         OneShotCurveSetup deployer = new OneShotCurveSetup(address(accounting), address(registry), params);
+        _grantExecuteRoles(deployer);
 
         _expectBondCurveAddition(params.bondCurve);
         vm.expectCall(
             address(registry),
-            abi.encodeWithSelector(ParametersRegistryMock.setKeysLimit.selector, 1, params.keysLimit.value)
+            abi.encodeWithSelector(ParametersRegistry.setKeysLimit.selector, 1, params.keysLimit.value)
         );
 
         deployer.execute();
@@ -178,15 +198,16 @@ contract OneShotCurveSetupTest is Test, Utilities {
 
     function test_execute_setsQueueConfig() external {
         IOneShotCurveSetup.ConstructorParams memory params = _baseParams();
-        params.queueConfig = _queueOverride(7, 13);
+        params.queueConfig = _queueOverride(5, 13);
 
         OneShotCurveSetup deployer = new OneShotCurveSetup(address(accounting), address(registry), params);
+        _grantExecuteRoles(deployer);
 
         _expectBondCurveAddition(params.bondCurve);
         vm.expectCall(
             address(registry),
             abi.encodeWithSelector(
-                ParametersRegistryMock.setQueueConfig.selector,
+                ParametersRegistry.setQueueConfig.selector,
                 1,
                 params.queueConfig.priority,
                 params.queueConfig.maxDeposits
@@ -201,11 +222,12 @@ contract OneShotCurveSetupTest is Test, Utilities {
         params.rewardShareData = _intervalOverride(7777);
 
         OneShotCurveSetup deployer = new OneShotCurveSetup(address(accounting), address(registry), params);
+        _grantExecuteRoles(deployer);
 
         _expectBondCurveAddition(params.bondCurve);
         vm.expectCall(
             address(registry),
-            abi.encodeWithSelector(ParametersRegistryMock.setRewardShareData.selector, 1, params.rewardShareData.data)
+            abi.encodeWithSelector(ParametersRegistry.setRewardShareData.selector, 1, params.rewardShareData.data)
         );
 
         deployer.execute();
@@ -216,12 +238,13 @@ contract OneShotCurveSetupTest is Test, Utilities {
         params.performanceLeewayData = _intervalOverride(5555);
 
         OneShotCurveSetup deployer = new OneShotCurveSetup(address(accounting), address(registry), params);
+        _grantExecuteRoles(deployer);
 
         _expectBondCurveAddition(params.bondCurve);
         vm.expectCall(
             address(registry),
             abi.encodeWithSelector(
-                ParametersRegistryMock.setPerformanceLeewayData.selector,
+                ParametersRegistry.setPerformanceLeewayData.selector,
                 1,
                 params.performanceLeewayData.data
             )
@@ -235,12 +258,13 @@ contract OneShotCurveSetupTest is Test, Utilities {
         params.strikesParams = _strikesOverride(9, 3);
 
         OneShotCurveSetup deployer = new OneShotCurveSetup(address(accounting), address(registry), params);
+        _grantExecuteRoles(deployer);
 
         _expectBondCurveAddition(params.bondCurve);
         vm.expectCall(
             address(registry),
             abi.encodeWithSelector(
-                ParametersRegistryMock.setStrikesParams.selector,
+                ParametersRegistry.setStrikesParams.selector,
                 1,
                 params.strikesParams.lifetime,
                 params.strikesParams.threshold
@@ -255,12 +279,13 @@ contract OneShotCurveSetupTest is Test, Utilities {
         params.badPerformancePenalty = _scalarOverride(21);
 
         OneShotCurveSetup deployer = new OneShotCurveSetup(address(accounting), address(registry), params);
+        _grantExecuteRoles(deployer);
 
         _expectBondCurveAddition(params.bondCurve);
         vm.expectCall(
             address(registry),
             abi.encodeWithSelector(
-                ParametersRegistryMock.setBadPerformancePenalty.selector,
+                ParametersRegistry.setBadPerformancePenalty.selector,
                 1,
                 params.badPerformancePenalty.value
             )
@@ -274,12 +299,13 @@ contract OneShotCurveSetupTest is Test, Utilities {
         params.performanceCoefficients = _performanceCoefficientsOverride(1, 2, 3);
 
         OneShotCurveSetup deployer = new OneShotCurveSetup(address(accounting), address(registry), params);
+        _grantExecuteRoles(deployer);
 
         _expectBondCurveAddition(params.bondCurve);
         vm.expectCall(
             address(registry),
             abi.encodeWithSelector(
-                ParametersRegistryMock.setPerformanceCoefficients.selector,
+                ParametersRegistry.setPerformanceCoefficients.selector,
                 1,
                 params.performanceCoefficients.attestationsWeight,
                 params.performanceCoefficients.blocksWeight,
@@ -295,15 +321,12 @@ contract OneShotCurveSetupTest is Test, Utilities {
         params.allowedExitDelay = _scalarOverride(100);
 
         OneShotCurveSetup deployer = new OneShotCurveSetup(address(accounting), address(registry), params);
+        _grantExecuteRoles(deployer);
 
         _expectBondCurveAddition(params.bondCurve);
         vm.expectCall(
             address(registry),
-            abi.encodeWithSelector(
-                ParametersRegistryMock.setAllowedExitDelay.selector,
-                1,
-                params.allowedExitDelay.value
-            )
+            abi.encodeWithSelector(ParametersRegistry.setAllowedExitDelay.selector, 1, params.allowedExitDelay.value)
         );
 
         deployer.execute();
@@ -314,11 +337,12 @@ contract OneShotCurveSetupTest is Test, Utilities {
         params.exitDelayFee = _scalarOverride(101);
 
         OneShotCurveSetup deployer = new OneShotCurveSetup(address(accounting), address(registry), params);
+        _grantExecuteRoles(deployer);
 
         _expectBondCurveAddition(params.bondCurve);
         vm.expectCall(
             address(registry),
-            abi.encodeWithSelector(ParametersRegistryMock.setExitDelayFee.selector, 1, params.exitDelayFee.value)
+            abi.encodeWithSelector(ParametersRegistry.setExitDelayFee.selector, 1, params.exitDelayFee.value)
         );
 
         deployer.execute();
@@ -329,12 +353,13 @@ contract OneShotCurveSetupTest is Test, Utilities {
         params.maxElWithdrawalRequestFee = _scalarOverride(202);
 
         OneShotCurveSetup deployer = new OneShotCurveSetup(address(accounting), address(registry), params);
+        _grantExecuteRoles(deployer);
 
         _expectBondCurveAddition(params.bondCurve);
         vm.expectCall(
             address(registry),
             abi.encodeWithSelector(
-                ParametersRegistryMock.setMaxElWithdrawalRequestFee.selector,
+                ParametersRegistry.setMaxElWithdrawalRequestFee.selector,
                 1,
                 params.maxElWithdrawalRequestFee.value
             )
@@ -343,12 +368,81 @@ contract OneShotCurveSetupTest is Test, Utilities {
         deployer.execute();
     }
 
+    function test_execute_revertWhen_InvalidQueueConfig() external {
+        IOneShotCurveSetup.ConstructorParams memory params = _baseParams();
+        params.queueConfig = _queueOverride(6, 13);
+
+        OneShotCurveSetup deployer = new OneShotCurveSetup(address(accounting), address(registry), params);
+        _grantExecuteRoles(deployer);
+
+        vm.expectRevert(IParametersRegistry.QueueCannotBeUsed.selector);
+        deployer.execute();
+
+        assertFalse(deployer.executed());
+        assertEq(accounting.getCurvesCount(), 1);
+    }
+
+    function test_execute_revertWhen_MissingRegistryRole() external {
+        IOneShotCurveSetup.ConstructorParams memory params = _baseParams();
+        params.keysLimit = _scalarOverride(55);
+
+        OneShotCurveSetup deployer = new OneShotCurveSetup(address(accounting), address(registry), params);
+
+        vm.startPrank(admin);
+        accounting.grantRole(accounting.MANAGE_BOND_CURVES_ROLE(), address(deployer));
+        vm.stopPrank();
+
+        vm.expectRevert();
+        deployer.execute();
+
+        assertFalse(deployer.executed());
+        assertEq(accounting.getCurvesCount(), 1);
+    }
+
+    function test_getIntervalOverrides() external {
+        IOneShotCurveSetup.ConstructorParams memory params = _baseParams();
+        params.rewardShareData = _intervalOverride(9000);
+        params.performanceLeewayData = _intervalOverride(400);
+
+        OneShotCurveSetup deployer = new OneShotCurveSetup(address(accounting), address(registry), params);
+
+        (bool rewardShareIsSet, IParametersRegistry.KeyNumberValueInterval[] memory rewardShareData) = deployer
+            .getRewardShareDataOverride();
+        (
+            bool performanceLeewayIsSet,
+            IParametersRegistry.KeyNumberValueInterval[] memory performanceLeewayData
+        ) = deployer.getPerformanceLeewayDataOverride();
+
+        assertTrue(rewardShareIsSet);
+        assertEq(rewardShareData.length, 1);
+        assertEq(rewardShareData[0].minKeyNumber, 1);
+        assertEq(rewardShareData[0].value, 9000);
+
+        assertTrue(performanceLeewayIsSet);
+        assertEq(performanceLeewayData.length, 1);
+        assertEq(performanceLeewayData[0].minKeyNumber, 1);
+        assertEq(performanceLeewayData[0].value, 400);
+    }
+
+    function test_getBondCurve() external {
+        IOneShotCurveSetup.ConstructorParams memory params = _baseParams();
+        OneShotCurveSetup deployer = new OneShotCurveSetup(address(accounting), address(registry), params);
+
+        IBondCurve.BondCurveIntervalInput[] memory bondCurve = deployer.getBondCurve();
+        assertEq(bondCurve.length, 2);
+        assertEq(bondCurve[0].minKeysCount, 1);
+        assertEq(bondCurve[0].trend, 1 ether);
+        assertEq(bondCurve[1].minKeysCount, 11);
+        assertEq(bondCurve[1].trend, 1.5 ether);
+    }
+
     function test_execute_revertWhen_AlreadyExecuted() external {
         OneShotCurveSetup deployer = new OneShotCurveSetup(
             address(accounting),
             address(registry),
             _paramsWithAllOverrides()
         );
+        _grantExecuteRoles(deployer);
 
         deployer.execute();
 
@@ -360,6 +454,7 @@ contract OneShotCurveSetupTest is Test, Utilities {
         IOneShotCurveSetup.ConstructorParams memory params = _paramsWithAllOverrides();
 
         OneShotCurveSetup deployer = new OneShotCurveSetup(address(accounting), address(registry), params);
+        _grantExecuteRoles(deployer);
 
         assertEq(address(deployer.ACCOUNTING()), address(accounting));
         assertEq(address(deployer.REGISTRY()), address(registry));
@@ -372,7 +467,7 @@ contract OneShotCurveSetupTest is Test, Utilities {
         vm.expectCall(
             address(registry),
             abi.encodeWithSelector(
-                ParametersRegistryMock.setKeyRemovalCharge.selector,
+                ParametersRegistry.setKeyRemovalCharge.selector,
                 expectedCurveId,
                 params.keyRemovalCharge.value
             )
@@ -380,23 +475,19 @@ contract OneShotCurveSetupTest is Test, Utilities {
         vm.expectCall(
             address(registry),
             abi.encodeWithSelector(
-                ParametersRegistryMock.setGeneralDelayedPenaltyAdditionalFine.selector,
+                ParametersRegistry.setGeneralDelayedPenaltyAdditionalFine.selector,
                 expectedCurveId,
                 params.generalDelayedPenaltyFine.value
             )
         );
         vm.expectCall(
             address(registry),
-            abi.encodeWithSelector(
-                ParametersRegistryMock.setKeysLimit.selector,
-                expectedCurveId,
-                params.keysLimit.value
-            )
+            abi.encodeWithSelector(ParametersRegistry.setKeysLimit.selector, expectedCurveId, params.keysLimit.value)
         );
         vm.expectCall(
             address(registry),
             abi.encodeWithSelector(
-                ParametersRegistryMock.setQueueConfig.selector,
+                ParametersRegistry.setQueueConfig.selector,
                 expectedCurveId,
                 params.queueConfig.priority,
                 params.queueConfig.maxDeposits
@@ -405,7 +496,7 @@ contract OneShotCurveSetupTest is Test, Utilities {
         vm.expectCall(
             address(registry),
             abi.encodeWithSelector(
-                ParametersRegistryMock.setRewardShareData.selector,
+                ParametersRegistry.setRewardShareData.selector,
                 expectedCurveId,
                 params.rewardShareData.data
             )
@@ -413,7 +504,7 @@ contract OneShotCurveSetupTest is Test, Utilities {
         vm.expectCall(
             address(registry),
             abi.encodeWithSelector(
-                ParametersRegistryMock.setPerformanceLeewayData.selector,
+                ParametersRegistry.setPerformanceLeewayData.selector,
                 expectedCurveId,
                 params.performanceLeewayData.data
             )
@@ -421,7 +512,7 @@ contract OneShotCurveSetupTest is Test, Utilities {
         vm.expectCall(
             address(registry),
             abi.encodeWithSelector(
-                ParametersRegistryMock.setStrikesParams.selector,
+                ParametersRegistry.setStrikesParams.selector,
                 expectedCurveId,
                 params.strikesParams.lifetime,
                 params.strikesParams.threshold
@@ -430,7 +521,7 @@ contract OneShotCurveSetupTest is Test, Utilities {
         vm.expectCall(
             address(registry),
             abi.encodeWithSelector(
-                ParametersRegistryMock.setBadPerformancePenalty.selector,
+                ParametersRegistry.setBadPerformancePenalty.selector,
                 expectedCurveId,
                 params.badPerformancePenalty.value
             )
@@ -438,7 +529,7 @@ contract OneShotCurveSetupTest is Test, Utilities {
         vm.expectCall(
             address(registry),
             abi.encodeWithSelector(
-                ParametersRegistryMock.setPerformanceCoefficients.selector,
+                ParametersRegistry.setPerformanceCoefficients.selector,
                 expectedCurveId,
                 params.performanceCoefficients.attestationsWeight,
                 params.performanceCoefficients.blocksWeight,
@@ -448,7 +539,7 @@ contract OneShotCurveSetupTest is Test, Utilities {
         vm.expectCall(
             address(registry),
             abi.encodeWithSelector(
-                ParametersRegistryMock.setAllowedExitDelay.selector,
+                ParametersRegistry.setAllowedExitDelay.selector,
                 expectedCurveId,
                 params.allowedExitDelay.value
             )
@@ -456,7 +547,7 @@ contract OneShotCurveSetupTest is Test, Utilities {
         vm.expectCall(
             address(registry),
             abi.encodeWithSelector(
-                ParametersRegistryMock.setExitDelayFee.selector,
+                ParametersRegistry.setExitDelayFee.selector,
                 expectedCurveId,
                 params.exitDelayFee.value
             )
@@ -464,11 +555,38 @@ contract OneShotCurveSetupTest is Test, Utilities {
         vm.expectCall(
             address(registry),
             abi.encodeWithSelector(
-                ParametersRegistryMock.setMaxElWithdrawalRequestFee.selector,
+                ParametersRegistry.setMaxElWithdrawalRequestFee.selector,
                 expectedCurveId,
                 params.maxElWithdrawalRequestFee.value
             )
         );
+    }
+
+    function _grantExecuteRoles(OneShotCurveSetup deployer) internal {
+        vm.startPrank(admin);
+        accounting.grantRole(accounting.MANAGE_BOND_CURVES_ROLE(), address(deployer));
+
+        registry.grantRole(registry.MANAGE_CURVE_PARAMETERS_ROLE(), address(deployer));
+        vm.stopPrank();
+    }
+
+    function _registryDefaults() internal pure returns (IParametersRegistry.InitializationData memory data) {
+        data.defaultKeyRemovalCharge = 0.05 ether;
+        data.defaultGeneralDelayedPenaltyAdditionalFine = 0.1 ether;
+        data.defaultKeysLimit = 100_000;
+        data.defaultRewardShare = 8000;
+        data.defaultPerformanceLeeway = 500;
+        data.defaultStrikesLifetime = 6;
+        data.defaultStrikesThreshold = 3;
+        data.defaultQueuePriority = 0;
+        data.defaultQueueMaxDeposits = 10;
+        data.defaultBadPerformancePenalty = 0.1 ether;
+        data.defaultAttestationsWeight = 54;
+        data.defaultBlocksWeight = 8;
+        data.defaultSyncWeight = 2;
+        data.defaultAllowedExitDelay = 1 days;
+        data.defaultExitDelayFee = 0.05 ether;
+        data.defaultMaxElWithdrawalRequestFee = 0.1 ether;
     }
 
     function _paramsWithAllOverrides() internal pure returns (IOneShotCurveSetup.ConstructorParams memory params) {

--- a/test/unit/ParametersRegistry.t.sol
+++ b/test/unit/ParametersRegistry.t.sol
@@ -280,12 +280,18 @@ abstract contract ParametersTest {
 
 contract ParametersRegistryBaseTestInitialized is ParametersRegistryBaseTest {
     address roleMember;
+    address curveRoleMember;
 
     function setUp() public virtual override {
         super.setUp();
         _enableInitializers(address(parametersRegistry));
         parametersRegistry.initialize(admin, defaultInitData);
         roleMember = nextAddress("ROLE_MEMBER");
+        curveRoleMember = nextAddress("CURVE_ROLE_MEMBER");
+
+        vm.startPrank(admin);
+        parametersRegistry.grantRole(parametersRegistry.MANAGE_CURVE_PARAMETERS_ROLE(), curveRoleMember);
+        vm.stopPrank();
     }
 }
 
@@ -334,6 +340,10 @@ contract ParametersRegistryRewardShareDataTest is ParametersRegistryBaseTestInit
 
     function test_set_FromRoleAdmin() public override {
         _test_set(admin);
+    }
+
+    function test_set_FromCurveRoleMember() public {
+        _test_set(curveRoleMember);
     }
 
     function test_set_Overwrite() public {
@@ -442,6 +452,10 @@ contract ParametersRegistryRewardShareDataTest is ParametersRegistryBaseTestInit
 
     function test_unset_FromRoleAdmin() public override {
         _test_unset(admin);
+    }
+
+    function test_unset_FromCurveRoleMember() public {
+        _test_unset(curveRoleMember);
     }
 
     function test_unset_RevertWhen_noRole() public override {
@@ -571,6 +585,10 @@ contract ParametersRegistryPerformanceLeewayDataTest is ParametersRegistryBaseTe
         _test_set(admin);
     }
 
+    function test_set_FromCurveRoleMember() public {
+        _test_set(curveRoleMember);
+    }
+
     function test_set_Overwrite() public {
         uint256 curveId = 1;
         IParametersRegistry.KeyNumberValueInterval[] memory first = new IParametersRegistry.KeyNumberValueInterval[](2);
@@ -655,6 +673,10 @@ contract ParametersRegistryPerformanceLeewayDataTest is ParametersRegistryBaseTe
 
     function test_unset_FromRoleAdmin() public override {
         _test_unset(admin);
+    }
+
+    function test_unset_FromCurveRoleMember() public {
+        _test_unset(curveRoleMember);
     }
 
     function test_unset_RevertWhen_noRole() public override {
@@ -784,6 +806,10 @@ contract ParametersRegistryKeyRemovalChargeTest is ParametersRegistryBaseTestIni
         _test_set(admin);
     }
 
+    function test_set_FromCurveRoleMember() public {
+        _test_set(curveRoleMember);
+    }
+
     function test_set_RevertWhen_noRole() public override {
         uint256 curveId = 1;
         uint256 charge = 1 ether;
@@ -800,6 +826,10 @@ contract ParametersRegistryKeyRemovalChargeTest is ParametersRegistryBaseTestIni
 
     function test_unset_FromRoleAdmin() public override {
         _test_unset(admin);
+    }
+
+    function test_unset_FromCurveRoleMember() public {
+        _test_unset(curveRoleMember);
     }
 
     function test_unset_RevertWhen_noRole() public override {
@@ -907,6 +937,10 @@ contract ParametersRegistryGeneralDelayedPenaltyAdditionalFineTest is
         _test_set(admin);
     }
 
+    function test_set_FromCurveRoleMember() public {
+        _test_set(curveRoleMember);
+    }
+
     function test_set_RevertWhen_noRole() public override {
         uint256 curveId = 1;
         uint256 fine = 1 ether;
@@ -923,6 +957,10 @@ contract ParametersRegistryGeneralDelayedPenaltyAdditionalFineTest is
 
     function test_unset_FromRoleAdmin() public override {
         _test_unset(admin);
+    }
+
+    function test_unset_FromCurveRoleMember() public {
+        _test_unset(curveRoleMember);
     }
 
     function test_unset_RevertWhen_noRole() public override {
@@ -1027,6 +1065,10 @@ contract ParametersRegistryKeysLimitTest is ParametersRegistryBaseTestInitialize
         _test_set(admin);
     }
 
+    function test_set_FromCurveRoleMember() public {
+        _test_set(curveRoleMember);
+    }
+
     function test_set_RevertWhen_noRole() public override {
         uint256 curveId = 1;
         uint256 limit = 1000;
@@ -1043,6 +1085,10 @@ contract ParametersRegistryKeysLimitTest is ParametersRegistryBaseTestInitialize
 
     function test_unset_FromRoleAdmin() public override {
         _test_unset(admin);
+    }
+
+    function test_unset_FromCurveRoleMember() public {
+        _test_unset(curveRoleMember);
     }
 
     function test_unset_RevertWhen_noRole() public override {
@@ -1166,6 +1212,10 @@ contract ParametersRegistryStrikesParamsTest is ParametersRegistryBaseTestInitia
         _test_set(admin);
     }
 
+    function test_set_FromCurveRoleMember() public {
+        _test_set(curveRoleMember);
+    }
+
     function test_set_RevertWhen_zeroLifetime() public {
         uint256 curveId = 1;
         uint256 lifetime = 0;
@@ -1203,6 +1253,10 @@ contract ParametersRegistryStrikesParamsTest is ParametersRegistryBaseTestInitia
 
     function test_unset_FromRoleAdmin() public override {
         _test_unset(admin);
+    }
+
+    function test_unset_FromCurveRoleMember() public {
+        _test_unset(curveRoleMember);
     }
 
     function test_unset_RevertWhen_noRole() public override {
@@ -1318,6 +1372,10 @@ contract ParametersRegistryBadPerformancePenaltyTest is ParametersRegistryBaseTe
         _test_set(admin);
     }
 
+    function test_set_FromCurveRoleMember() public {
+        _test_set(curveRoleMember);
+    }
+
     function test_set_RevertWhen_noRole() public override {
         uint256 curveId = 1;
         uint256 penalty = 1 ether;
@@ -1334,6 +1392,10 @@ contract ParametersRegistryBadPerformancePenaltyTest is ParametersRegistryBaseTe
 
     function test_unset_FromRoleAdmin() public override {
         _test_unset(admin);
+    }
+
+    function test_unset_FromCurveRoleMember() public {
+        _test_unset(curveRoleMember);
     }
 
     function test_unset_RevertWhen_noRole() public override {
@@ -1452,6 +1514,10 @@ contract ParametersRegistryPerformanceCoefficientsTest is ParametersRegistryBase
         _test_set(admin);
     }
 
+    function test_set_FromCurveRoleMember() public {
+        _test_set(curveRoleMember);
+    }
+
     function test_set_RevertWhen_noRole() public override {
         uint256 curveId = 1;
         uint256 attestations = 100;
@@ -1481,6 +1547,10 @@ contract ParametersRegistryPerformanceCoefficientsTest is ParametersRegistryBase
 
     function test_unset_FromRoleAdmin() public override {
         _test_unset(admin);
+    }
+
+    function test_unset_FromCurveRoleMember() public {
+        _test_unset(curveRoleMember);
     }
 
     function test_unset_RevertWhen_noRole() public override {
@@ -1632,6 +1702,10 @@ contract ParametersRegistryQueueConfigTest is ParametersRegistryBaseTestInitiali
         _test_set(admin);
     }
 
+    function test_set_FromCurveRoleMember() public {
+        _test_set(curveRoleMember);
+    }
+
     function test_set_RevertWhen_noRole() public override {
         uint256 curveId = 11;
         uint32 priority = 3;
@@ -1649,6 +1723,10 @@ contract ParametersRegistryQueueConfigTest is ParametersRegistryBaseTestInitiali
 
     function test_unset_FromRoleAdmin() public override {
         _test_unset(admin);
+    }
+
+    function test_unset_FromCurveRoleMember() public {
+        _test_unset(curveRoleMember);
     }
 
     function test_unset_RevertWhen_noRole() public override {
@@ -1795,6 +1873,10 @@ contract ParametersRegistryAllowedExitDelayTest is ParametersRegistryBaseTestIni
         _test_set(admin);
     }
 
+    function test_set_FromCurveRoleMember() public {
+        _test_set(curveRoleMember);
+    }
+
     function test_set_RevertWhen_InvalidAllowedExitDelay() public {
         uint256 curveId = 1;
         uint256 delay = 0;
@@ -1820,6 +1902,10 @@ contract ParametersRegistryAllowedExitDelayTest is ParametersRegistryBaseTestIni
 
     function test_unset_FromRoleAdmin() public override {
         _test_unset(admin);
+    }
+
+    function test_unset_FromCurveRoleMember() public {
+        _test_unset(curveRoleMember);
     }
 
     function test_unset_RevertWhen_noRole() public override {
@@ -1924,6 +2010,10 @@ contract ParametersRegistryExitDelayFeeTest is ParametersRegistryBaseTestInitial
         _test_set(admin);
     }
 
+    function test_set_FromCurveRoleMember() public {
+        _test_set(curveRoleMember);
+    }
+
     function test_set_RevertWhen_noRole() public override {
         uint256 curveId = 1;
         uint256 penalty = 1 ether;
@@ -1940,6 +2030,10 @@ contract ParametersRegistryExitDelayFeeTest is ParametersRegistryBaseTestInitial
 
     function test_unset_FromRoleAdmin() public override {
         _test_unset(admin);
+    }
+
+    function test_unset_FromCurveRoleMember() public {
+        _test_unset(curveRoleMember);
     }
 
     function test_unset_RevertWhen_noRole() public override {
@@ -2044,6 +2138,10 @@ contract ParametersRegistryMaxElWithdrawalRequestFeeTest is ParametersRegistryBa
         _test_set(admin);
     }
 
+    function test_set_FromCurveRoleMember() public {
+        _test_set(curveRoleMember);
+    }
+
     function test_set_RevertWhen_noRole() public override {
         uint256 curveId = 1;
         uint256 fee = 1 ether;
@@ -2060,6 +2158,10 @@ contract ParametersRegistryMaxElWithdrawalRequestFeeTest is ParametersRegistryBa
 
     function test_unset_FromRoleAdmin() public override {
         _test_unset(admin);
+    }
+
+    function test_unset_FromCurveRoleMember() public {
+        _test_unset(curveRoleMember);
     }
 
     function test_unset_RevertWhen_noRole() public override {


### PR DESCRIPTION
## Description

- Add `MANAGE_CURVE_PARAMETERS_ROLE` access to per-curve setters/unsetters in `ParametersRegistry`, while keeping default setters under existing role checks.
- Update `OneShotCurveSetup` to operate with only `MANAGE_BOND_CURVES_ROLE` and `MANAGE_CURVE_PARAMETERS_ROLE` and renounce both roles after successful `execute()`.
- Clarify intended utility-contract role model in NatSpec.
- Expand unit tests with per-function curve-role `set/unset` coverage and one-shot role-revocation assertions.

## Checklist

- [x] Appropriate PR labels applied
- [x] Test coverage maintained (`just coverage`)
  - [ ] No need to add/update tests
  - [x] Tests are added/updated
- [x] Documentation maintained
  - [ ] No need to update
  - [x] Updated
