### PR TITLE
refactor: bump OpenZeppelin to 5.4.0 and adopt new utilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
   },
   "dependencies": {
     "@lodestar/types": "^1.31.0",
-    "@openzeppelin/contracts": "5.0.2",
-    "@openzeppelin/contracts-upgradeable": "5.0.2",
+    "@openzeppelin/contracts": "5.4.0",
+    "@openzeppelin/contracts-upgradeable": "5.4.0",
     "@openzeppelin/merkle-tree": "^1.0.8",
     "ds-test": "https://github.com/dapphub/ds-test",
     "forge-std": "https://github.com/foundry-rs/forge-std.git#v1.9.6",

--- a/src/Accounting.sol
+++ b/src/Accounting.sol
@@ -4,6 +4,7 @@
 pragma solidity 0.8.33;
 
 import { AccessControlEnumerableUpgradeable } from "@openzeppelin/contracts-upgradeable/access/extensions/AccessControlEnumerableUpgradeable.sol";
+import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";
 
 import { BondCore } from "./abstract/BondCore.sol";
 import { BondCurve } from "./abstract/BondCurve.sol";
@@ -424,7 +425,7 @@ contract Accounting is
         (uint256 current, uint256 required) = getBondSummaryShares(nodeOperatorId);
         current = current + feesToDistribute;
 
-        return current > required ? current - required : 0;
+        return Math.saturatingSub(current, required);
     }
 
     /// @inheritdoc IAccounting
@@ -444,9 +445,7 @@ contract Accounting is
         uint256 current = BondCore.getBond(nodeOperatorId);
         uint256 totalRequired = _getRequiredBond(nodeOperatorId, additionalKeys);
 
-        unchecked {
-            return totalRequired > current ? totalRequired - current : 0;
-        }
+        return Math.saturatingSub(totalRequired, current);
     }
 
     function _pullAndSplitFeeRewards(
@@ -507,10 +506,8 @@ contract Accounting is
 
     /// @dev Calculates claimable bond shares accounting for locked bond and withdrawn validators
     function _getClaimableBondShares(uint256 nodeOperatorId) internal view returns (uint256) {
-        unchecked {
-            (uint256 currentShares, uint256 requiredShares) = getBondSummaryShares(nodeOperatorId);
-            return currentShares > requiredShares ? currentShares - requiredShares : 0;
-        }
+        (uint256 currentShares, uint256 requiredShares) = getBondSummaryShares(nodeOperatorId);
+        return Math.saturatingSub(currentShares, requiredShares);
     }
 
     function _getRequiredBond(uint256 nodeOperatorId, uint256 additionalKeys) internal view returns (uint256) {
@@ -553,7 +550,7 @@ contract Accounting is
             currentBond + 10 wei,
             BondCurve.getBondCurveId(nodeOperatorId)
         );
-        return nonWithdrawnKeys > bondedKeys ? nonWithdrawnKeys - bondedKeys : 0;
+        return Math.saturatingSub(nonWithdrawnKeys, bondedKeys);
     }
 
     function _onlyRecoverer() internal view override {

--- a/src/CSModule.sol
+++ b/src/CSModule.sol
@@ -62,21 +62,20 @@ contract CSModule is ICSModule, BaseModule {
     ///      If the version 3 contract is deployed from scratch, the `initialize` method should be used instead.
     ///      To prevent possible frontrun this method should strictly be called in the same TX as the upgrade transaction and should not be called separately.
     function finalizeUpgradeV3() external reinitializer(INITIALIZED_VERSION) {
-        // Clean `__freeSlot1` since the storage slot is no longer needed in version 3.
-        assembly ("memory-safe") {
-            sstore(__freeSlot1.slot, 0x00)
-        }
+        Layout storage $ = _layout();
+        // Clean `Layout.freeSlot1` since the storage slot is no longer needed in version 3.
+        $.freeSlot1 = 0;
         // NOTE: Don't call `_initTopUpQueue` because it is disabled by default and existing CSM deployment can only support 0x01 validators mode.
 
         // NOTE: Rebuild the global withdrawn counter for the future.
         uint256 totalWithdrawnValidators;
         unchecked {
-            for (uint256 i; i < _nodeOperatorsCount; ++i) {
-                totalWithdrawnValidators += _nodeOperators[i].totalWithdrawnKeys;
+            for (uint256 i; i < $.nodeOperatorsCount; ++i) {
+                totalWithdrawnValidators += $.nodeOperators[i].totalWithdrawnKeys;
             }
         }
-        _totalWithdrawnValidators = totalWithdrawnValidators;
-        _upToDateOperatorDepositInfoCount = _nodeOperatorsCount;
+        $.totalWithdrawnValidators = totalWithdrawnValidators;
+        $.upToDateOperatorDepositInfoCount = $.nodeOperatorsCount;
     }
 
     /// @inheritdoc IBaseModule
@@ -114,12 +113,12 @@ contract CSModule is ICSModule, BaseModule {
 
         // NOTE: The highest priority to start iterations with. Priorities are ordered like 0, 1, 2, ...
         for (uint256 priority; depositsLeft > 0 && priority <= _queueLowestPriority(); ++priority) {
-            DepositQueueLib.Queue storage depositQueue = _depositQueueByPriority[priority];
+            DepositQueueLib.Queue storage depositQueue = _layout().depositQueueByPriority[priority];
             for (Batch item = depositQueue.peek(); !item.isNil() && depositsLeft > 0; item = depositQueue.peek()) {
                 // NOTE: see the `enqueuedCount` note below.
                 unchecked {
                     uint32 noId = uint32(item.noId());
-                    NodeOperator storage no = _nodeOperators[noId];
+                    NodeOperator storage no = _layout().nodeOperators[noId];
 
                     uint256 keysInBatch = item.keys();
 
@@ -193,9 +192,9 @@ contract CSModule is ICSModule, BaseModule {
         unchecked {
             // Deposits counts are capped by queue length (< 2^32) and the storage slots are uint64.
             // forge-lint: disable-next-line(unsafe-typecast)
-            _depositableValidatorsCount -= uint64(depositsCount);
+            _layout().depositableValidatorsCount -= uint64(depositsCount);
             // forge-lint: disable-next-line(unsafe-typecast)
-            _totalDepositedValidators += uint64(depositsCount);
+            _layout().totalDepositedValidators += uint64(depositsCount);
         }
 
         _incrementModuleNonce();
@@ -219,7 +218,7 @@ contract CSModule is ICSModule, BaseModule {
 
         // Cap top-ups so we don't over-allocate to keys that lost balance due to CL penalties.
         uint256[] memory cappedTopUpLimits = NodeOperatorOps.capTopUpLimitsByKeyBalance(
-            _keyAddedBalances,
+            _layout().keyAddedBalances,
             operatorIds,
             keyIndices,
             topUpLimits
@@ -236,7 +235,12 @@ contract CSModule is ICSModule, BaseModule {
 
         if (allocations.length == 0) return allocations;
 
-        NodeOperatorOps.increaseKeyAddedBalancesByAllocations(_keyAddedBalances, operatorIds, keyIndices, allocations);
+        NodeOperatorOps.increaseKeyAddedBalancesByAllocations(
+            _layout().keyAddedBalances,
+            operatorIds,
+            keyIndices,
+            allocations
+        );
 
         _incrementModuleNonce();
     }
@@ -323,9 +327,10 @@ contract CSModule is ICSModule, BaseModule {
         override(BaseModule, IStakingModule)
         returns (uint256 totalExitedValidators, uint256 totalDepositedValidators, uint256 depositableValidatorsCount)
     {
-        totalExitedValidators = _totalExitedValidators;
-        totalDepositedValidators = _totalDepositedValidators;
-        depositableValidatorsCount = _depositableValidatorsCount;
+        Layout storage $ = _layout();
+        totalExitedValidators = $.totalExitedValidators;
+        totalDepositedValidators = $.totalDepositedValidators;
+        depositableValidatorsCount = $.depositableValidatorsCount;
         if (_topUpQueueEnabled()) {
             depositableValidatorsCount = Math.min(depositableValidatorsCount, _topUpQueue().capacity());
         }
@@ -333,13 +338,13 @@ contract CSModule is ICSModule, BaseModule {
 
     /// @inheritdoc ICSModule
     function depositQueuePointers(uint256 queuePriority) external view returns (uint128 head, uint128 tail) {
-        DepositQueueLib.Queue storage q = _depositQueueByPriority[queuePriority];
+        DepositQueueLib.Queue storage q = _layout().depositQueueByPriority[queuePriority];
         return (q.head, q.tail);
     }
 
     /// @inheritdoc ICSModule
     function depositQueueItem(uint256 queuePriority, uint128 index) external view returns (Batch) {
-        return _depositQueueByPriority[queuePriority].at(index);
+        return _layout().depositQueueByPriority[queuePriority].at(index);
     }
 
     /// @inheritdoc ICSModule

--- a/src/CSModule.sol
+++ b/src/CSModule.sol
@@ -62,7 +62,7 @@ contract CSModule is ICSModule, BaseModule {
     ///      If the version 3 contract is deployed from scratch, the `initialize` method should be used instead.
     ///      To prevent possible frontrun this method should strictly be called in the same TX as the upgrade transaction and should not be called separately.
     function finalizeUpgradeV3() external reinitializer(INITIALIZED_VERSION) {
-        Layout storage $ = _baseStorage();
+        BaseModuleStorage storage $ = _baseStorage();
         // Clean `Layout.freeSlot1` since the storage slot is no longer needed in version 3.
         $.freeSlot1 = 0;
         // NOTE: Don't call `_initTopUpQueue` because it is disabled by default and existing CSM deployment can only support 0x01 validators mode.
@@ -289,7 +289,7 @@ contract CSModule is ICSModule, BaseModule {
         _requireDepositInfoUpToDate();
         return
             DepositQueueOps.cleanDepositQueue({
-                layout: _baseStorage(),
+                $: _baseStorage(),
                 queueLowestPriority: _queueLowestPriority(),
                 maxItems: maxItems
             });
@@ -327,7 +327,7 @@ contract CSModule is ICSModule, BaseModule {
         override(BaseModule, IStakingModule)
         returns (uint256 totalExitedValidators, uint256 totalDepositedValidators, uint256 depositableValidatorsCount)
     {
-        Layout storage $ = _baseStorage();
+        BaseModuleStorage storage $ = _baseStorage();
         totalExitedValidators = $.totalExitedValidators;
         totalDepositedValidators = $.totalDepositedValidators;
         depositableValidatorsCount = $.depositableValidatorsCount;
@@ -367,7 +367,7 @@ contract CSModule is ICSModule, BaseModule {
     ) internal override returns (bool changed) {
         changed = super._applyDepositableValidatorsCount(no, nodeOperatorId, newCount, incrementNonceIfUpdated);
         DepositQueueOps.enqueueNodeOperatorKeys({
-            layout: _baseStorage(),
+            $: _baseStorage(),
             parametersRegistry: _parametersRegistry(),
             accounting: _accounting(),
             queueLowestPriority: _queueLowestPriority(),

--- a/src/CSModule.sol
+++ b/src/CSModule.sol
@@ -286,8 +286,7 @@ contract CSModule is ICSModule, BaseModule {
         _requireDepositInfoUpToDate();
         return
             DepositQueueOps.cleanDepositQueue({
-                depositQueues: _depositQueueByPriority,
-                nodeOperators: _nodeOperators,
+                layout: _layout(),
                 queueLowestPriority: _queueLowestPriority(),
                 maxItems: maxItems
             });
@@ -364,8 +363,7 @@ contract CSModule is ICSModule, BaseModule {
     ) internal override returns (bool changed) {
         changed = super._applyDepositableValidatorsCount(no, nodeOperatorId, newCount, incrementNonceIfUpdated);
         DepositQueueOps.enqueueNodeOperatorKeys({
-            nodeOperators: _nodeOperators,
-            depositQueues: _depositQueueByPriority,
+            layout: _layout(),
             parametersRegistry: _parametersRegistry(),
             accounting: _accounting(),
             queueLowestPriority: _queueLowestPriority(),

--- a/src/CSModule.sol
+++ b/src/CSModule.sol
@@ -62,7 +62,7 @@ contract CSModule is ICSModule, BaseModule {
     ///      If the version 3 contract is deployed from scratch, the `initialize` method should be used instead.
     ///      To prevent possible frontrun this method should strictly be called in the same TX as the upgrade transaction and should not be called separately.
     function finalizeUpgradeV3() external reinitializer(INITIALIZED_VERSION) {
-        Layout storage $ = _layout();
+        Layout storage $ = _baseStorage();
         // Clean `Layout.freeSlot1` since the storage slot is no longer needed in version 3.
         $.freeSlot1 = 0;
         // NOTE: Don't call `_initTopUpQueue` because it is disabled by default and existing CSM deployment can only support 0x01 validators mode.
@@ -113,12 +113,12 @@ contract CSModule is ICSModule, BaseModule {
 
         // NOTE: The highest priority to start iterations with. Priorities are ordered like 0, 1, 2, ...
         for (uint256 priority; depositsLeft > 0 && priority <= _queueLowestPriority(); ++priority) {
-            DepositQueueLib.Queue storage depositQueue = _layout().depositQueueByPriority[priority];
+            DepositQueueLib.Queue storage depositQueue = _baseStorage().depositQueueByPriority[priority];
             for (Batch item = depositQueue.peek(); !item.isNil() && depositsLeft > 0; item = depositQueue.peek()) {
                 // NOTE: see the `enqueuedCount` note below.
                 unchecked {
                     uint32 noId = uint32(item.noId());
-                    NodeOperator storage no = _layout().nodeOperators[noId];
+                    NodeOperator storage no = _baseStorage().nodeOperators[noId];
 
                     uint256 keysInBatch = item.keys();
 
@@ -192,9 +192,9 @@ contract CSModule is ICSModule, BaseModule {
         unchecked {
             // Deposits counts are capped by queue length (< 2^32) and the storage slots are uint64.
             // forge-lint: disable-next-line(unsafe-typecast)
-            _layout().depositableValidatorsCount -= uint64(depositsCount);
+            _baseStorage().depositableValidatorsCount -= uint64(depositsCount);
             // forge-lint: disable-next-line(unsafe-typecast)
-            _layout().totalDepositedValidators += uint64(depositsCount);
+            _baseStorage().totalDepositedValidators += uint64(depositsCount);
         }
 
         _incrementModuleNonce();
@@ -218,7 +218,7 @@ contract CSModule is ICSModule, BaseModule {
 
         // Cap top-ups so we don't over-allocate to keys that lost balance due to CL penalties.
         uint256[] memory cappedTopUpLimits = NodeOperatorOps.capTopUpLimitsByKeyBalance(
-            _layout().keyAddedBalances,
+            _baseStorage().keyAddedBalances,
             operatorIds,
             keyIndices,
             topUpLimits
@@ -236,7 +236,7 @@ contract CSModule is ICSModule, BaseModule {
         if (allocations.length == 0) return allocations;
 
         NodeOperatorOps.increaseKeyAddedBalancesByAllocations(
-            _layout().keyAddedBalances,
+            _baseStorage().keyAddedBalances,
             operatorIds,
             keyIndices,
             allocations
@@ -289,7 +289,7 @@ contract CSModule is ICSModule, BaseModule {
         _requireDepositInfoUpToDate();
         return
             DepositQueueOps.cleanDepositQueue({
-                layout: _layout(),
+                layout: _baseStorage(),
                 queueLowestPriority: _queueLowestPriority(),
                 maxItems: maxItems
             });
@@ -327,7 +327,7 @@ contract CSModule is ICSModule, BaseModule {
         override(BaseModule, IStakingModule)
         returns (uint256 totalExitedValidators, uint256 totalDepositedValidators, uint256 depositableValidatorsCount)
     {
-        Layout storage $ = _layout();
+        Layout storage $ = _baseStorage();
         totalExitedValidators = $.totalExitedValidators;
         totalDepositedValidators = $.totalDepositedValidators;
         depositableValidatorsCount = $.depositableValidatorsCount;
@@ -338,13 +338,13 @@ contract CSModule is ICSModule, BaseModule {
 
     /// @inheritdoc ICSModule
     function depositQueuePointers(uint256 queuePriority) external view returns (uint128 head, uint128 tail) {
-        DepositQueueLib.Queue storage q = _layout().depositQueueByPriority[queuePriority];
+        DepositQueueLib.Queue storage q = _baseStorage().depositQueueByPriority[queuePriority];
         return (q.head, q.tail);
     }
 
     /// @inheritdoc ICSModule
     function depositQueueItem(uint256 queuePriority, uint128 index) external view returns (Batch) {
-        return _layout().depositQueueByPriority[queuePriority].at(index);
+        return _baseStorage().depositQueueByPriority[queuePriority].at(index);
     }
 
     /// @inheritdoc ICSModule
@@ -367,7 +367,7 @@ contract CSModule is ICSModule, BaseModule {
     ) internal override returns (bool changed) {
         changed = super._applyDepositableValidatorsCount(no, nodeOperatorId, newCount, incrementNonceIfUpdated);
         DepositQueueOps.enqueueNodeOperatorKeys({
-            layout: _layout(),
+            layout: _baseStorage(),
             parametersRegistry: _parametersRegistry(),
             accounting: _accounting(),
             queueLowestPriority: _queueLowestPriority(),
@@ -399,7 +399,7 @@ contract CSModule is ICSModule, BaseModule {
     }
 
     function _topUpQueue() internal view returns (TopUpQueueLib.Queue storage) {
-        CSModuleStorage storage $ = _storage();
+        CSModuleStorage storage $ = _csmStorage();
         return $.topUpQueue;
     }
 
@@ -422,7 +422,7 @@ contract CSModule is ICSModule, BaseModule {
         }
     }
 
-    function _storage() internal pure returns (CSModuleStorage storage $) {
+    function _csmStorage() internal pure returns (CSModuleStorage storage $) {
         assembly ("memory-safe") {
             $.slot := CSMODULE_STORAGE_LOCATION
         }

--- a/src/CuratedModule.sol
+++ b/src/CuratedModule.sol
@@ -61,7 +61,7 @@ contract CuratedModule is ICuratedModule, BaseModule {
         _requireDepositInfoUpToDate();
 
         // TODO: think about changing to list of structs
-        Layout storage $ = _baseStorage();
+        BaseModuleStorage storage $ = _baseStorage();
         (uint256 allocated, uint256[] memory operatorIds, uint256[] memory allocations) = CuratedDepositAllocator
             .allocateInitialDeposits($.nodeOperators, $.nodeOperatorsCount, depositsCount);
         if (allocated == 0) return (publicKeys, signatures);
@@ -217,7 +217,7 @@ contract CuratedModule is ICuratedModule, BaseModule {
         uint256 maxDepositAmount
     ) external view returns (uint256 allocated, uint256[] memory operatorIds, uint256[] memory allocations) {
         _requireDepositInfoUpToDate();
-        Layout storage $ = _baseStorage();
+        BaseModuleStorage storage $ = _baseStorage();
         uint256 operatorsCount = $.nodeOperatorsCount;
         if (maxDepositAmount == 0 || operatorsCount == 0) return (0, new uint256[](0), new uint256[](0));
 
@@ -265,7 +265,7 @@ contract CuratedModule is ICuratedModule, BaseModule {
         uint256[] calldata keyIndices,
         uint256[] memory topUpLimits
     ) internal returns (uint256[] memory allocations) {
-        Layout storage $ = _baseStorage();
+        BaseModuleStorage storage $ = _baseStorage();
         uint256[] memory uniqueOperatorIds = _uniqueOperatorIds(operatorIds);
         (, uint256[] memory allocatedOperatorIds, uint256[] memory operatorAllocations) = CuratedDepositAllocator
             .allocateTopUps({

--- a/src/CuratedModule.sol
+++ b/src/CuratedModule.sol
@@ -61,8 +61,9 @@ contract CuratedModule is ICuratedModule, BaseModule {
         _requireDepositInfoUpToDate();
 
         // TODO: think about changing to list of structs
+        Layout storage $ = _layout();
         (uint256 allocated, uint256[] memory operatorIds, uint256[] memory allocations) = CuratedDepositAllocator
-            .allocateInitialDeposits(_nodeOperators, _nodeOperatorsCount, depositsCount);
+            .allocateInitialDeposits($.nodeOperators, $.nodeOperatorsCount, depositsCount);
         if (allocated == 0) return (publicKeys, signatures);
         (publicKeys, signatures) = SigningKeys.initKeysSigsBuf(allocated);
 
@@ -70,7 +71,7 @@ contract CuratedModule is ICuratedModule, BaseModule {
         for (uint256 i; i < allocations.length; ++i) {
             uint256 allocation = allocations[i];
             uint256 operatorId = operatorIds[i];
-            NodeOperator storage no = _nodeOperators[operatorId];
+            NodeOperator storage no = $.nodeOperators[operatorId];
 
             SigningKeys.loadKeysSigs({
                 nodeOperatorId: operatorId,
@@ -104,10 +105,10 @@ contract CuratedModule is ICuratedModule, BaseModule {
         unchecked {
             // `allocated` is capped by _depositableValidatorsCount which is uint64.
             // forge-lint: disable-next-line(unsafe-typecast)
-            _depositableValidatorsCount -= uint64(allocated);
+            $.depositableValidatorsCount -= uint64(allocated);
             // `allocated` is capped by _depositableValidatorsCount which is uint64.
             // forge-lint: disable-next-line(unsafe-typecast)
-            _totalDepositedValidators += uint64(allocated);
+            $.totalDepositedValidators += uint64(allocated);
         }
 
         _incrementModuleNonce();
@@ -142,7 +143,7 @@ contract CuratedModule is ICuratedModule, BaseModule {
 
         // Cap top-ups so we don't over-allocate to keys that lost balance due to CL penalties.
         uint256[] memory cappedTopUpLimits = NodeOperatorOps.capTopUpLimitsByKeyBalance(
-            _keyAddedBalances,
+            _layout().keyAddedBalances,
             operatorIds,
             keyIndices,
             topUpLimits
@@ -158,7 +159,7 @@ contract CuratedModule is ICuratedModule, BaseModule {
         _checkStakingRouterRole();
         CuratedOperatorBalancesOps.applyReportedBalances(
             _storage().operatorBalances,
-            _nodeOperatorsCount,
+            _layout().nodeOperatorsCount,
             operatorIds,
             totalBalancesGwei
         );
@@ -172,7 +173,12 @@ contract CuratedModule is ICuratedModule, BaseModule {
         address newRewardAddress
     ) external {
         _checkRole(OPERATOR_ADDRESSES_ADMIN_ROLE);
-        NOAddresses.changeNodeOperatorAddresses(_nodeOperators, nodeOperatorId, newManagerAddress, newRewardAddress);
+        NOAddresses.changeNodeOperatorAddresses(
+            _layout().nodeOperators,
+            nodeOperatorId,
+            newManagerAddress,
+            newRewardAddress
+        );
     }
 
     /// @inheritdoc ICuratedModule
@@ -180,7 +186,7 @@ contract CuratedModule is ICuratedModule, BaseModule {
         if (msg.sender != address(_metaRegistry())) revert SenderIsNotMetaRegistry();
         if (newWeight == 0) {
             _applyDepositableValidatorsCount({
-                no: _nodeOperators[nodeOperatorId],
+                no: _layout().nodeOperators[nodeOperatorId],
                 nodeOperatorId: nodeOperatorId,
                 newCount: 0,
                 incrementNonceIfUpdated: false
@@ -211,7 +217,8 @@ contract CuratedModule is ICuratedModule, BaseModule {
         uint256 maxDepositAmount
     ) external view returns (uint256 allocated, uint256[] memory operatorIds, uint256[] memory allocations) {
         _requireDepositInfoUpToDate();
-        uint256 operatorsCount = _nodeOperatorsCount;
+        Layout storage $ = _layout();
+        uint256 operatorsCount = $.nodeOperatorsCount;
         if (maxDepositAmount == 0 || operatorsCount == 0) return (0, new uint256[](0), new uint256[](0));
 
         uint256[] memory allOperatorIds = new uint256[](operatorsCount);
@@ -220,7 +227,7 @@ contract CuratedModule is ICuratedModule, BaseModule {
         }
 
         (allocated, operatorIds, allocations) = CuratedDepositAllocator.allocateTopUps({
-            nodeOperators: _nodeOperators,
+            nodeOperators: $.nodeOperators,
             nodeOperatorBalances: _storage().operatorBalances,
             operatorsCount: operatorsCount,
             allocationAmount: maxDepositAmount,
@@ -258,12 +265,13 @@ contract CuratedModule is ICuratedModule, BaseModule {
         uint256[] calldata keyIndices,
         uint256[] memory topUpLimits
     ) internal returns (uint256[] memory allocations) {
+        Layout storage $ = _layout();
         uint256[] memory uniqueOperatorIds = _uniqueOperatorIds(operatorIds);
         (, uint256[] memory allocatedOperatorIds, uint256[] memory operatorAllocations) = CuratedDepositAllocator
             .allocateTopUps({
-                nodeOperators: _nodeOperators,
+                nodeOperators: $.nodeOperators,
                 nodeOperatorBalances: _storage().operatorBalances,
-                operatorsCount: _nodeOperatorsCount,
+                operatorsCount: $.nodeOperatorsCount,
                 allocationAmount: maxDepositAmount,
                 operatorIds: uniqueOperatorIds
             });
@@ -274,10 +282,10 @@ contract CuratedModule is ICuratedModule, BaseModule {
             topUpLimits: topUpLimits,
             allocatedOperatorIds: allocatedOperatorIds,
             operatorAllocations: operatorAllocations,
-            operatorsCount: _nodeOperatorsCount
+            operatorsCount: $.nodeOperatorsCount
         });
 
-        NodeOperatorOps.increaseKeyAddedBalancesByAllocations(_keyAddedBalances, operatorIds, keyIndices, allocations);
+        NodeOperatorOps.increaseKeyAddedBalancesByAllocations($.keyAddedBalances, operatorIds, keyIndices, allocations);
         CuratedOperatorBalancesOps.increaseByAllocations(
             _storage().operatorBalances,
             uniqueOperatorIds,
@@ -314,7 +322,7 @@ contract CuratedModule is ICuratedModule, BaseModule {
         for (uint256 i; i < pubkeys.length; ++i) {
             uint256 operatorId = operatorIds[i];
             uint256 keyIndex = keyIndices[i];
-            if (keyIndex >= _nodeOperators[operatorId].totalDepositedKeys) revert SigningKeysInvalidOffset();
+            if (keyIndex >= _layout().nodeOperators[operatorId].totalDepositedKeys) revert SigningKeysInvalidOffset();
             SigningKeys.verifySigningKey(operatorId, keyIndex, pubkeys[i]);
         }
     }

--- a/src/CuratedModule.sol
+++ b/src/CuratedModule.sol
@@ -61,7 +61,7 @@ contract CuratedModule is ICuratedModule, BaseModule {
         _requireDepositInfoUpToDate();
 
         // TODO: think about changing to list of structs
-        Layout storage $ = _layout();
+        Layout storage $ = _baseStorage();
         (uint256 allocated, uint256[] memory operatorIds, uint256[] memory allocations) = CuratedDepositAllocator
             .allocateInitialDeposits($.nodeOperators, $.nodeOperatorsCount, depositsCount);
         if (allocated == 0) return (publicKeys, signatures);
@@ -97,7 +97,7 @@ contract CuratedModule is ICuratedModule, BaseModule {
             emit DepositableSigningKeysCountChanged(operatorId, depositableValidatorsCount);
 
             CuratedOperatorBalancesOps.increaseBalance(
-                _storage().operatorBalances,
+                _curatedStorage().operatorBalances,
                 operatorId,
                 allocation * CuratedDepositAllocator.MIN_ACTIVATION_BALANCE
             );
@@ -143,7 +143,7 @@ contract CuratedModule is ICuratedModule, BaseModule {
 
         // Cap top-ups so we don't over-allocate to keys that lost balance due to CL penalties.
         uint256[] memory cappedTopUpLimits = NodeOperatorOps.capTopUpLimitsByKeyBalance(
-            _layout().keyAddedBalances,
+            _baseStorage().keyAddedBalances,
             operatorIds,
             keyIndices,
             topUpLimits
@@ -158,8 +158,8 @@ contract CuratedModule is ICuratedModule, BaseModule {
     function updateOperatorBalances(bytes calldata operatorIds, bytes calldata totalBalancesGwei) external {
         _checkStakingRouterRole();
         CuratedOperatorBalancesOps.applyReportedBalances(
-            _storage().operatorBalances,
-            _layout().nodeOperatorsCount,
+            _curatedStorage().operatorBalances,
+            _baseStorage().nodeOperatorsCount,
             operatorIds,
             totalBalancesGwei
         );
@@ -174,7 +174,7 @@ contract CuratedModule is ICuratedModule, BaseModule {
     ) external {
         _checkRole(OPERATOR_ADDRESSES_ADMIN_ROLE);
         NOAddresses.changeNodeOperatorAddresses(
-            _layout().nodeOperators,
+            _baseStorage().nodeOperators,
             nodeOperatorId,
             newManagerAddress,
             newRewardAddress
@@ -186,7 +186,7 @@ contract CuratedModule is ICuratedModule, BaseModule {
         if (msg.sender != address(_metaRegistry())) revert SenderIsNotMetaRegistry();
         if (newWeight == 0) {
             _applyDepositableValidatorsCount({
-                no: _layout().nodeOperators[nodeOperatorId],
+                no: _baseStorage().nodeOperators[nodeOperatorId],
                 nodeOperatorId: nodeOperatorId,
                 newCount: 0,
                 incrementNonceIfUpdated: false
@@ -209,7 +209,7 @@ contract CuratedModule is ICuratedModule, BaseModule {
 
     /// @inheritdoc ICuratedModule
     function getNodeOperatorBalance(uint256 operatorId) external view returns (uint256) {
-        return _storage().operatorBalances[operatorId];
+        return _curatedStorage().operatorBalances[operatorId];
     }
 
     /// @inheritdoc ICuratedModule
@@ -217,7 +217,7 @@ contract CuratedModule is ICuratedModule, BaseModule {
         uint256 maxDepositAmount
     ) external view returns (uint256 allocated, uint256[] memory operatorIds, uint256[] memory allocations) {
         _requireDepositInfoUpToDate();
-        Layout storage $ = _layout();
+        Layout storage $ = _baseStorage();
         uint256 operatorsCount = $.nodeOperatorsCount;
         if (maxDepositAmount == 0 || operatorsCount == 0) return (0, new uint256[](0), new uint256[](0));
 
@@ -228,7 +228,7 @@ contract CuratedModule is ICuratedModule, BaseModule {
 
         (allocated, operatorIds, allocations) = CuratedDepositAllocator.allocateTopUps({
             nodeOperators: $.nodeOperators,
-            nodeOperatorBalances: _storage().operatorBalances,
+            nodeOperatorBalances: _curatedStorage().operatorBalances,
             operatorsCount: operatorsCount,
             allocationAmount: maxDepositAmount,
             operatorIds: allOperatorIds
@@ -265,12 +265,12 @@ contract CuratedModule is ICuratedModule, BaseModule {
         uint256[] calldata keyIndices,
         uint256[] memory topUpLimits
     ) internal returns (uint256[] memory allocations) {
-        Layout storage $ = _layout();
+        Layout storage $ = _baseStorage();
         uint256[] memory uniqueOperatorIds = _uniqueOperatorIds(operatorIds);
         (, uint256[] memory allocatedOperatorIds, uint256[] memory operatorAllocations) = CuratedDepositAllocator
             .allocateTopUps({
                 nodeOperators: $.nodeOperators,
-                nodeOperatorBalances: _storage().operatorBalances,
+                nodeOperatorBalances: _curatedStorage().operatorBalances,
                 operatorsCount: $.nodeOperatorsCount,
                 allocationAmount: maxDepositAmount,
                 operatorIds: uniqueOperatorIds
@@ -287,7 +287,7 @@ contract CuratedModule is ICuratedModule, BaseModule {
 
         NodeOperatorOps.increaseKeyAddedBalancesByAllocations($.keyAddedBalances, operatorIds, keyIndices, allocations);
         CuratedOperatorBalancesOps.increaseByAllocations(
-            _storage().operatorBalances,
+            _curatedStorage().operatorBalances,
             uniqueOperatorIds,
             perOperatorIncrements
         );
@@ -322,7 +322,8 @@ contract CuratedModule is ICuratedModule, BaseModule {
         for (uint256 i; i < pubkeys.length; ++i) {
             uint256 operatorId = operatorIds[i];
             uint256 keyIndex = keyIndices[i];
-            if (keyIndex >= _layout().nodeOperators[operatorId].totalDepositedKeys) revert SigningKeysInvalidOffset();
+            if (keyIndex >= _baseStorage().nodeOperators[operatorId].totalDepositedKeys)
+                revert SigningKeysInvalidOffset();
             SigningKeys.verifySigningKey(operatorId, keyIndex, pubkeys[i]);
         }
     }
@@ -337,7 +338,7 @@ contract CuratedModule is ICuratedModule, BaseModule {
         }
     }
 
-    function _storage() internal pure returns (CuratedModuleStorage storage $) {
+    function _curatedStorage() internal pure returns (CuratedModuleStorage storage $) {
         assembly ("memory-safe") {
             $.slot := CURATED_MODULE_STORAGE_LOCATION
         }

--- a/src/FeeDistributor.sol
+++ b/src/FeeDistributor.sol
@@ -4,6 +4,7 @@
 pragma solidity 0.8.33;
 
 import { MerkleProof } from "@openzeppelin/contracts/utils/cryptography/MerkleProof.sol";
+import { Strings } from "@openzeppelin/contracts/utils/Strings.sol";
 import { AccessControlEnumerableUpgradeable } from "@openzeppelin/contracts-upgradeable/access/extensions/AccessControlEnumerableUpgradeable.sol";
 import { Initializable } from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 
@@ -122,7 +123,7 @@ contract FeeDistributor is IFeeDistributor, Initializable, AccessControlEnumerab
         if (distributed == 0 && rebate > 0) revert InvalidReportData();
         if (distributed > 0) {
             if (bytes(_treeCid).length == 0) revert InvalidTreeCid();
-            if (keccak256(bytes(_treeCid)) == keccak256(bytes(treeCid))) revert InvalidTreeCid();
+            if (Strings.equal(_treeCid, treeCid)) revert InvalidTreeCid();
             if (_treeRoot == bytes32(0)) revert InvalidTreeRoot();
             if (_treeRoot == treeRoot) revert InvalidTreeRoot();
 
@@ -147,7 +148,7 @@ contract FeeDistributor is IFeeDistributor, Initializable, AccessControlEnumerab
         if (bytes(_logCid).length == 0) revert InvalidLogCID();
         // NOTE: Make sure off-chain tooling provides a distinct CID of a log even for empty reports, e.g. by mixing
         // in a frame identifier such as reference slot to a file.
-        if (keccak256(bytes(_logCid)) == keccak256(bytes(logCid))) revert InvalidLogCID();
+        if (Strings.equal(_logCid, logCid)) revert InvalidLogCID();
 
         logCid = _logCid;
         emit DistributionLogUpdated(_logCid);

--- a/src/ValidatorStrikes.sol
+++ b/src/ValidatorStrikes.sol
@@ -4,6 +4,7 @@
 pragma solidity 0.8.33;
 
 import { MerkleProof } from "@openzeppelin/contracts/utils/cryptography/MerkleProof.sol";
+import { Strings } from "@openzeppelin/contracts/utils/Strings.sol";
 import { Initializable } from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import { AccessControlEnumerableUpgradeable } from "@openzeppelin/contracts-upgradeable/access/extensions/AccessControlEnumerableUpgradeable.sol";
 
@@ -80,7 +81,7 @@ contract ValidatorStrikes is IValidatorStrikes, Initializable, AccessControlEnum
         }
 
         bool isSameRoot = _treeRoot == treeRoot;
-        bool isSameCid = keccak256(bytes(_treeCid)) == keccak256(bytes(treeCid));
+        bool isSameCid = Strings.equal(_treeCid, treeCid);
         if (isSameRoot != isSameCid) revert InvalidReportData();
         if (!isSameRoot) {
             treeRoot = _treeRoot;

--- a/src/abstract/BaseModule.sol
+++ b/src/abstract/BaseModule.sol
@@ -82,22 +82,23 @@ abstract contract BaseModule is
         address /* referrer */
     ) public virtual whenResumed returns (uint256 nodeOperatorId) {
         _checkCreateNodeOperatorRole();
-        nodeOperatorId = _nodeOperatorsCount;
+        Layout storage $ = _layout();
+        nodeOperatorId = $.nodeOperatorsCount;
 
         NodeOperatorOps.createNodeOperator({
-            nodeOperators: _nodeOperators,
+            nodeOperators: $.nodeOperators,
             nodeOperatorId: nodeOperatorId,
             from: from,
             managementProperties: managementProperties
         });
 
         unchecked {
-            ++_nodeOperatorsCount;
+            ++$.nodeOperatorsCount;
         }
 
         // If all operators have up-to-date deposit info, then the new operator also has it, so we can just increase the counter.
-        if (nodeOperatorId == _upToDateOperatorDepositInfoCount) {
-            ++_upToDateOperatorDepositInfoCount;
+        if (nodeOperatorId == $.upToDateOperatorDepositInfoCount) {
+            ++$.upToDateOperatorDepositInfoCount;
         }
         _incrementModuleNonce();
     }
@@ -160,32 +161,32 @@ abstract contract BaseModule is
 
     /// @inheritdoc IBaseModule
     function proposeNodeOperatorManagerAddressChange(uint256 nodeOperatorId, address proposedAddress) external {
-        NOAddresses.proposeNodeOperatorManagerAddressChange(_nodeOperators, nodeOperatorId, proposedAddress);
+        NOAddresses.proposeNodeOperatorManagerAddressChange(_layout().nodeOperators, nodeOperatorId, proposedAddress);
     }
 
     /// @inheritdoc IBaseModule
     function confirmNodeOperatorManagerAddressChange(uint256 nodeOperatorId) external {
-        NOAddresses.confirmNodeOperatorManagerAddressChange(_nodeOperators, nodeOperatorId);
+        NOAddresses.confirmNodeOperatorManagerAddressChange(_layout().nodeOperators, nodeOperatorId);
     }
 
     /// @inheritdoc IBaseModule
     function proposeNodeOperatorRewardAddressChange(uint256 nodeOperatorId, address proposedAddress) external {
-        NOAddresses.proposeNodeOperatorRewardAddressChange(_nodeOperators, nodeOperatorId, proposedAddress);
+        NOAddresses.proposeNodeOperatorRewardAddressChange(_layout().nodeOperators, nodeOperatorId, proposedAddress);
     }
 
     /// @inheritdoc IBaseModule
     function confirmNodeOperatorRewardAddressChange(uint256 nodeOperatorId) external {
-        NOAddresses.confirmNodeOperatorRewardAddressChange(_nodeOperators, nodeOperatorId);
+        NOAddresses.confirmNodeOperatorRewardAddressChange(_layout().nodeOperators, nodeOperatorId);
     }
 
     /// @inheritdoc IBaseModule
     function resetNodeOperatorManagerAddress(uint256 nodeOperatorId) external {
-        NOAddresses.resetNodeOperatorManagerAddress(_nodeOperators, nodeOperatorId);
+        NOAddresses.resetNodeOperatorManagerAddress(_layout().nodeOperators, nodeOperatorId);
     }
 
     /// @inheritdoc IBaseModule
     function changeNodeOperatorRewardAddress(uint256 nodeOperatorId, address newAddress) external {
-        NOAddresses.changeNodeOperatorRewardAddress(_nodeOperators, nodeOperatorId, newAddress);
+        NOAddresses.changeNodeOperatorRewardAddress(_layout().nodeOperators, nodeOperatorId, newAddress);
     }
 
     /// @inheritdoc IStakingModule
@@ -202,10 +203,11 @@ abstract contract BaseModule is
         bytes calldata exitedValidatorsCounts
     ) external {
         _checkStakingRouterRole();
-        _totalExitedValidators = NodeOperatorOps.updateExitedValidatorsCount({
-            nodeOperators: _nodeOperators,
-            nodeOperatorsCount: _nodeOperatorsCount,
-            totalExitedValidators: _totalExitedValidators,
+        Layout storage $ = _layout();
+        $.totalExitedValidators = NodeOperatorOps.updateExitedValidatorsCount({
+            nodeOperators: $.nodeOperators,
+            nodeOperatorsCount: $.nodeOperatorsCount,
+            totalExitedValidators: $.totalExitedValidators,
             nodeOperatorIds: nodeOperatorIds,
             exitedValidatorsCounts: exitedValidatorsCounts
         });
@@ -215,12 +217,13 @@ abstract contract BaseModule is
     /// @inheritdoc IStakingModule
     function unsafeUpdateValidatorsCount(uint256 nodeOperatorId, uint256 exitedValidatorsCount) external {
         _checkStakingRouterRole();
-        _totalExitedValidators = NodeOperatorOps.unsafeUpdateValidatorsCount({
-            nodeOperators: _nodeOperators,
-            nodeOperatorsCount: _nodeOperatorsCount,
+        Layout storage $ = _layout();
+        $.totalExitedValidators = NodeOperatorOps.unsafeUpdateValidatorsCount({
+            nodeOperators: $.nodeOperators,
+            nodeOperatorsCount: $.nodeOperatorsCount,
             nodeOperatorId: nodeOperatorId,
             exitedValidatorsCount: exitedValidatorsCount,
-            totalExitedValidators: _totalExitedValidators
+            totalExitedValidators: $.totalExitedValidators
         });
     }
 
@@ -232,7 +235,7 @@ abstract contract BaseModule is
     ) external {
         _checkStakingRouterRole();
 
-        NodeOperatorOps.setTargetLimit(_nodeOperators, nodeOperatorId, targetLimitMode, targetLimit);
+        NodeOperatorOps.setTargetLimit(_layout().nodeOperators, nodeOperatorId, targetLimitMode, targetLimit);
 
         _updateDepositableValidatorsCount({ nodeOperatorId: nodeOperatorId, incrementNonceIfUpdated: false });
         _incrementModuleNonce();
@@ -304,12 +307,13 @@ abstract contract BaseModule is
     function reportValidatorSlashing(uint256 nodeOperatorId, uint256 keyIndex) external {
         _checkVerifierRole();
         _onlyExistingNodeOperator(nodeOperatorId);
-        NodeOperator storage no = _nodeOperators[nodeOperatorId];
+        Layout storage $ = _layout();
+        NodeOperator storage no = $.nodeOperators[nodeOperatorId];
         if (keyIndex >= no.totalDepositedKeys) revert SigningKeysInvalidOffset();
 
         uint256 pointer = KeyPointerLib.keyPointer(nodeOperatorId, keyIndex);
-        if (_isValidatorSlashed[pointer]) revert ValidatorSlashingAlreadyReported();
-        _isValidatorSlashed[pointer] = true;
+        if ($.isValidatorSlashed[pointer]) revert ValidatorSlashingAlreadyReported();
+        $.isValidatorSlashed[pointer] = true;
 
         bytes memory pubkey = SigningKeys.loadKeys(nodeOperatorId, keyIndex, 1);
         emit ValidatorSlashingReported(nodeOperatorId, keyIndex, pubkey);
@@ -380,7 +384,7 @@ abstract contract BaseModule is
     /// @inheritdoc IBaseModule
     function requestFullDepositInfoUpdate() external {
         _canRequestDepositInfoUpdate();
-        _upToDateOperatorDepositInfoCount = 0;
+        _layout().upToDateOperatorDepositInfoCount = 0;
         emit FullDepositInfoUpdateRequested();
         _incrementModuleNonce();
     }
@@ -389,8 +393,9 @@ abstract contract BaseModule is
     function batchDepositInfoUpdate(uint256 maxCount) external returns (uint256 operatorsLeft) {
         if (maxCount == 0) revert InvalidInput();
 
-        uint256 operatorsCount = _nodeOperatorsCount;
-        uint256 noId = _upToDateOperatorDepositInfoCount;
+        Layout storage $ = _layout();
+        uint256 operatorsCount = $.nodeOperatorsCount;
+        uint256 noId = $.upToDateOperatorDepositInfoCount;
         if (noId == operatorsCount) return 0;
 
         uint256 limit = noId + maxCount > operatorsCount ? operatorsCount : noId + maxCount;
@@ -399,7 +404,7 @@ abstract contract BaseModule is
             _updateDepositInfo(noId);
         }
 
-        _upToDateOperatorDepositInfoCount = limit;
+        $.upToDateOperatorDepositInfoCount = limit;
         operatorsLeft = operatorsCount - limit;
 
         if (operatorsLeft == 0) emit NodeOperatorDepositInfoFullyUpdated();
@@ -418,9 +423,10 @@ abstract contract BaseModule is
         virtual
         returns (uint256 totalExitedValidators, uint256 totalDepositedValidators, uint256 depositableValidatorsCount)
     {
-        totalExitedValidators = _totalExitedValidators;
-        totalDepositedValidators = _totalDepositedValidators;
-        depositableValidatorsCount = _depositableValidatorsCount;
+        Layout storage $ = _layout();
+        totalExitedValidators = $.totalExitedValidators;
+        totalDepositedValidators = $.totalDepositedValidators;
+        depositableValidatorsCount = $.depositableValidatorsCount;
     }
 
     /// @inheritdoc IStakingModule
@@ -429,7 +435,7 @@ abstract contract BaseModule is
     ///      withdrawal credentials.
     function onWithdrawalCredentialsChanged() external view {
         _checkStakingRouterRole();
-        if (_depositableValidatorsCount > 0) revert DepositableKeysWithUnsupportedWithdrawalCredentials();
+        if (_layout().depositableValidatorsCount > 0) revert DepositableKeysWithUnsupportedWithdrawalCredentials();
     }
 
     /// @inheritdoc IBaseModule
@@ -439,12 +445,12 @@ abstract contract BaseModule is
 
     /// @inheritdoc IBaseModule
     function isValidatorSlashed(uint256 nodeOperatorId, uint256 keyIndex) external view returns (bool) {
-        return _isValidatorSlashed[KeyPointerLib.keyPointer(nodeOperatorId, keyIndex)];
+        return _layout().isValidatorSlashed[KeyPointerLib.keyPointer(nodeOperatorId, keyIndex)];
     }
 
     /// @inheritdoc IBaseModule
     function isValidatorWithdrawn(uint256 nodeOperatorId, uint256 keyIndex) external view returns (bool) {
-        return _isValidatorWithdrawn[KeyPointerLib.keyPointer(nodeOperatorId, keyIndex)];
+        return _layout().isValidatorWithdrawn[KeyPointerLib.keyPointer(nodeOperatorId, keyIndex)];
     }
 
     /// @inheritdoc IStakingModule
@@ -454,26 +460,26 @@ abstract contract BaseModule is
 
     /// @inheritdoc IBaseModule
     function getNodeOperator(uint256 nodeOperatorId) external view returns (NodeOperator memory) {
-        return _nodeOperators[nodeOperatorId];
+        return _layout().nodeOperators[nodeOperatorId];
     }
 
     /// @inheritdoc IBaseModule
     function getNodeOperatorManagementProperties(
         uint256 nodeOperatorId
     ) external view returns (NodeOperatorManagementProperties memory) {
-        NodeOperator storage no = _nodeOperators[nodeOperatorId];
+        NodeOperator storage no = _layout().nodeOperators[nodeOperatorId];
         return (NodeOperatorManagementProperties(no.managerAddress, no.rewardAddress, no.extendedManagerPermissions));
     }
 
     /// @inheritdoc IBaseModule
     function getNodeOperatorOwner(uint256 nodeOperatorId) external view returns (address) {
-        NodeOperator storage no = _nodeOperators[nodeOperatorId];
+        NodeOperator storage no = _layout().nodeOperators[nodeOperatorId];
         return no.extendedManagerPermissions ? no.managerAddress : no.rewardAddress;
     }
 
     /// @inheritdoc IBaseModule
     function getNodeOperatorNonWithdrawnKeys(uint256 nodeOperatorId) external view returns (uint256) {
-        NodeOperator storage no = _nodeOperators[nodeOperatorId];
+        NodeOperator storage no = _layout().nodeOperators[nodeOperatorId];
         unchecked {
             return no.totalAddedKeys - no.totalWithdrawnKeys;
         }
@@ -503,7 +509,7 @@ abstract contract BaseModule is
             uint256 depositableValidatorsCount
         )
     {
-        return NodeOperatorOps.getNodeOperatorSummary(_nodeOperators, nodeOperatorId, _accounting());
+        return NodeOperatorOps.getNodeOperatorSummary(_layout().nodeOperators, nodeOperatorId, _accounting());
     }
 
     /// @inheritdoc IBaseModule
@@ -538,22 +544,22 @@ abstract contract BaseModule is
 
     /// @inheritdoc IStakingModule
     function getNonce() external view returns (uint256) {
-        return _nonce;
+        return _layout().nonce;
     }
 
     /// @inheritdoc IStakingModule
     function getNodeOperatorsCount() external view returns (uint256) {
-        return _nodeOperatorsCount;
+        return _layout().nodeOperatorsCount;
     }
 
     /// @inheritdoc IStakingModule
     function getActiveNodeOperatorsCount() external view returns (uint256) {
-        return _nodeOperatorsCount;
+        return _layout().nodeOperatorsCount;
     }
 
     /// @inheritdoc IStakingModule
     function getNodeOperatorIsActive(uint256 nodeOperatorId) external view returns (bool) {
-        return nodeOperatorId < _nodeOperatorsCount;
+        return nodeOperatorId < _layout().nodeOperatorsCount;
     }
 
     /// @inheritdoc IStakingModule
@@ -561,7 +567,7 @@ abstract contract BaseModule is
         uint256 offset,
         uint256 limit
     ) external view returns (uint256[] memory nodeOperatorIds) {
-        return NodeOperatorOps.getNodeOperatorIds(_nodeOperatorsCount, offset, limit);
+        return NodeOperatorOps.getNodeOperatorIds(_layout().nodeOperatorsCount, offset, limit);
     }
 
     /// @inheritdoc IStakingModule
@@ -584,12 +590,13 @@ abstract contract BaseModule is
 
     /// @inheritdoc IBaseModule
     function getKeyAddedBalance(uint256 nodeOperatorId, uint256 keyIndex) external view returns (uint256) {
-        return _keyAddedBalances[KeyPointerLib.keyPointer(nodeOperatorId, keyIndex)];
+        return _layout().keyAddedBalances[KeyPointerLib.keyPointer(nodeOperatorId, keyIndex)];
     }
 
     /// @inheritdoc IBaseModule
     function getNodeOperatorDepositInfoToUpdateCount() external view returns (uint256 count) {
-        count = _nodeOperatorsCount - _upToDateOperatorDepositInfoCount;
+        Layout storage $ = _layout();
+        count = $.nodeOperatorsCount - $.upToDateOperatorDepositInfoCount;
     }
 
     // solhint-disable-next-line func-name-mixedcase
@@ -617,7 +624,7 @@ abstract contract BaseModule is
         if (touchedCount == 0) return;
 
         unchecked {
-            _totalWithdrawnValidators += touchedCount;
+            _layout().totalWithdrawnValidators += touchedCount;
         }
         for (uint256 i; i < touchedCount; ++i) {
             _updateDepositableValidatorsCount({
@@ -631,7 +638,7 @@ abstract contract BaseModule is
 
     function _incrementModuleNonce() internal {
         unchecked {
-            emit NonceChanged(++_nonce);
+            emit NonceChanged(++_layout().nonce);
         }
     }
 
@@ -642,7 +649,7 @@ abstract contract BaseModule is
         bytes calldata signatures
     ) internal virtual {
         NodeOperatorOps.addKeys({
-            nodeOperators: _nodeOperators,
+            nodeOperators: _layout().nodeOperators,
             nodeOperatorId: nodeOperatorId,
             keysCount: keysCount,
             publicKeys: publicKeys,
@@ -660,9 +667,9 @@ abstract contract BaseModule is
     ) internal returns (bool changed) {
         return
             _applyDepositableValidatorsCount({
-                no: _nodeOperators[nodeOperatorId],
+                no: _layout().nodeOperators[nodeOperatorId],
                 nodeOperatorId: nodeOperatorId,
-                newCount: NodeOperatorOps.calculateDepositableValidatorsCount(_nodeOperators, nodeOperatorId),
+                newCount: NodeOperatorOps.calculateDepositableValidatorsCount(_layout().nodeOperators, nodeOperatorId),
                 incrementNonceIfUpdated: incrementNonceIfUpdated
             });
     }
@@ -675,7 +682,7 @@ abstract contract BaseModule is
     ) internal virtual {
         _onlyNodeOperatorManager(nodeOperatorId, msg.sender);
         NodeOperatorOps.removeKeys({
-            nodeOperators: _nodeOperators,
+            nodeOperators: _layout().nodeOperators,
             nodeOperatorId: nodeOperatorId,
             startIndex: startIndex,
             keysCount: keysCount,
@@ -696,8 +703,8 @@ abstract contract BaseModule is
 
         // Updating the global counter.
         unchecked {
-            _depositableValidatorsCount =
-                _depositableValidatorsCount -
+            _layout().depositableValidatorsCount =
+                _layout().depositableValidatorsCount -
                 no.depositableValidatorsCount +
                 // Each term is bounded by uint32 counts, so fitting into uint64 is safe.
                 // forge-lint: disable-next-line(unsafe-typecast)
@@ -720,19 +727,20 @@ abstract contract BaseModule is
     }
 
     function _onlyNodeOperatorManager(uint256 nodeOperatorId, address from) internal view {
-        address managerAddress = _nodeOperators[nodeOperatorId].managerAddress;
+        address managerAddress = _layout().nodeOperators[nodeOperatorId].managerAddress;
         if (managerAddress == address(0)) revert NodeOperatorDoesNotExist();
         if (managerAddress != from) revert SenderIsNotEligible();
     }
 
     function _onlyExistingNodeOperator(uint256 nodeOperatorId) internal view {
-        if (nodeOperatorId < _nodeOperatorsCount) return;
+        if (nodeOperatorId < _layout().nodeOperatorsCount) return;
 
         revert NodeOperatorDoesNotExist();
     }
 
     function _onlyValidIndexRange(uint256 nodeOperatorId, uint256 startIndex, uint256 keysCount) internal view {
-        if (startIndex + keysCount > _nodeOperators[nodeOperatorId].totalAddedKeys) revert SigningKeysInvalidOffset();
+        if (startIndex + keysCount > _layout().nodeOperators[nodeOperatorId].totalAddedKeys)
+            revert SigningKeysInvalidOffset();
     }
 
     function _getBondCurveId(uint256 nodeOperatorId) internal view returns (uint256) {
@@ -779,7 +787,8 @@ abstract contract BaseModule is
     }
 
     function _requireDepositInfoUpToDate() internal view {
-        if (_upToDateOperatorDepositInfoCount != _nodeOperatorsCount) revert DepositInfoIsNotUpToDate();
+        Layout storage $ = _layout();
+        if ($.upToDateOperatorDepositInfoCount != $.nodeOperatorsCount) revert DepositInfoIsNotUpToDate();
     }
 
     /// @dev Default implementation of the guard for requesting deposit info update.

--- a/src/abstract/BaseModule.sol
+++ b/src/abstract/BaseModule.sol
@@ -82,7 +82,7 @@ abstract contract BaseModule is
         address /* referrer */
     ) public virtual whenResumed returns (uint256 nodeOperatorId) {
         _checkCreateNodeOperatorRole();
-        Layout storage $ = _baseStorage();
+        BaseModuleStorage storage $ = _baseStorage();
         nodeOperatorId = $.nodeOperatorsCount;
 
         NodeOperatorOps.createNodeOperator({
@@ -211,28 +211,14 @@ abstract contract BaseModule is
         bytes calldata exitedValidatorsCounts
     ) external {
         _checkStakingRouterRole();
-        Layout storage $ = _baseStorage();
-        $.totalExitedValidators = NodeOperatorOps.updateExitedValidatorsCount({
-            nodeOperators: $.nodeOperators,
-            nodeOperatorsCount: $.nodeOperatorsCount,
-            totalExitedValidators: $.totalExitedValidators,
-            nodeOperatorIds: nodeOperatorIds,
-            exitedValidatorsCounts: exitedValidatorsCounts
-        });
+        NodeOperatorOps.updateExitedValidatorsCount(_baseStorage(), nodeOperatorIds, exitedValidatorsCounts);
     }
 
     /// @dev DEPRECATED: Should be removed in the future versions.
     /// @inheritdoc IStakingModule
     function unsafeUpdateValidatorsCount(uint256 nodeOperatorId, uint256 exitedValidatorsCount) external {
         _checkStakingRouterRole();
-        Layout storage $ = _baseStorage();
-        $.totalExitedValidators = NodeOperatorOps.unsafeUpdateValidatorsCount({
-            nodeOperators: $.nodeOperators,
-            nodeOperatorsCount: $.nodeOperatorsCount,
-            nodeOperatorId: nodeOperatorId,
-            exitedValidatorsCount: exitedValidatorsCount,
-            totalExitedValidators: $.totalExitedValidators
-        });
+        NodeOperatorOps.unsafeUpdateValidatorsCount(_baseStorage(), nodeOperatorId, exitedValidatorsCount);
     }
 
     /// @inheritdoc IStakingModule
@@ -315,7 +301,7 @@ abstract contract BaseModule is
     function reportValidatorSlashing(uint256 nodeOperatorId, uint256 keyIndex) external {
         _checkVerifierRole();
         _onlyExistingNodeOperator(nodeOperatorId);
-        Layout storage $ = _baseStorage();
+        BaseModuleStorage storage $ = _baseStorage();
         NodeOperator storage no = $.nodeOperators[nodeOperatorId];
         if (keyIndex >= no.totalDepositedKeys) revert SigningKeysInvalidOffset();
 
@@ -336,7 +322,7 @@ abstract contract BaseModule is
         _checkVerifierRole();
 
         NodeOperatorOps.reportValidatorBalance({
-            layout: _baseStorage(),
+            $: _baseStorage(),
             nodeOperatorId: nodeOperatorId,
             keyIndex: keyIndex,
             currentBalanceWei: currentBalanceWei
@@ -401,7 +387,7 @@ abstract contract BaseModule is
     function batchDepositInfoUpdate(uint256 maxCount) external returns (uint256 operatorsLeft) {
         if (maxCount == 0) revert InvalidInput();
 
-        Layout storage $ = _baseStorage();
+        BaseModuleStorage storage $ = _baseStorage();
         uint256 operatorsCount = $.nodeOperatorsCount;
         uint256 noId = $.upToDateOperatorDepositInfoCount;
         if (noId == operatorsCount) return 0;
@@ -431,7 +417,7 @@ abstract contract BaseModule is
         virtual
         returns (uint256 totalExitedValidators, uint256 totalDepositedValidators, uint256 depositableValidatorsCount)
     {
-        Layout storage $ = _baseStorage();
+        BaseModuleStorage storage $ = _baseStorage();
         totalExitedValidators = $.totalExitedValidators;
         totalDepositedValidators = $.totalDepositedValidators;
         depositableValidatorsCount = $.depositableValidatorsCount;
@@ -603,7 +589,7 @@ abstract contract BaseModule is
 
     /// @inheritdoc IBaseModule
     function getNodeOperatorDepositInfoToUpdateCount() external view returns (uint256 count) {
-        Layout storage $ = _baseStorage();
+        BaseModuleStorage storage $ = _baseStorage();
         count = $.nodeOperatorsCount - $.upToDateOperatorDepositInfoCount;
     }
 
@@ -798,7 +784,7 @@ abstract contract BaseModule is
     }
 
     function _requireDepositInfoUpToDate() internal view {
-        Layout storage $ = _baseStorage();
+        BaseModuleStorage storage $ = _baseStorage();
         if ($.upToDateOperatorDepositInfoCount != $.nodeOperatorsCount) revert DepositInfoIsNotUpToDate();
     }
 

--- a/src/abstract/BaseModule.sol
+++ b/src/abstract/BaseModule.sol
@@ -244,12 +244,7 @@ abstract contract BaseModule is
         bytes calldata vettedSigningKeysCounts
     ) external {
         _checkStakingRouterRole();
-        NodeOperatorOps.decreaseVettedSigningKeysCount(
-            _nodeOperators,
-            _nodeOperatorsCount,
-            nodeOperatorIds,
-            vettedSigningKeysCounts
-        );
+        NodeOperatorOps.decreaseVettedSigningKeysCount(_layout(), nodeOperatorIds, vettedSigningKeysCounts);
     }
 
     /// @inheritdoc IBaseModule
@@ -329,9 +324,7 @@ abstract contract BaseModule is
         _checkVerifierRole();
 
         NodeOperatorOps.reportValidatorBalance({
-            nodeOperators: _nodeOperators,
-            nodeOperatorsCount: _nodeOperatorsCount,
-            keyAddedBalances: _keyAddedBalances,
+            layout: _layout(),
             nodeOperatorId: nodeOperatorId,
             keyIndex: keyIndex,
             currentBalanceWei: currentBalanceWei
@@ -615,30 +608,25 @@ abstract contract BaseModule is
     }
 
     function _reportWithdrawnValidators(WithdrawnValidatorInfo[] calldata validatorInfos, bool slashed) internal {
-        bool anySubmission;
+        (uint256[] memory touchedOperatorIds, uint256 touchedCount) = WithdrawnValidatorLib.processBatch(
+            validatorInfos,
+            slashed,
+            _layout()
+        );
 
-        for (uint256 i; i < validatorInfos.length; ++i) {
-            WithdrawnValidatorInfo calldata info = validatorInfos[i];
-            _onlyExistingNodeOperator(info.nodeOperatorId);
+        if (touchedCount == 0) return;
 
-            uint256 pointer = KeyPointerLib.keyPointer(info.nodeOperatorId, info.keyIndex);
-            if (_isValidatorWithdrawn[pointer]) continue;
-            if (info.isSlashed != slashed) revert InvalidWithdrawnValidatorInfo();
-            if (info.isSlashed && !_isValidatorSlashed[pointer]) revert SlashingPenaltyIsNotApplicable();
-
-            NodeOperator storage no = _nodeOperators[info.nodeOperatorId];
-            WithdrawnValidatorLib.process(no, info, _keyAddedBalances[pointer]);
-
-            _updateDepositableValidatorsCount({ nodeOperatorId: info.nodeOperatorId, incrementNonceIfUpdated: false });
-
-            _isValidatorWithdrawn[pointer] = true;
-            unchecked {
-                ++_totalWithdrawnValidators;
-            }
-            anySubmission = true;
+        unchecked {
+            _totalWithdrawnValidators += touchedCount;
+        }
+        for (uint256 i; i < touchedCount; ++i) {
+            _updateDepositableValidatorsCount({
+                nodeOperatorId: touchedOperatorIds[i],
+                incrementNonceIfUpdated: false
+            });
         }
 
-        if (anySubmission) _incrementModuleNonce();
+        _incrementModuleNonce();
     }
 
     function _incrementModuleNonce() internal {

--- a/src/abstract/BaseModule.sol
+++ b/src/abstract/BaseModule.sol
@@ -82,7 +82,7 @@ abstract contract BaseModule is
         address /* referrer */
     ) public virtual whenResumed returns (uint256 nodeOperatorId) {
         _checkCreateNodeOperatorRole();
-        Layout storage $ = _layout();
+        Layout storage $ = _baseStorage();
         nodeOperatorId = $.nodeOperatorsCount;
 
         NodeOperatorOps.createNodeOperator({
@@ -161,32 +161,40 @@ abstract contract BaseModule is
 
     /// @inheritdoc IBaseModule
     function proposeNodeOperatorManagerAddressChange(uint256 nodeOperatorId, address proposedAddress) external {
-        NOAddresses.proposeNodeOperatorManagerAddressChange(_layout().nodeOperators, nodeOperatorId, proposedAddress);
+        NOAddresses.proposeNodeOperatorManagerAddressChange(
+            _baseStorage().nodeOperators,
+            nodeOperatorId,
+            proposedAddress
+        );
     }
 
     /// @inheritdoc IBaseModule
     function confirmNodeOperatorManagerAddressChange(uint256 nodeOperatorId) external {
-        NOAddresses.confirmNodeOperatorManagerAddressChange(_layout().nodeOperators, nodeOperatorId);
+        NOAddresses.confirmNodeOperatorManagerAddressChange(_baseStorage().nodeOperators, nodeOperatorId);
     }
 
     /// @inheritdoc IBaseModule
     function proposeNodeOperatorRewardAddressChange(uint256 nodeOperatorId, address proposedAddress) external {
-        NOAddresses.proposeNodeOperatorRewardAddressChange(_layout().nodeOperators, nodeOperatorId, proposedAddress);
+        NOAddresses.proposeNodeOperatorRewardAddressChange(
+            _baseStorage().nodeOperators,
+            nodeOperatorId,
+            proposedAddress
+        );
     }
 
     /// @inheritdoc IBaseModule
     function confirmNodeOperatorRewardAddressChange(uint256 nodeOperatorId) external {
-        NOAddresses.confirmNodeOperatorRewardAddressChange(_layout().nodeOperators, nodeOperatorId);
+        NOAddresses.confirmNodeOperatorRewardAddressChange(_baseStorage().nodeOperators, nodeOperatorId);
     }
 
     /// @inheritdoc IBaseModule
     function resetNodeOperatorManagerAddress(uint256 nodeOperatorId) external {
-        NOAddresses.resetNodeOperatorManagerAddress(_layout().nodeOperators, nodeOperatorId);
+        NOAddresses.resetNodeOperatorManagerAddress(_baseStorage().nodeOperators, nodeOperatorId);
     }
 
     /// @inheritdoc IBaseModule
     function changeNodeOperatorRewardAddress(uint256 nodeOperatorId, address newAddress) external {
-        NOAddresses.changeNodeOperatorRewardAddress(_layout().nodeOperators, nodeOperatorId, newAddress);
+        NOAddresses.changeNodeOperatorRewardAddress(_baseStorage().nodeOperators, nodeOperatorId, newAddress);
     }
 
     /// @inheritdoc IStakingModule
@@ -203,7 +211,7 @@ abstract contract BaseModule is
         bytes calldata exitedValidatorsCounts
     ) external {
         _checkStakingRouterRole();
-        Layout storage $ = _layout();
+        Layout storage $ = _baseStorage();
         $.totalExitedValidators = NodeOperatorOps.updateExitedValidatorsCount({
             nodeOperators: $.nodeOperators,
             nodeOperatorsCount: $.nodeOperatorsCount,
@@ -217,7 +225,7 @@ abstract contract BaseModule is
     /// @inheritdoc IStakingModule
     function unsafeUpdateValidatorsCount(uint256 nodeOperatorId, uint256 exitedValidatorsCount) external {
         _checkStakingRouterRole();
-        Layout storage $ = _layout();
+        Layout storage $ = _baseStorage();
         $.totalExitedValidators = NodeOperatorOps.unsafeUpdateValidatorsCount({
             nodeOperators: $.nodeOperators,
             nodeOperatorsCount: $.nodeOperatorsCount,
@@ -235,7 +243,7 @@ abstract contract BaseModule is
     ) external {
         _checkStakingRouterRole();
 
-        NodeOperatorOps.setTargetLimit(_layout().nodeOperators, nodeOperatorId, targetLimitMode, targetLimit);
+        NodeOperatorOps.setTargetLimit(_baseStorage().nodeOperators, nodeOperatorId, targetLimitMode, targetLimit);
 
         _updateDepositableValidatorsCount({ nodeOperatorId: nodeOperatorId, incrementNonceIfUpdated: false });
         _incrementModuleNonce();
@@ -247,7 +255,7 @@ abstract contract BaseModule is
         bytes calldata vettedSigningKeysCounts
     ) external {
         _checkStakingRouterRole();
-        NodeOperatorOps.decreaseVettedSigningKeysCount(_layout(), nodeOperatorIds, vettedSigningKeysCounts);
+        NodeOperatorOps.decreaseVettedSigningKeysCount(_baseStorage(), nodeOperatorIds, vettedSigningKeysCounts);
     }
 
     /// @inheritdoc IBaseModule
@@ -307,7 +315,7 @@ abstract contract BaseModule is
     function reportValidatorSlashing(uint256 nodeOperatorId, uint256 keyIndex) external {
         _checkVerifierRole();
         _onlyExistingNodeOperator(nodeOperatorId);
-        Layout storage $ = _layout();
+        Layout storage $ = _baseStorage();
         NodeOperator storage no = $.nodeOperators[nodeOperatorId];
         if (keyIndex >= no.totalDepositedKeys) revert SigningKeysInvalidOffset();
 
@@ -328,7 +336,7 @@ abstract contract BaseModule is
         _checkVerifierRole();
 
         NodeOperatorOps.reportValidatorBalance({
-            layout: _layout(),
+            layout: _baseStorage(),
             nodeOperatorId: nodeOperatorId,
             keyIndex: keyIndex,
             currentBalanceWei: currentBalanceWei
@@ -384,7 +392,7 @@ abstract contract BaseModule is
     /// @inheritdoc IBaseModule
     function requestFullDepositInfoUpdate() external {
         _canRequestDepositInfoUpdate();
-        _layout().upToDateOperatorDepositInfoCount = 0;
+        _baseStorage().upToDateOperatorDepositInfoCount = 0;
         emit FullDepositInfoUpdateRequested();
         _incrementModuleNonce();
     }
@@ -393,7 +401,7 @@ abstract contract BaseModule is
     function batchDepositInfoUpdate(uint256 maxCount) external returns (uint256 operatorsLeft) {
         if (maxCount == 0) revert InvalidInput();
 
-        Layout storage $ = _layout();
+        Layout storage $ = _baseStorage();
         uint256 operatorsCount = $.nodeOperatorsCount;
         uint256 noId = $.upToDateOperatorDepositInfoCount;
         if (noId == operatorsCount) return 0;
@@ -423,7 +431,7 @@ abstract contract BaseModule is
         virtual
         returns (uint256 totalExitedValidators, uint256 totalDepositedValidators, uint256 depositableValidatorsCount)
     {
-        Layout storage $ = _layout();
+        Layout storage $ = _baseStorage();
         totalExitedValidators = $.totalExitedValidators;
         totalDepositedValidators = $.totalDepositedValidators;
         depositableValidatorsCount = $.depositableValidatorsCount;
@@ -435,7 +443,7 @@ abstract contract BaseModule is
     ///      withdrawal credentials.
     function onWithdrawalCredentialsChanged() external view {
         _checkStakingRouterRole();
-        if (_layout().depositableValidatorsCount > 0) revert DepositableKeysWithUnsupportedWithdrawalCredentials();
+        if (_baseStorage().depositableValidatorsCount > 0) revert DepositableKeysWithUnsupportedWithdrawalCredentials();
     }
 
     /// @inheritdoc IBaseModule
@@ -445,12 +453,12 @@ abstract contract BaseModule is
 
     /// @inheritdoc IBaseModule
     function isValidatorSlashed(uint256 nodeOperatorId, uint256 keyIndex) external view returns (bool) {
-        return _layout().isValidatorSlashed[KeyPointerLib.keyPointer(nodeOperatorId, keyIndex)];
+        return _baseStorage().isValidatorSlashed[KeyPointerLib.keyPointer(nodeOperatorId, keyIndex)];
     }
 
     /// @inheritdoc IBaseModule
     function isValidatorWithdrawn(uint256 nodeOperatorId, uint256 keyIndex) external view returns (bool) {
-        return _layout().isValidatorWithdrawn[KeyPointerLib.keyPointer(nodeOperatorId, keyIndex)];
+        return _baseStorage().isValidatorWithdrawn[KeyPointerLib.keyPointer(nodeOperatorId, keyIndex)];
     }
 
     /// @inheritdoc IStakingModule
@@ -460,26 +468,26 @@ abstract contract BaseModule is
 
     /// @inheritdoc IBaseModule
     function getNodeOperator(uint256 nodeOperatorId) external view returns (NodeOperator memory) {
-        return _layout().nodeOperators[nodeOperatorId];
+        return _baseStorage().nodeOperators[nodeOperatorId];
     }
 
     /// @inheritdoc IBaseModule
     function getNodeOperatorManagementProperties(
         uint256 nodeOperatorId
     ) external view returns (NodeOperatorManagementProperties memory) {
-        NodeOperator storage no = _layout().nodeOperators[nodeOperatorId];
+        NodeOperator storage no = _baseStorage().nodeOperators[nodeOperatorId];
         return (NodeOperatorManagementProperties(no.managerAddress, no.rewardAddress, no.extendedManagerPermissions));
     }
 
     /// @inheritdoc IBaseModule
     function getNodeOperatorOwner(uint256 nodeOperatorId) external view returns (address) {
-        NodeOperator storage no = _layout().nodeOperators[nodeOperatorId];
+        NodeOperator storage no = _baseStorage().nodeOperators[nodeOperatorId];
         return no.extendedManagerPermissions ? no.managerAddress : no.rewardAddress;
     }
 
     /// @inheritdoc IBaseModule
     function getNodeOperatorNonWithdrawnKeys(uint256 nodeOperatorId) external view returns (uint256) {
-        NodeOperator storage no = _layout().nodeOperators[nodeOperatorId];
+        NodeOperator storage no = _baseStorage().nodeOperators[nodeOperatorId];
         unchecked {
             return no.totalAddedKeys - no.totalWithdrawnKeys;
         }
@@ -509,7 +517,7 @@ abstract contract BaseModule is
             uint256 depositableValidatorsCount
         )
     {
-        return NodeOperatorOps.getNodeOperatorSummary(_layout().nodeOperators, nodeOperatorId, _accounting());
+        return NodeOperatorOps.getNodeOperatorSummary(_baseStorage().nodeOperators, nodeOperatorId, _accounting());
     }
 
     /// @inheritdoc IBaseModule
@@ -544,22 +552,22 @@ abstract contract BaseModule is
 
     /// @inheritdoc IStakingModule
     function getNonce() external view returns (uint256) {
-        return _layout().nonce;
+        return _baseStorage().nonce;
     }
 
     /// @inheritdoc IStakingModule
     function getNodeOperatorsCount() external view returns (uint256) {
-        return _layout().nodeOperatorsCount;
+        return _baseStorage().nodeOperatorsCount;
     }
 
     /// @inheritdoc IStakingModule
     function getActiveNodeOperatorsCount() external view returns (uint256) {
-        return _layout().nodeOperatorsCount;
+        return _baseStorage().nodeOperatorsCount;
     }
 
     /// @inheritdoc IStakingModule
     function getNodeOperatorIsActive(uint256 nodeOperatorId) external view returns (bool) {
-        return nodeOperatorId < _layout().nodeOperatorsCount;
+        return nodeOperatorId < _baseStorage().nodeOperatorsCount;
     }
 
     /// @inheritdoc IStakingModule
@@ -567,7 +575,7 @@ abstract contract BaseModule is
         uint256 offset,
         uint256 limit
     ) external view returns (uint256[] memory nodeOperatorIds) {
-        return NodeOperatorOps.getNodeOperatorIds(_layout().nodeOperatorsCount, offset, limit);
+        return NodeOperatorOps.getNodeOperatorIds(_baseStorage().nodeOperatorsCount, offset, limit);
     }
 
     /// @inheritdoc IStakingModule
@@ -590,12 +598,12 @@ abstract contract BaseModule is
 
     /// @inheritdoc IBaseModule
     function getKeyAddedBalance(uint256 nodeOperatorId, uint256 keyIndex) external view returns (uint256) {
-        return _layout().keyAddedBalances[KeyPointerLib.keyPointer(nodeOperatorId, keyIndex)];
+        return _baseStorage().keyAddedBalances[KeyPointerLib.keyPointer(nodeOperatorId, keyIndex)];
     }
 
     /// @inheritdoc IBaseModule
     function getNodeOperatorDepositInfoToUpdateCount() external view returns (uint256 count) {
-        Layout storage $ = _layout();
+        Layout storage $ = _baseStorage();
         count = $.nodeOperatorsCount - $.upToDateOperatorDepositInfoCount;
     }
 
@@ -618,13 +626,13 @@ abstract contract BaseModule is
         (uint256[] memory touchedOperatorIds, uint256 touchedCount) = WithdrawnValidatorLib.processBatch(
             validatorInfos,
             slashed,
-            _layout()
+            _baseStorage()
         );
 
         if (touchedCount == 0) return;
 
         unchecked {
-            _layout().totalWithdrawnValidators += touchedCount;
+            _baseStorage().totalWithdrawnValidators += touchedCount;
         }
         for (uint256 i; i < touchedCount; ++i) {
             _updateDepositableValidatorsCount({
@@ -638,7 +646,7 @@ abstract contract BaseModule is
 
     function _incrementModuleNonce() internal {
         unchecked {
-            emit NonceChanged(++_layout().nonce);
+            emit NonceChanged(++_baseStorage().nonce);
         }
     }
 
@@ -649,7 +657,7 @@ abstract contract BaseModule is
         bytes calldata signatures
     ) internal virtual {
         NodeOperatorOps.addKeys({
-            nodeOperators: _layout().nodeOperators,
+            nodeOperators: _baseStorage().nodeOperators,
             nodeOperatorId: nodeOperatorId,
             keysCount: keysCount,
             publicKeys: publicKeys,
@@ -667,9 +675,12 @@ abstract contract BaseModule is
     ) internal returns (bool changed) {
         return
             _applyDepositableValidatorsCount({
-                no: _layout().nodeOperators[nodeOperatorId],
+                no: _baseStorage().nodeOperators[nodeOperatorId],
                 nodeOperatorId: nodeOperatorId,
-                newCount: NodeOperatorOps.calculateDepositableValidatorsCount(_layout().nodeOperators, nodeOperatorId),
+                newCount: NodeOperatorOps.calculateDepositableValidatorsCount(
+                    _baseStorage().nodeOperators,
+                    nodeOperatorId
+                ),
                 incrementNonceIfUpdated: incrementNonceIfUpdated
             });
     }
@@ -682,7 +693,7 @@ abstract contract BaseModule is
     ) internal virtual {
         _onlyNodeOperatorManager(nodeOperatorId, msg.sender);
         NodeOperatorOps.removeKeys({
-            nodeOperators: _layout().nodeOperators,
+            nodeOperators: _baseStorage().nodeOperators,
             nodeOperatorId: nodeOperatorId,
             startIndex: startIndex,
             keysCount: keysCount,
@@ -703,8 +714,8 @@ abstract contract BaseModule is
 
         // Updating the global counter.
         unchecked {
-            _layout().depositableValidatorsCount =
-                _layout().depositableValidatorsCount -
+            _baseStorage().depositableValidatorsCount =
+                _baseStorage().depositableValidatorsCount -
                 no.depositableValidatorsCount +
                 // Each term is bounded by uint32 counts, so fitting into uint64 is safe.
                 // forge-lint: disable-next-line(unsafe-typecast)
@@ -727,19 +738,19 @@ abstract contract BaseModule is
     }
 
     function _onlyNodeOperatorManager(uint256 nodeOperatorId, address from) internal view {
-        address managerAddress = _layout().nodeOperators[nodeOperatorId].managerAddress;
+        address managerAddress = _baseStorage().nodeOperators[nodeOperatorId].managerAddress;
         if (managerAddress == address(0)) revert NodeOperatorDoesNotExist();
         if (managerAddress != from) revert SenderIsNotEligible();
     }
 
     function _onlyExistingNodeOperator(uint256 nodeOperatorId) internal view {
-        if (nodeOperatorId < _layout().nodeOperatorsCount) return;
+        if (nodeOperatorId < _baseStorage().nodeOperatorsCount) return;
 
         revert NodeOperatorDoesNotExist();
     }
 
     function _onlyValidIndexRange(uint256 nodeOperatorId, uint256 startIndex, uint256 keysCount) internal view {
-        if (startIndex + keysCount > _layout().nodeOperators[nodeOperatorId].totalAddedKeys)
+        if (startIndex + keysCount > _baseStorage().nodeOperators[nodeOperatorId].totalAddedKeys)
             revert SigningKeysInvalidOffset();
     }
 
@@ -787,7 +798,7 @@ abstract contract BaseModule is
     }
 
     function _requireDepositInfoUpToDate() internal view {
-        Layout storage $ = _layout();
+        Layout storage $ = _baseStorage();
         if ($.upToDateOperatorDepositInfoCount != $.nodeOperatorsCount) revert DepositInfoIsNotUpToDate();
     }
 

--- a/src/abstract/MerkleGate.sol
+++ b/src/abstract/MerkleGate.sol
@@ -5,6 +5,7 @@ pragma solidity 0.8.33;
 
 import { AccessControlEnumerableUpgradeable } from "@openzeppelin/contracts-upgradeable/access/extensions/AccessControlEnumerableUpgradeable.sol";
 import { MerkleProof } from "@openzeppelin/contracts/utils/cryptography/MerkleProof.sol";
+import { Strings } from "@openzeppelin/contracts/utils/Strings.sol";
 
 import { AssetRecoverer } from "./AssetRecoverer.sol";
 import { PausableWithRoles } from "./PausableWithRoles.sol";
@@ -77,7 +78,7 @@ abstract contract MerkleGate is IMerkleGate, AccessControlEnumerableUpgradeable,
         if (treeRoot_ == bytes32(0)) revert InvalidTreeRoot();
         if (treeRoot_ == treeRoot) revert InvalidTreeRoot();
         if (bytes(treeCid_).length == 0) revert InvalidTreeCid();
-        if (keccak256(bytes(treeCid_)) == keccak256(bytes(treeCid))) revert InvalidTreeCid();
+        if (Strings.equal(treeCid_, treeCid)) revert InvalidTreeCid();
 
         treeRoot = treeRoot_;
         treeCid = treeCid_;

--- a/src/abstract/ModuleLinearStorage.sol
+++ b/src/abstract/ModuleLinearStorage.sol
@@ -10,7 +10,7 @@ import { DepositQueueLib } from "../lib/DepositQueueLib.sol";
 abstract contract ModuleLinearStorage {
     /// @dev Linear storage layout of the module. All state lives in a single struct
     ///      accessed via `_baseStorage()` at slot 0.
-    struct Layout {
+    struct BaseModuleStorage {
         /// @dev Having this mapping here to preserve the current layout of the storage of the CSModule.
         mapping(uint256 priority => DepositQueueLib.Queue queue) depositQueueByPriority;
         bytes32 freeSlot1;
@@ -29,7 +29,7 @@ abstract contract ModuleLinearStorage {
         uint64 nodeOperatorsCount;
     }
 
-    function _baseStorage() internal pure returns (Layout storage $) {
+    function _baseStorage() internal pure returns (BaseModuleStorage storage $) {
         assembly ("memory-safe") {
             // ModuleLinearStorage starts at slot 0 in the current inheritance layout.
             $.slot := 0

--- a/src/abstract/ModuleLinearStorage.sol
+++ b/src/abstract/ModuleLinearStorage.sol
@@ -9,7 +9,7 @@ import { DepositQueueLib } from "../lib/DepositQueueLib.sol";
 
 abstract contract ModuleLinearStorage {
     /// @dev Linear storage layout of the module. All state lives in a single struct
-    ///      accessed via `_layout()` at slot 0.
+    ///      accessed via `_baseStorage()` at slot 0.
     struct Layout {
         /// @dev Having this mapping here to preserve the current layout of the storage of the CSModule.
         mapping(uint256 priority => DepositQueueLib.Queue queue) depositQueueByPriority;
@@ -29,7 +29,7 @@ abstract contract ModuleLinearStorage {
         uint64 nodeOperatorsCount;
     }
 
-    function _layout() internal pure returns (Layout storage $) {
+    function _baseStorage() internal pure returns (Layout storage $) {
         assembly ("memory-safe") {
             // ModuleLinearStorage starts at slot 0 in the current inheritance layout.
             $.slot := 0

--- a/src/abstract/ModuleLinearStorage.sol
+++ b/src/abstract/ModuleLinearStorage.sol
@@ -27,4 +27,29 @@ abstract contract ModuleLinearStorage {
     uint64 internal _totalExitedValidators;
     uint64 internal _depositableValidatorsCount;
     uint64 internal _nodeOperatorsCount;
+
+    /// @dev Mirror of the linear storage layout used to pass module storage as a single struct pointer.
+    ///      Field order and types must stay in sync with the variables above.
+    struct Layout {
+        mapping(uint256 priority => DepositQueueLib.Queue queue) depositQueueByPriority;
+        bytes32 freeSlot1;
+        uint256 upToDateOperatorDepositInfoCount;
+        uint256 totalWithdrawnValidators;
+        mapping(uint256 noKeyIndexPacked => uint256) keyAddedBalances;
+        uint256 nonce;
+        mapping(uint256 nodeOperatorId => NodeOperator) nodeOperators;
+        mapping(uint256 noKeyIndexPacked => bool) isValidatorWithdrawn;
+        mapping(uint256 noKeyIndexPacked => bool) isValidatorSlashed;
+        uint64 totalDepositedValidators;
+        uint64 totalExitedValidators;
+        uint64 depositableValidatorsCount;
+        uint64 nodeOperatorsCount;
+    }
+
+    function _layout() internal pure returns (Layout storage $) {
+        assembly ("memory-safe") {
+            // ModuleLinearStorage starts at slot 0 in the current inheritance layout.
+            $.slot := 0
+        }
+    }
 }

--- a/src/abstract/ModuleLinearStorage.sol
+++ b/src/abstract/ModuleLinearStorage.sol
@@ -8,36 +8,19 @@ import { NodeOperator } from "../interfaces/IBaseModule.sol";
 import { DepositQueueLib } from "../lib/DepositQueueLib.sol";
 
 abstract contract ModuleLinearStorage {
-    /// @dev Having this mapping here to preserve the current layout of the storage of the CSModule.
-    mapping(uint256 priority => DepositQueueLib.Queue queue) internal _depositQueueByPriority;
-
-    bytes32 internal __freeSlot1;
-    uint256 internal _upToDateOperatorDepositInfoCount;
-    /// @dev Total number of withdrawn validators reported for the module.
-    uint256 internal _totalWithdrawnValidators;
-    mapping(uint256 noKeyIndexPacked => uint256) internal _keyAddedBalances;
-
-    uint256 internal _nonce;
-    mapping(uint256 nodeOperatorId => NodeOperator) internal _nodeOperators;
-    /// @dev see KeyPointerLib.keyPointer function for details of noKeyIndexPacked structure
-    mapping(uint256 noKeyIndexPacked => bool) internal _isValidatorWithdrawn;
-    mapping(uint256 noKeyIndexPacked => bool) internal _isValidatorSlashed;
-
-    uint64 internal _totalDepositedValidators;
-    uint64 internal _totalExitedValidators;
-    uint64 internal _depositableValidatorsCount;
-    uint64 internal _nodeOperatorsCount;
-
-    /// @dev Mirror of the linear storage layout used to pass module storage as a single struct pointer.
-    ///      Field order and types must stay in sync with the variables above.
+    /// @dev Linear storage layout of the module. All state lives in a single struct
+    ///      accessed via `_layout()` at slot 0.
     struct Layout {
+        /// @dev Having this mapping here to preserve the current layout of the storage of the CSModule.
         mapping(uint256 priority => DepositQueueLib.Queue queue) depositQueueByPriority;
         bytes32 freeSlot1;
         uint256 upToDateOperatorDepositInfoCount;
+        /// @dev Total number of withdrawn validators reported for the module.
         uint256 totalWithdrawnValidators;
         mapping(uint256 noKeyIndexPacked => uint256) keyAddedBalances;
         uint256 nonce;
         mapping(uint256 nodeOperatorId => NodeOperator) nodeOperators;
+        /// @dev see KeyPointerLib.keyPointer function for details of noKeyIndexPacked structure
         mapping(uint256 noKeyIndexPacked => bool) isValidatorWithdrawn;
         mapping(uint256 noKeyIndexPacked => bool) isValidatorSlashed;
         uint64 totalDepositedValidators;

--- a/src/lib/DepositQueueOps.sol
+++ b/src/lib/DepositQueueOps.sol
@@ -17,7 +17,7 @@ library DepositQueueOps {
     using TransientUintUintMapLib for TransientUintUintMap;
 
     function cleanDepositQueue(
-        ModuleLinearStorage.Layout storage layout,
+        ModuleLinearStorage.BaseModuleStorage storage $,
         uint256 queueLowestPriority,
         uint256 maxItems
     ) external returns (uint256 removed, uint256 lastRemovedAtDepth) {
@@ -37,14 +37,14 @@ library DepositQueueOps {
         uint256 priority = 0;
 
         while (priority <= queueLowestPriority) {
-            queue = layout.depositQueueByPriority[priority];
+            queue = $.depositQueueByPriority[priority];
 
             (
                 uint256 removedPerQueue,
                 uint256 lastRemovedAtDepthPerQueue,
                 uint256 visitedPerQueue,
                 bool reachedOutOfQueue
-            ) = _clean(queue, layout.nodeOperators, maxItems, queueLookup);
+            ) = _clean(queue, $.nodeOperators, maxItems, queueLookup);
 
             if (removedPerQueue > 0) {
                 unchecked {
@@ -77,13 +77,13 @@ library DepositQueueOps {
     }
 
     function enqueueNodeOperatorKeys(
-        ModuleLinearStorage.Layout storage layout,
+        ModuleLinearStorage.BaseModuleStorage storage $,
         IParametersRegistry parametersRegistry,
         IAccounting accounting,
         uint256 queueLowestPriority,
         uint256 nodeOperatorId
     ) external {
-        NodeOperator storage no = layout.nodeOperators[nodeOperatorId];
+        NodeOperator storage no = $.nodeOperators[nodeOperatorId];
         uint32 depositable = no.depositableValidatorsCount;
         uint32 enqueued = no.enqueuedCount;
         if (depositable <= enqueued) return;
@@ -106,7 +106,7 @@ library DepositQueueOps {
                     if (count > priorityDepositsLeft) count = priorityDepositsLeft;
 
                     _enqueueNodeOperatorKeys({
-                        queue: layout.depositQueueByPriority[priority],
+                        queue: $.depositQueueByPriority[priority],
                         no: no,
                         nodeOperatorId: nodeOperatorId,
                         queuePriority: priority,
@@ -118,7 +118,7 @@ library DepositQueueOps {
         }
         if (toEnqueue > 0) {
             _enqueueNodeOperatorKeys({
-                queue: layout.depositQueueByPriority[queueLowestPriority],
+                queue: $.depositQueueByPriority[queueLowestPriority],
                 no: no,
                 nodeOperatorId: nodeOperatorId,
                 queuePriority: queueLowestPriority,

--- a/src/lib/DepositQueueOps.sol
+++ b/src/lib/DepositQueueOps.sol
@@ -7,6 +7,7 @@ import { IAccounting } from "../interfaces/IAccounting.sol";
 import { ICSModule } from "../interfaces/ICSModule.sol";
 import { IParametersRegistry } from "../interfaces/IParametersRegistry.sol";
 import { NodeOperator } from "../interfaces/IBaseModule.sol";
+import { ModuleLinearStorage } from "../abstract/ModuleLinearStorage.sol";
 
 import { TransientUintUintMap, TransientUintUintMapLib } from "./TransientUintUintMapLib.sol";
 import { Batch, DepositQueueLib } from "./DepositQueueLib.sol";
@@ -16,8 +17,7 @@ library DepositQueueOps {
     using TransientUintUintMapLib for TransientUintUintMap;
 
     function cleanDepositQueue(
-        mapping(uint256 => DepositQueueLib.Queue) storage depositQueues,
-        mapping(uint256 => NodeOperator) storage nodeOperators,
+        ModuleLinearStorage.Layout storage layout,
         uint256 queueLowestPriority,
         uint256 maxItems
     ) external returns (uint256 removed, uint256 lastRemovedAtDepth) {
@@ -37,14 +37,14 @@ library DepositQueueOps {
         uint256 priority = 0;
 
         while (priority <= queueLowestPriority) {
-            queue = depositQueues[priority];
+            queue = layout.depositQueueByPriority[priority];
 
             (
                 uint256 removedPerQueue,
                 uint256 lastRemovedAtDepthPerQueue,
                 uint256 visitedPerQueue,
                 bool reachedOutOfQueue
-            ) = _clean(queue, nodeOperators, maxItems, queueLookup);
+            ) = _clean(queue, layout.nodeOperators, maxItems, queueLookup);
 
             if (removedPerQueue > 0) {
                 unchecked {
@@ -77,14 +77,13 @@ library DepositQueueOps {
     }
 
     function enqueueNodeOperatorKeys(
-        mapping(uint256 => NodeOperator) storage nodeOperators,
-        mapping(uint256 => DepositQueueLib.Queue) storage depositQueues,
+        ModuleLinearStorage.Layout storage layout,
         IParametersRegistry parametersRegistry,
         IAccounting accounting,
         uint256 queueLowestPriority,
         uint256 nodeOperatorId
     ) external {
-        NodeOperator storage no = nodeOperators[nodeOperatorId];
+        NodeOperator storage no = layout.nodeOperators[nodeOperatorId];
         uint32 depositable = no.depositableValidatorsCount;
         uint32 enqueued = no.enqueuedCount;
         if (depositable <= enqueued) return;
@@ -107,7 +106,7 @@ library DepositQueueOps {
                     if (count > priorityDepositsLeft) count = priorityDepositsLeft;
 
                     _enqueueNodeOperatorKeys({
-                        queue: depositQueues[priority],
+                        queue: layout.depositQueueByPriority[priority],
                         no: no,
                         nodeOperatorId: nodeOperatorId,
                         queuePriority: priority,
@@ -119,7 +118,7 @@ library DepositQueueOps {
         }
         if (toEnqueue > 0) {
             _enqueueNodeOperatorKeys({
-                queue: depositQueues[queueLowestPriority],
+                queue: layout.depositQueueByPriority[queueLowestPriority],
                 no: no,
                 nodeOperatorId: nodeOperatorId,
                 queuePriority: queueLowestPriority,

--- a/src/lib/NodeOperatorOps.sol
+++ b/src/lib/NodeOperatorOps.sol
@@ -75,14 +75,11 @@ library NodeOperatorOps {
     }
 
     function updateExitedValidatorsCount(
-        mapping(uint256 => NodeOperator) storage nodeOperators,
-        uint256 nodeOperatorsCount,
-        uint64 totalExitedValidators,
+        ModuleLinearStorage.BaseModuleStorage storage $,
         bytes calldata nodeOperatorIds,
         bytes calldata exitedValidatorsCounts
-    ) external returns (uint64 newTotalExitedValidators) {
+    ) external {
         uint256 operatorsInReport = ValidatorCountsReport.safeCountOperators(nodeOperatorIds, exitedValidatorsCounts);
-        newTotalExitedValidators = totalExitedValidators;
 
         for (uint256 i = 0; i < operatorsInReport; ++i) {
             (uint256 nodeOperatorId, uint256 exitedValidatorsCount) = ValidatorCountsReport.next(
@@ -90,36 +87,20 @@ library NodeOperatorOps {
                 exitedValidatorsCounts,
                 i
             );
-            newTotalExitedValidators = _updateExitedValidatorsCount({
-                nodeOperators: nodeOperators,
-                nodeOperatorsCount: nodeOperatorsCount,
-                totalExitedValidators: newTotalExitedValidators,
-                nodeOperatorId: nodeOperatorId,
-                exitedValidatorsCount: exitedValidatorsCount,
-                allowDecrease: false
-            });
+            _updateExitedValidatorsCount($, nodeOperatorId, exitedValidatorsCount, false);
         }
     }
 
     function unsafeUpdateValidatorsCount(
-        mapping(uint256 => NodeOperator) storage nodeOperators,
-        uint256 nodeOperatorsCount,
-        uint64 totalExitedValidators,
+        ModuleLinearStorage.BaseModuleStorage storage $,
         uint256 nodeOperatorId,
         uint256 exitedValidatorsCount
-    ) external returns (uint64 newTotalExitedValidators) {
-        newTotalExitedValidators = _updateExitedValidatorsCount({
-            nodeOperators: nodeOperators,
-            nodeOperatorsCount: nodeOperatorsCount,
-            totalExitedValidators: totalExitedValidators,
-            nodeOperatorId: nodeOperatorId,
-            exitedValidatorsCount: exitedValidatorsCount,
-            allowDecrease: true
-        });
+    ) external {
+        _updateExitedValidatorsCount($, nodeOperatorId, exitedValidatorsCount, true);
     }
 
     function decreaseVettedSigningKeysCount(
-        ModuleLinearStorage.Layout storage layout,
+        ModuleLinearStorage.BaseModuleStorage storage $,
         bytes calldata nodeOperatorIds,
         bytes calldata vettedSigningKeysCounts
     ) external {
@@ -132,9 +113,9 @@ library NodeOperatorOps {
                 vettedSigningKeysCounts,
                 i
             );
-            _onlyExistingNodeOperator(nodeOperatorId, layout.nodeOperatorsCount);
+            _onlyExistingNodeOperator(nodeOperatorId, $.nodeOperatorsCount);
 
-            NodeOperator storage no = layout.nodeOperators[nodeOperatorId];
+            NodeOperator storage no = $.nodeOperators[nodeOperatorId];
 
             if (vettedSigningKeysCount == no.totalVettedKeys) continue;
 
@@ -155,13 +136,13 @@ library NodeOperatorOps {
     }
 
     function reportValidatorBalance(
-        ModuleLinearStorage.Layout storage layout,
+        ModuleLinearStorage.BaseModuleStorage storage $,
         uint256 nodeOperatorId,
         uint256 keyIndex,
         uint256 currentBalanceWei
     ) external {
-        _onlyExistingNodeOperator(nodeOperatorId, layout.nodeOperatorsCount);
-        if (keyIndex >= layout.nodeOperators[nodeOperatorId].totalDepositedKeys) {
+        _onlyExistingNodeOperator(nodeOperatorId, $.nodeOperatorsCount);
+        if (keyIndex >= $.nodeOperators[nodeOperatorId].totalDepositedKeys) {
             revert IBaseModule.SigningKeysInvalidOffset();
         }
 
@@ -176,8 +157,8 @@ library NodeOperatorOps {
         }
 
         uint256 pointer = KeyPointerLib.keyPointer(nodeOperatorId, keyIndex);
-        if (newKeyAddedBalance <= layout.keyAddedBalances[pointer]) revert IBaseModule.UnreportableBalance();
-        layout.keyAddedBalances[pointer] = newKeyAddedBalance;
+        if (newKeyAddedBalance <= $.keyAddedBalances[pointer]) revert IBaseModule.UnreportableBalance();
+        $.keyAddedBalances[pointer] = newKeyAddedBalance;
         emit IBaseModule.KeyAddedBalanceChanged(nodeOperatorId, keyIndex, newKeyAddedBalance);
     }
 
@@ -441,15 +422,13 @@ library NodeOperatorOps {
     }
 
     function _updateExitedValidatorsCount(
-        mapping(uint256 => NodeOperator) storage nodeOperators,
-        uint256 nodeOperatorsCount,
-        uint64 totalExitedValidators,
+        ModuleLinearStorage.BaseModuleStorage storage $,
         uint256 nodeOperatorId,
         uint256 exitedValidatorsCount,
         bool allowDecrease
-    ) internal returns (uint64 newTotalExitedValidators) {
-        _onlyExistingNodeOperator(nodeOperatorId, nodeOperatorsCount);
-        NodeOperator storage no = nodeOperators[nodeOperatorId];
+    ) internal {
+        _onlyExistingNodeOperator(nodeOperatorId, $.nodeOperatorsCount);
+        NodeOperator storage no = $.nodeOperators[nodeOperatorId];
         if (exitedValidatorsCount > no.totalDepositedKeys) revert IBaseModule.InvalidInput();
         if (!allowDecrease && exitedValidatorsCount < no.totalExitedKeys) revert IBaseModule.InvalidInput();
 
@@ -458,7 +437,7 @@ library NodeOperatorOps {
             // `totalExitedValidators` accumulates the same uint32 per-operator counts, so pushing
             // the new value through uint64 preserves the exact result.
             // forge-lint: disable-next-item(unsafe-typecast)
-            newTotalExitedValidators = (totalExitedValidators - no.totalExitedKeys) + uint64(exitedValidatorsCount);
+            $.totalExitedValidators = ($.totalExitedValidators - no.totalExitedKeys) + uint64(exitedValidatorsCount);
         }
         // Each node operator stores its exited count in a uint32 slot; `exitedValidatorsCount`
         // is validated against `totalDepositedKeys` (also uint32), so the cast is safe.

--- a/src/lib/NodeOperatorOps.sol
+++ b/src/lib/NodeOperatorOps.sol
@@ -10,6 +10,7 @@ import { FORCED_TARGET_LIMIT_MODE_ID } from "../interfaces/IStakingModule.sol";
 import { IAccounting } from "../interfaces/IAccounting.sol";
 import { IParametersRegistry } from "../interfaces/IParametersRegistry.sol";
 
+import { ModuleLinearStorage } from "../abstract/ModuleLinearStorage.sol";
 import { CuratedDepositAllocator } from "./allocator/CuratedDepositAllocator.sol";
 import { ValidatorCountsReport } from "./ValidatorCountsReport.sol";
 import { WithdrawnValidatorLib } from "./WithdrawnValidatorLib.sol";
@@ -118,8 +119,7 @@ library NodeOperatorOps {
     }
 
     function decreaseVettedSigningKeysCount(
-        mapping(uint256 => NodeOperator) storage nodeOperators,
-        uint256 nodeOperatorsCount,
+        ModuleLinearStorage.Layout storage layout,
         bytes calldata nodeOperatorIds,
         bytes calldata vettedSigningKeysCounts
     ) external {
@@ -132,9 +132,9 @@ library NodeOperatorOps {
                 vettedSigningKeysCounts,
                 i
             );
-            _onlyExistingNodeOperator(nodeOperatorId, nodeOperatorsCount);
+            _onlyExistingNodeOperator(nodeOperatorId, layout.nodeOperatorsCount);
 
-            NodeOperator storage no = nodeOperators[nodeOperatorId];
+            NodeOperator storage no = layout.nodeOperators[nodeOperatorId];
 
             if (vettedSigningKeysCount == no.totalVettedKeys) continue;
 
@@ -155,15 +155,13 @@ library NodeOperatorOps {
     }
 
     function reportValidatorBalance(
-        mapping(uint256 => NodeOperator) storage nodeOperators,
-        uint256 nodeOperatorsCount,
-        mapping(uint256 => uint256) storage keyAddedBalances,
+        ModuleLinearStorage.Layout storage layout,
         uint256 nodeOperatorId,
         uint256 keyIndex,
         uint256 currentBalanceWei
     ) external {
-        _onlyExistingNodeOperator(nodeOperatorId, nodeOperatorsCount);
-        if (keyIndex >= nodeOperators[nodeOperatorId].totalDepositedKeys) {
+        _onlyExistingNodeOperator(nodeOperatorId, layout.nodeOperatorsCount);
+        if (keyIndex >= layout.nodeOperators[nodeOperatorId].totalDepositedKeys) {
             revert IBaseModule.SigningKeysInvalidOffset();
         }
 
@@ -178,8 +176,8 @@ library NodeOperatorOps {
         }
 
         uint256 pointer = KeyPointerLib.keyPointer(nodeOperatorId, keyIndex);
-        if (newKeyAddedBalance <= keyAddedBalances[pointer]) revert IBaseModule.UnreportableBalance();
-        keyAddedBalances[pointer] = newKeyAddedBalance;
+        if (newKeyAddedBalance <= layout.keyAddedBalances[pointer]) revert IBaseModule.UnreportableBalance();
+        layout.keyAddedBalances[pointer] = newKeyAddedBalance;
         emit IBaseModule.KeyAddedBalanceChanged(nodeOperatorId, keyIndex, newKeyAddedBalance);
     }
 

--- a/src/lib/TransientUintUintMapLib.sol
+++ b/src/lib/TransientUintUintMapLib.sol
@@ -3,63 +3,52 @@
 
 pragma solidity 0.8.33;
 
-type TransientUintUintMap is uint256;
+import { SlotDerivation } from "@openzeppelin/contracts/utils/SlotDerivation.sol";
+import { TransientSlot } from "@openzeppelin/contracts/utils/TransientSlot.sol";
+
+type TransientUintUintMap is bytes32;
 
 using TransientUintUintMapLib for TransientUintUintMap global;
 
 library TransientUintUintMapLib {
-    function create() internal returns (TransientUintUintMap self) {
-        // keccak256(abi.encode(uint256(keccak256("TransientUintUintMap")) - 1)) & ~bytes32(uint256(0xff))
-        uint256 anchor = 0x6e38e7eaa4307e6ee6c66720337876ca65012869fbef035f57219354c1728400;
+    using SlotDerivation for bytes32;
+    using TransientSlot for bytes32;
+    using TransientSlot for TransientSlot.Uint256Slot;
 
-        // `anchor` slot in the transient storage tracks the "address" of the last created object.
-        // The next address is being computed as keccak256(`anchor` . `prev`).
-        assembly ("memory-safe") {
-            let prev := tload(anchor)
-            mstore(0x00, anchor)
-            mstore(0x20, prev)
-            self := keccak256(0x00, 0x40)
-            tstore(anchor, self)
-        }
+    // SlotDerivation.erc7201Slot("TransientUintUintMap")
+    bytes32 private constant ANCHOR = 0x6e38e7eaa4307e6ee6c66720337876ca65012869fbef035f57219354c1728400;
+
+    function create() internal returns (TransientUintUintMap self) {
+        // `ANCHOR` slot in the transient storage tracks the base of the last created object.
+        // The next base is derived as a mapping slot from `ANCHOR` keyed by `prev`.
+        TransientSlot.Uint256Slot anchor = ANCHOR.asUint256();
+        uint256 prev = anchor.tload();
+        self = TransientUintUintMap.wrap(ANCHOR.deriveMapping(prev));
+        anchor.tstore(uint256(TransientUintUintMap.unwrap(self)));
     }
 
     function add(TransientUintUintMap self, uint256 key, uint256 value) internal {
-        uint256 slot = _slot(self, key);
-        assembly ("memory-safe") {
-            let v := tload(slot)
-            // NOTE: Here's no overflow check.
-            v := add(v, value)
-            tstore(slot, v)
+        TransientSlot.Uint256Slot slot = _slot(self, key).asUint256();
+        // NOTE: Here's no overflow check.
+        unchecked {
+            slot.tstore(slot.tload() + value);
         }
     }
 
     function set(TransientUintUintMap self, uint256 key, uint256 value) internal {
-        uint256 slot = _slot(self, key);
-        assembly ("memory-safe") {
-            tstore(slot, value)
-        }
+        _slot(self, key).asUint256().tstore(value);
     }
 
-    function get(TransientUintUintMap self, uint256 key) internal view returns (uint256 v) {
-        uint256 slot = _slot(self, key);
-        assembly ("memory-safe") {
-            v := tload(slot)
-        }
+    function get(TransientUintUintMap self, uint256 key) internal view returns (uint256) {
+        return _slot(self, key).asUint256().tload();
     }
 
-    function load(bytes32 tslot) internal pure returns (TransientUintUintMap self) {
-        assembly ("memory-safe") {
-            self := tslot
-        }
+    function load(bytes32 tslot) internal pure returns (TransientUintUintMap) {
+        return TransientUintUintMap.wrap(tslot);
     }
 
-    function _slot(TransientUintUintMap self, uint256 key) internal pure returns (uint256 slot) {
-        // Compute an address in the transient storage in the same manner it works for storage mappings.
-        // `slot` = keccak256(`self` . `key`)
-        assembly ("memory-safe") {
-            mstore(0x00, self)
-            mstore(0x20, key)
-            slot := keccak256(0x00, 0x40)
-        }
+    function _slot(TransientUintUintMap self, uint256 key) internal pure returns (bytes32) {
+        // Derives a transient storage slot following Solidity mapping layout.
+        return TransientUintUintMap.unwrap(self).deriveMapping(key);
     }
 }

--- a/src/lib/WithdrawnValidatorLib.sol
+++ b/src/lib/WithdrawnValidatorLib.sol
@@ -48,14 +48,6 @@ library WithdrawnValidatorLib {
         }
     }
 
-    function process(
-        NodeOperator storage no,
-        WithdrawnValidatorInfo calldata validatorInfo,
-        uint256 keyAddedBalance
-    ) external {
-        _process(no, validatorInfo, keyAddedBalance);
-    }
-
     function _process(
         NodeOperator storage no,
         WithdrawnValidatorInfo calldata validatorInfo,

--- a/src/lib/WithdrawnValidatorLib.sol
+++ b/src/lib/WithdrawnValidatorLib.sol
@@ -24,23 +24,22 @@ library WithdrawnValidatorLib {
     function processBatch(
         WithdrawnValidatorInfo[] calldata validatorInfos,
         bool slashed,
-        ModuleLinearStorage.Layout storage layout
+        ModuleLinearStorage.BaseModuleStorage storage $
     ) external returns (uint256[] memory touchedOperatorIds, uint256 touchedCount) {
         touchedOperatorIds = new uint256[](validatorInfos.length);
 
         for (uint256 i; i < validatorInfos.length; ++i) {
             WithdrawnValidatorInfo calldata info = validatorInfos[i];
-            if (info.nodeOperatorId >= layout.nodeOperatorsCount) revert IBaseModule.NodeOperatorDoesNotExist();
+            if (info.nodeOperatorId >= $.nodeOperatorsCount) revert IBaseModule.NodeOperatorDoesNotExist();
 
             uint256 pointer = _keyPointer(info.nodeOperatorId, info.keyIndex);
-            if (layout.isValidatorWithdrawn[pointer]) continue;
+            if ($.isValidatorWithdrawn[pointer]) continue;
             if (info.isSlashed != slashed) revert IBaseModule.InvalidWithdrawnValidatorInfo();
-            if (info.isSlashed && !layout.isValidatorSlashed[pointer])
-                revert IBaseModule.SlashingPenaltyIsNotApplicable();
+            if (info.isSlashed && !$.isValidatorSlashed[pointer]) revert IBaseModule.SlashingPenaltyIsNotApplicable();
 
-            _process(layout.nodeOperators[info.nodeOperatorId], info, layout.keyAddedBalances[pointer]);
+            _process($.nodeOperators[info.nodeOperatorId], info, $.keyAddedBalances[pointer]);
 
-            layout.isValidatorWithdrawn[pointer] = true;
+            $.isValidatorWithdrawn[pointer] = true;
             touchedOperatorIds[touchedCount] = info.nodeOperatorId;
             unchecked {
                 ++touchedCount;

--- a/src/lib/WithdrawnValidatorLib.sol
+++ b/src/lib/WithdrawnValidatorLib.sol
@@ -8,6 +8,7 @@ import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";
 import { IBaseModule, NodeOperator, WithdrawnValidatorInfo } from "../interfaces/IBaseModule.sol";
 import { ExitPenaltyInfo } from "../interfaces/IExitPenalties.sol";
 import { IAccounting } from "../interfaces/IAccounting.sol";
+import { ModuleLinearStorage } from "../abstract/ModuleLinearStorage.sol";
 
 import { SigningKeys } from "./SigningKeys.sol";
 
@@ -20,11 +21,46 @@ library WithdrawnValidatorLib {
     /// @dev Acts as the denominator to calculate the scaled penalty.
     uint256 public constant PENALTY_SCALE = MIN_ACTIVATION_BALANCE / PENALTY_QUOTIENT;
 
+    function processBatch(
+        WithdrawnValidatorInfo[] calldata validatorInfos,
+        bool slashed,
+        ModuleLinearStorage.Layout storage layout
+    ) external returns (uint256[] memory touchedOperatorIds, uint256 touchedCount) {
+        touchedOperatorIds = new uint256[](validatorInfos.length);
+
+        for (uint256 i; i < validatorInfos.length; ++i) {
+            WithdrawnValidatorInfo calldata info = validatorInfos[i];
+            if (info.nodeOperatorId >= layout.nodeOperatorsCount) revert IBaseModule.NodeOperatorDoesNotExist();
+
+            uint256 pointer = _keyPointer(info.nodeOperatorId, info.keyIndex);
+            if (layout.isValidatorWithdrawn[pointer]) continue;
+            if (info.isSlashed != slashed) revert IBaseModule.InvalidWithdrawnValidatorInfo();
+            if (info.isSlashed && !layout.isValidatorSlashed[pointer])
+                revert IBaseModule.SlashingPenaltyIsNotApplicable();
+
+            _process(layout.nodeOperators[info.nodeOperatorId], info, layout.keyAddedBalances[pointer]);
+
+            layout.isValidatorWithdrawn[pointer] = true;
+            touchedOperatorIds[touchedCount] = info.nodeOperatorId;
+            unchecked {
+                ++touchedCount;
+            }
+        }
+    }
+
     function process(
         NodeOperator storage no,
         WithdrawnValidatorInfo calldata validatorInfo,
         uint256 keyAddedBalance
     ) external {
+        _process(no, validatorInfo, keyAddedBalance);
+    }
+
+    function _process(
+        NodeOperator storage no,
+        WithdrawnValidatorInfo calldata validatorInfo,
+        uint256 keyAddedBalance
+    ) private {
         if (validatorInfo.slashingPenalty > 0 && !validatorInfo.isSlashed) {
             revert IBaseModule.InvalidWithdrawnValidatorInfo();
         }
@@ -119,5 +155,11 @@ library WithdrawnValidatorLib {
 
     function _scalePenaltyByMultiplier(uint256 penalty, uint256 multiplier) internal pure returns (uint256) {
         return (penalty * multiplier) / PENALTY_SCALE;
+    }
+
+    function _keyPointer(uint256 nodeOperatorId, uint256 keyIndex) internal pure returns (uint256 pointer) {
+        assembly ("memory-safe") {
+            pointer := or(shl(128, nodeOperatorId), keyIndex)
+        }
     }
 }

--- a/src/lib/allocator/DepositAllocatorGreedy.sol
+++ b/src/lib/allocator/DepositAllocatorGreedy.sol
@@ -3,6 +3,9 @@
 pragma solidity 0.8.33;
 
 import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";
+import { Arrays } from "@openzeppelin/contracts/utils/Arrays.sol";
+import { Comparators } from "@openzeppelin/contracts/utils/Comparators.sol";
+import { PackedSortKey, PackedSortKeyLib } from "./PackedSortKeyLib.sol";
 
 /// @dev Helper struct for input allocation state.
 struct AllocationState {
@@ -18,6 +21,8 @@ struct AllocationState {
 
 /// @notice Greedy imbalance math with the same entrypoints as DepositPouringMath.
 library DepositAllocatorGreedy {
+    using PackedSortKeyLib for PackedSortKey;
+
     // Fixed-point scale (2^96) for share ratios to represent fractional shares as integers.
     uint256 internal constant S_SCALE = uint256(1) << 96;
 
@@ -39,13 +44,13 @@ library DepositAllocatorGreedy {
         uint256 n = state.sharesX96.length;
         allocations = new uint256[](n);
 
-        uint256[] memory imbalances = _computeImbalances(state, allocationAmount, step);
-        uint256[] memory idx = _sortedIndicesByImbalanceDesc(imbalances);
+        PackedSortKey[] memory keys = _sortedKeysByImbalanceDesc(state, allocationAmount, step);
 
         uint256 remainder = allocationAmount;
         for (uint256 i; i < n && remainder > 0; ++i) {
-            uint256 opIdx = idx[i];
-            uint256 possible = Math.min(imbalances[opIdx], _quantize(state.capacities[opIdx], step));
+            PackedSortKey key = keys[i];
+            uint256 opIdx = key.unpackIndex();
+            uint256 possible = Math.min(key.unpackImbalance(), _quantize(state.capacities[opIdx], step));
             if (possible == 0) continue;
 
             uint256 toGive = Math.min(possible, _quantize(remainder, step));
@@ -68,41 +73,29 @@ library DepositAllocatorGreedy {
         }
     }
 
-    function _sortedIndicesByImbalanceDesc(uint256[] memory imbalances) internal pure returns (uint256[] memory idx) {
-        // TODO: use OpenZeppelin lib
-        uint256 n = imbalances.length;
-        idx = new uint256[](n);
-        unchecked {
-            for (uint256 i = 1; i < n; ++i) {
-                uint256 keyImb = imbalances[i];
-                uint256 j = i;
-                while (j > 0) {
-                    uint256 prev = idx[j - 1];
-                    if (imbalances[prev] >= keyImb) break;
-                    idx[j] = prev;
-                    --j;
-                }
-                idx[j] = i;
-            }
-        }
-    }
-
-    function _computeImbalances(
+    function _sortedKeysByImbalanceDesc(
         AllocationState memory state,
         uint256 allocationAmount,
         uint256 step
-    ) internal pure returns (uint256[] memory imbalances) {
+    ) internal pure returns (PackedSortKey[] memory keys) {
         uint256 n = state.sharesX96.length;
-        imbalances = new uint256[](n);
+        keys = new PackedSortKey[](n);
         uint256 targetTotal = state.totalCurrent + allocationAmount;
-        for (uint256 i; i < n; ++i) {
-            // NOTE: Rounding up to avoid cases when 10 keys aren't allocated over 100 equal operators
-            uint256 target = Math.mulDiv(state.sharesX96[i], targetTotal, S_SCALE, Math.Rounding.Ceil);
-            uint256 current = state.currents[i];
-            if (target <= current) continue;
-            unchecked {
-                imbalances[i] = _quantize(target - current, step);
+
+        unchecked {
+            for (uint256 i; i < n; ++i) {
+                uint256 imbalance;
+                // NOTE: Rounding up to avoid cases when 10 keys aren't allocated over 100 equal operators
+                uint256 target = Math.mulDiv(state.sharesX96[i], targetTotal, S_SCALE, Math.Rounding.Ceil);
+                uint256 current = state.currents[i];
+                if (target > current) {
+                    imbalance = _quantize(target - current, step);
+                }
+                // Sort key: imbalance desc, index asc on ties.
+                keys[i] = PackedSortKeyLib.pack(imbalance, i);
             }
         }
+
+        Arrays.sort(PackedSortKeyLib.asUint256Array(keys), Comparators.gt);
     }
 }

--- a/src/lib/allocator/PackedSortKeyLib.sol
+++ b/src/lib/allocator/PackedSortKeyLib.sol
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText: 2026 Lido <info@lido.fi>
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity 0.8.33;
+
+/// @notice Packed sort key used for ordering operators by imbalance.
+/// @dev Layout:
+///      - high 224 bits: imbalance
+///      - low 32 bits: reversed index (`INDEX_MASK - idx`) so lower original index wins ties.
+///      Assumes `idx <= type(uint32).max`.
+type PackedSortKey is uint256;
+
+/// @notice Helper functions to pack and unpack `PackedSortKey`.
+library PackedSortKeyLib {
+    uint256 internal constant INDEX_BITS = 32;
+    uint256 internal constant INDEX_MASK = type(uint32).max;
+
+    /// @notice Packs imbalance and index into a single sortable key.
+    /// @dev Sorting packed keys in descending order produces:
+    ///      - imbalance descending
+    ///      - index ascending on equal imbalance.
+    /// @param imbalance Operator imbalance value.
+    /// @param idx Operator index in the source arrays.
+    /// @return key Packed key.
+    function pack(uint256 imbalance, uint256 idx) internal pure returns (PackedSortKey key) {
+        key = PackedSortKey.wrap((imbalance << INDEX_BITS) | (INDEX_MASK - idx));
+    }
+
+    /// @notice Unpacks the original operator index from a packed key.
+    /// @param key Packed key.
+    /// @return idx Original operator index.
+    function unpackIndex(PackedSortKey key) internal pure returns (uint256 idx) {
+        idx = INDEX_MASK - (PackedSortKey.unwrap(key) & INDEX_MASK);
+    }
+
+    /// @notice Unpacks imbalance from a packed key.
+    /// @param key Packed key.
+    /// @return imbalance Imbalance value.
+    function unpackImbalance(PackedSortKey key) internal pure returns (uint256 imbalance) {
+        imbalance = PackedSortKey.unwrap(key) >> INDEX_BITS;
+    }
+
+    /// @notice Reinterprets a packed key array as uint256[].
+    /// @dev `PackedSortKey` wraps `uint256`, so both arrays have identical in-memory layout.
+    ///      Useful for passing keys to helpers that accept `uint256[]` (e.g. `Arrays.sort`).
+    /// @param keys Packed key array.
+    /// @return out Same array viewed as uint256[].
+    function asUint256Array(PackedSortKey[] memory keys) internal pure returns (uint256[] memory out) {
+        assembly ("memory-safe") {
+            out := keys
+        }
+    }
+}

--- a/src/lib/proxy/OssifiableProxy.sol
+++ b/src/lib/proxy/OssifiableProxy.sol
@@ -6,6 +6,7 @@ pragma solidity 0.8.33;
 import { StorageSlot } from "@openzeppelin/contracts/utils/StorageSlot.sol";
 import { ERC1967Proxy } from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 import { ERC1967Utils } from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Utils.sol";
+import { IERC1967 } from "@openzeppelin/contracts/interfaces/IERC1967.sol";
 
 /// @notice An ossifiable proxy contract. Extends the ERC1967Proxy contract by
 ///     adding admin functionality
@@ -46,7 +47,7 @@ contract OssifiableProxy is ERC1967Proxy {
     function proxy__ossify() external onlyAdmin {
         address prevAdmin = ERC1967Utils.getAdmin();
         StorageSlot.getAddressSlot(ERC1967Utils.ADMIN_SLOT).value = address(0);
-        emit ERC1967Utils.AdminChanged(prevAdmin, address(0));
+        emit IERC1967.AdminChanged(prevAdmin, address(0));
         emit ProxyOssified();
     }
 

--- a/test/fork/deployment/PostDeploymentCurated.t.sol
+++ b/test/fork/deployment/PostDeploymentCurated.t.sol
@@ -130,15 +130,13 @@ contract CuratedGatesDeploymentTest is DeploymentBaseTest {
 
     function _assertCreateRoleOrderMatchesConfig() internal view {
         bytes32 role = module.CREATE_NODE_OPERATOR_ROLE();
-        uint256 gatesCount = deployParams.curatedGates.length;
-        assertEq(module.getRoleMemberCount(role), gatesCount, "unexpected create role members count");
+        address[] memory members = module.getRoleMembers(role);
+        assertEq(members.length, deployParams.curatedGates.length, "unexpected create role members count");
 
-        for (uint256 i = 0; i < gatesCount; ++i) {
-            address roleMember = module.getRoleMember(role, i);
-            address expectedGate = curatedGates[i];
-            assertEq(roleMember, expectedGate, "create role order mismatch");
+        for (uint256 i = 0; i < members.length; ++i) {
+            assertEq(members[i], curatedGates[i], "create role order mismatch");
 
-            CuratedGate gate = CuratedGate(roleMember);
+            CuratedGate gate = CuratedGate(members[i]);
             CuratedGateConfig storage cfg = deployParams.curatedGates[i];
             assertEq(gate.treeRoot(), cfg.treeRoot, "unexpected gate root");
             assertEq(gate.treeCid(), cfg.treeCid, "unexpected gate cid");

--- a/test/fork/utils/TwoPhaseFrameConfigUpdate.t.sol
+++ b/test/fork/utils/TwoPhaseFrameConfigUpdate.t.sol
@@ -4,6 +4,7 @@
 pragma solidity 0.8.33;
 
 import { Test } from "forge-std/Test.sol";
+import { Bytes } from "@openzeppelin/contracts/utils/Bytes.sol";
 
 import { TwoPhaseFrameConfigUpdate } from "src/utils/TwoPhaseFrameConfigUpdate.sol";
 import { IFeeOracle } from "src/interfaces/IFeeOracle.sol";
@@ -192,15 +193,9 @@ contract TwoPhaseFrameConfigUpdateTest is Test, Utilities, DeploymentFixtures {
         bytes memory b = bytes(path);
         if (b.length == 0) return "";
 
-        uint256 i = b.length;
-        while (i > 0) {
-            if (b[i - 1] == "/") break;
-            unchecked {
-                --i;
-            }
-        }
-        if (i == 0) return "";
-        dir = string(slice(b, 0, i));
+        uint256 i = Bytes.lastIndexOf(b, "/");
+        if (i == type(uint256).max) return "";
+        dir = string(Bytes.slice(b, 0, i + 1));
     }
 
     function test_shiftReportWindow() public {

--- a/test/helpers/Fixtures.sol
+++ b/test/helpers/Fixtures.sol
@@ -35,6 +35,7 @@ import { DeployParams } from "script/csm/DeployBase.s.sol";
 import { DeployCSM0x02Params } from "script/csm0x02/DeployCSM0x02Base.s.sol";
 import { CuratedDeployParams } from "script/curated/DeployBase.s.sol";
 import { GIndex } from "src/lib/GIndex.sol";
+import { Strings } from "@openzeppelin/contracts/utils/Strings.sol";
 import { IACL } from "src/interfaces/IACL.sol";
 import { IKernel } from "src/interfaces/IKernel.sol";
 import { Batch } from "src/lib/DepositQueueLib.sol";
@@ -698,7 +699,7 @@ contract DeploymentHelpers is Test {
     }
 
     function _isEmpty(string memory s) internal pure returns (bool) {
-        return keccak256(abi.encodePacked(s)) == keccak256(abi.encodePacked(""));
+        return Strings.equal(s, "");
     }
 }
 

--- a/test/helpers/MerkleTree.sol
+++ b/test/helpers/MerkleTree.sol
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity 0.8.33;
 
+import { Hashes } from "@openzeppelin/contracts/utils/cryptography/Hashes.sol";
+
 /// @dev There's no leaves sorting for simplicity.
 contract MerkleTree {
     bytes32[] internal tree;
@@ -116,6 +118,6 @@ contract MerkleTree {
     }
 
     function _hashPair(bytes32 a, bytes32 b) private pure returns (bytes32) {
-        return a < b ? keccak256(bytes.concat(a, b)) : keccak256(bytes.concat(b, a));
+        return Hashes.commutativeKeccak256(a, b);
     }
 }

--- a/test/helpers/Utilities.sol
+++ b/test/helpers/Utilities.sol
@@ -4,6 +4,7 @@ pragma solidity 0.8.33;
 
 import { CommonBase, Vm } from "forge-std/Base.sol";
 import { Strings } from "@openzeppelin/contracts/utils/Strings.sol";
+import { Bytes } from "@openzeppelin/contracts/utils/Bytes.sol";
 import { IAccessControl } from "@openzeppelin/contracts/access/IAccessControl.sol";
 
 /// @author madlabman
@@ -199,11 +200,8 @@ contract Utilities is CommonBase {
         return arr;
     }
 
-    function slice(bytes memory subject, uint256 offset, uint256 length) public pure returns (bytes memory result) {
-        result = new bytes(length);
-        for (uint256 i; i < length; ++i) {
-            result[i] = subject[offset + i];
-        }
+    function slice(bytes memory subject, uint256 offset, uint256 length) public pure returns (bytes memory) {
+        return Bytes.slice(subject, offset, offset + length);
     }
 
     function shuffle(uint256[] memory arr) public {

--- a/test/unit/abstract/BondCurve.t.sol
+++ b/test/unit/abstract/BondCurve.t.sol
@@ -6,6 +6,7 @@ pragma solidity 0.8.33;
 import { Test } from "forge-std/Test.sol";
 
 import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";
+import { Arrays } from "@openzeppelin/contracts/utils/Arrays.sol";
 
 import { BondCurve } from "src/abstract/BondCurve.sol";
 import { IBondCurve } from "src/interfaces/IBondCurve.sol";
@@ -637,16 +638,11 @@ contract BondCurveFuzz is Test {
         }
 
         // Assume: minKeysCount[i] < minKeysCount[i + 1]
-        uint256 n = minKeysCount.length;
-        for (uint256 i = 0; i < n; i++) {
-            for (uint256 j = 0; j < n - 1; j++) {
-                if (minKeysCount[j] > minKeysCount[j + 1]) {
-                    (minKeysCount[j], minKeysCount[j + 1]) = (minKeysCount[j + 1], minKeysCount[j]);
-                }
-                if (minKeysCount[j] == minKeysCount[j + 1]) {
-                    // Make it different because we need to have unique values
-                    minKeysCount[j + 1] = minKeysCount[j] + 1;
-                }
+        Arrays.sort(minKeysCount);
+        for (uint256 j = 0; j < minKeysCount.length - 1; j++) {
+            if (minKeysCount[j] >= minKeysCount[j + 1]) {
+                // Make it different because we need to have unique values
+                minKeysCount[j + 1] = minKeysCount[j] + 1;
             }
         }
         // Assume: first interval starts from "1" keys count

--- a/test/unit/lib/allocator/PackedSortKeyLib.t.sol
+++ b/test/unit/lib/allocator/PackedSortKeyLib.t.sol
@@ -1,0 +1,62 @@
+// SPDX-FileCopyrightText: 2026 Lido <info@lido.fi>
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity 0.8.33;
+
+import { Test } from "forge-std/Test.sol";
+import { Arrays } from "@openzeppelin/contracts/utils/Arrays.sol";
+import { Comparators } from "@openzeppelin/contracts/utils/Comparators.sol";
+
+import { PackedSortKey, PackedSortKeyLib } from "src/lib/allocator/PackedSortKeyLib.sol";
+
+contract PackedSortKeyLibTest is Test {
+    using PackedSortKeyLib for PackedSortKey;
+
+    function test_packUnpack_RoundTrip() public pure {
+        uint256 imbalance = 123_456_789 ether;
+        uint256 idx = 777;
+
+        PackedSortKey key = PackedSortKeyLib.pack(imbalance, idx);
+
+        assertEq(key.unpackImbalance(), imbalance);
+        assertEq(key.unpackIndex(), idx);
+    }
+
+    function test_ordering_EqualImbalanceLowerIndexWins() public pure {
+        uint256 imbalance = 42 ether;
+
+        PackedSortKey k0 = PackedSortKeyLib.pack(imbalance, 0);
+        PackedSortKey k1 = PackedSortKeyLib.pack(imbalance, 1);
+
+        assertGt(PackedSortKey.unwrap(k0), PackedSortKey.unwrap(k1));
+    }
+
+    function test_ordering_HigherImbalanceWins() public pure {
+        PackedSortKey lowImbalance = PackedSortKeyLib.pack(1 ether, type(uint32).max);
+        PackedSortKey highImbalance = PackedSortKeyLib.pack(2 ether, 0);
+
+        assertGt(PackedSortKey.unwrap(highImbalance), PackedSortKey.unwrap(lowImbalance));
+    }
+
+    function test_asUint256Array_CastAndSortReflectOnPackedArray() public pure {
+        PackedSortKey[] memory keys = new PackedSortKey[](3);
+        keys[0] = PackedSortKeyLib.pack(1 ether, 2);
+        keys[1] = PackedSortKeyLib.pack(3 ether, 1);
+        keys[2] = PackedSortKeyLib.pack(2 ether, 0);
+
+        uint256[] memory raw = PackedSortKeyLib.asUint256Array(keys);
+        assertEq(raw.length, 3);
+        assertEq(raw[0], PackedSortKey.unwrap(keys[0]));
+        assertEq(raw[1], PackedSortKey.unwrap(keys[1]));
+        assertEq(raw[2], PackedSortKey.unwrap(keys[2]));
+
+        Arrays.sort(raw, Comparators.gt);
+
+        // Verify sorting through uint256[] view updates original PackedSortKey[] view.
+        assertEq(keys[0].unpackImbalance(), 3 ether);
+        assertEq(keys[0].unpackIndex(), 1);
+        assertEq(keys[1].unpackImbalance(), 2 ether);
+        assertEq(keys[1].unpackIndex(), 0);
+        assertEq(keys[2].unpackImbalance(), 1 ether);
+        assertEq(keys[2].unpackIndex(), 2);
+    }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -240,19 +240,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@openzeppelin/contracts-upgradeable@npm:5.0.2":
-  version: 5.0.2
-  resolution: "@openzeppelin/contracts-upgradeable@npm:5.0.2"
+"@openzeppelin/contracts-upgradeable@npm:5.4.0":
+  version: 5.4.0
+  resolution: "@openzeppelin/contracts-upgradeable@npm:5.4.0"
   peerDependencies:
-    "@openzeppelin/contracts": 5.0.2
-  checksum: 10c0/0bd47a4fa0ba8084c1df9573968ff02387bc21514d846b5feb4ad42f90f3ba26bb1e40f17f03e4fa24ffbe473b9ea06c137283297884ab7d5b98d2c112904dc9
+    "@openzeppelin/contracts": 5.4.0
+  checksum: 10c0/0bf78ad1a42151eb41eb7ff6645714a65649766643514b704d398927fe72533d2a143557306610db93f625124dfef9ee06b2c9ca624ada16074962cbcb622b6b
   languageName: node
   linkType: hard
 
-"@openzeppelin/contracts@npm:5.0.2":
-  version: 5.0.2
-  resolution: "@openzeppelin/contracts@npm:5.0.2"
-  checksum: 10c0/d042661db7bb2f3a4b9ef30bba332e86ac20907d171f2ebfccdc9255cc69b62786fead8d6904b8148a8f26946bc7c15eead91b95f75db0c193a99d52e528663e
+"@openzeppelin/contracts@npm:5.4.0":
+  version: 5.4.0
+  resolution: "@openzeppelin/contracts@npm:5.4.0"
+  checksum: 10c0/7e05646dee4905fea4493f0fb2ad208abaff84b9f5ef1b9e1a5fc61d0e74d9bc30759bdf0d09a08049cfef6a290623330d83469eadc990a7bba6c2cd09a27e1d
   languageName: node
   linkType: hard
 
@@ -724,8 +724,8 @@ __metadata:
   resolution: "community-staking-module@workspace:."
   dependencies:
     "@lodestar/types": "npm:^1.31.0"
-    "@openzeppelin/contracts": "npm:5.0.2"
-    "@openzeppelin/contracts-upgradeable": "npm:5.0.2"
+    "@openzeppelin/contracts": "npm:5.4.0"
+    "@openzeppelin/contracts-upgradeable": "npm:5.4.0"
     "@openzeppelin/merkle-tree": "npm:^1.0.8"
     ds-test: "https://github.com/dapphub/ds-test"
     forge-std: "https://github.com/foundry-rs/forge-std.git#v1.9.6"


### PR DESCRIPTION
## Description

- Pin `@openzeppelin/contracts` and `@openzeppelin/contracts-upgradeable` to `5.4.0`.
- Reduce module bytecode by passing a single `ModuleLinearStorage.Layout` pointer instead of multiple storage mappings/fields.
- Optimize greedy allocator sorting via packed keys with OZ `Arrays.sort` and new `PackedSortKeyLib`.
- Replace hand-rolled transient-map assembly with OZ `SlotDerivation` and `TransientSlot`.
- Use `Math.saturatingSub` for floor-at-zero subtractions in Accounting.
- Use `Strings.equal` for CID equality checks.
- Adopt OZ 5.4.0 utilities in test helpers.
- Align `OssifiableProxy` admin-change emit with OZ 5.4 `IERC1967.AdminChanged`.

## Checklist

- [x] Appropriate PR labels applied
- [x] Test coverage maintained (`just coverage`)
  - [ ] No need to add/update tests
  - [x] Tests are added/updated
- [x] Documentation maintained
  - [x] No need to update
  - [ ] Updated
