### PR TITLE
feat: add an event for a passed item in the top-up queue

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,7 @@
   Bad: `vm.prank(admin); target.grantRole(target.ROLE(), user)` or `vm.prank(admin); module.PARAMETERS_REGISTRY().setX(...)`.
   Good: precompute external values before prank (`bytes32 role = target.ROLE();`) or use `vm.startPrank`/`vm.stopPrank` for multi-call sequences.
 - Do not assert unchanged state after a reverting call.
+- Order tests: happy path first, revert cases afterwards.
 - Deployment test name suffixes are part of the test selection contract used by `just` recipes and encode two axes: phase and flow.
 - Phase semantics:
 - `*_scratch*`: checks for post-deploy, pre-vote state only.

--- a/src/interfaces/ICSModule.sol
+++ b/src/interfaces/ICSModule.sol
@@ -12,6 +12,7 @@ import { IStakingModuleV2 } from "./IStakingModule.sol";
 /// @title Lido's Community Staking Module interface
 interface ICSModule is IBaseModule, IStakingModuleV2, IDepositQueueLib, ITopUpQueueLib {
     event BatchEnqueued(uint256 indexed queuePriority, uint256 indexed nodeOperatorId, uint256 count);
+    event TopUpQueueItemPassed(uint256 indexed nodeOperatorId, uint256 keyIndex);
     event TopUpQueueLimitSet(uint256 limit);
     event TopUpQueueRewound(uint256 to);
 

--- a/src/lib/TopUpQueueOps.sol
+++ b/src/lib/TopUpQueueOps.sol
@@ -79,6 +79,7 @@ library TopUpQueueOps {
 
             if (allocations[i] == limit) {
                 topUpQueue.dequeue();
+                emit ICSModule.TopUpQueueItemPassed(item.noId(), item.keyIndex());
             } else if (i < keyCount - 1) revert ICSModule.UnexpectedExtraKey();
         }
     }

--- a/test/unit/CSModule.t.sol
+++ b/test/unit/CSModule.t.sol
@@ -952,6 +952,52 @@ contract CSMTopUpQueue is CSMCommon {
         });
     }
 
+    function test_topUp_emitsTopUpQueueItemPassedForEachKey() public {
+        createNodeOperator(2);
+        createNodeOperator(1);
+        csm.obtainDepositData(3, "");
+
+        bytes memory packed = csm.getSigningKeys(0, 0, 2);
+        bytes memory key2 = csm.getSigningKeys(1, 0, 1);
+        bytes[] memory pubkeys = BytesArr(slice(packed, 0, 48), slice(packed, 48, 48), key2);
+
+        vm.expectEmit(address(csm));
+        emit ICSModule.TopUpQueueItemPassed(0, 0);
+        vm.expectEmit(address(csm));
+        emit ICSModule.TopUpQueueItemPassed(0, 1);
+        vm.expectEmit(address(csm));
+        emit ICSModule.TopUpQueueItemPassed(1, 0);
+
+        csm.allocateDeposits({
+            maxDepositAmount: 3 ether,
+            pubkeys: pubkeys,
+            keyIndices: UintArr(0, 1, 0),
+            operatorIds: UintArr(0, 0, 1),
+            topUpLimits: UintArr(1 ether, 1 ether, 1 ether)
+        });
+    }
+
+    function test_topUp_noPassedEventWhenPartialAllocation() public {
+        createNodeOperator(1);
+        csm.obtainDepositData(1, "");
+
+        bytes memory key = csm.getSigningKeys(0, 0, 1);
+
+        vm.recordLogs();
+        csm.allocateDeposits({
+            maxDepositAmount: 1 ether,
+            pubkeys: BytesArr(key),
+            keyIndices: UintArr(0),
+            operatorIds: UintArr(0),
+            topUpLimits: UintArr(3 ether)
+        });
+        Vm.Log[] memory entries = vm.getRecordedLogs();
+
+        for (uint256 i; i < entries.length; ++i) {
+            assertNotEq(entries[i].topics[0], ICSModule.TopUpQueueItemPassed.selector);
+        }
+    }
+
     function test_topUp_noEmitWhenKeyAtCap() public {
         createNodeOperator(1);
         csm.obtainDepositData(1, "");


### PR DESCRIPTION
## Description

Well, that's it. Now there's an event.

## Checklist

- [x] Appropriate PR labels applied
- [x] Test coverage maintained (`just coverage`)
  - [ ] No need to add/update tests
  - [x] Tests are added/updated
- [x] Documentation maintained
  - [x] No need to update
  - [ ] Updated
