### PR TITLE
refactor: rename TopUpQueueItemPassed to TopUpQueueItemProcessed

### DIFF
--- a/src/interfaces/ICSModule.sol
+++ b/src/interfaces/ICSModule.sol
@@ -12,7 +12,7 @@ import { IStakingModuleV2 } from "./IStakingModule.sol";
 /// @title Lido's Community Staking Module interface
 interface ICSModule is IBaseModule, IStakingModuleV2, IDepositQueueLib, ITopUpQueueLib {
     event BatchEnqueued(uint256 indexed queuePriority, uint256 indexed nodeOperatorId, uint256 count);
-    event TopUpQueueItemPassed(uint256 indexed nodeOperatorId, uint256 keyIndex);
+    event TopUpQueueItemProcessed(uint256 indexed nodeOperatorId, uint256 keyIndex);
     event TopUpQueueLimitSet(uint256 limit);
     event TopUpQueueRewound(uint256 to);
 

--- a/src/lib/TopUpQueueOps.sol
+++ b/src/lib/TopUpQueueOps.sol
@@ -79,7 +79,7 @@ library TopUpQueueOps {
 
             if (allocations[i] == limit) {
                 topUpQueue.dequeue();
-                emit ICSModule.TopUpQueueItemPassed(item.noId(), item.keyIndex());
+                emit ICSModule.TopUpQueueItemProcessed(item.noId(), item.keyIndex());
             } else if (i < keyCount - 1) revert ICSModule.UnexpectedExtraKey();
         }
     }

--- a/test/unit/CSModule.t.sol
+++ b/test/unit/CSModule.t.sol
@@ -952,7 +952,7 @@ contract CSMTopUpQueue is CSMCommon {
         });
     }
 
-    function test_topUp_emitsTopUpQueueItemPassedForEachKey() public {
+    function test_topUp_emitsTopUpQueueItemProcessedForEachKey() public {
         createNodeOperator(2);
         createNodeOperator(1);
         csm.obtainDepositData(3, "");
@@ -962,11 +962,11 @@ contract CSMTopUpQueue is CSMCommon {
         bytes[] memory pubkeys = BytesArr(slice(packed, 0, 48), slice(packed, 48, 48), key2);
 
         vm.expectEmit(address(csm));
-        emit ICSModule.TopUpQueueItemPassed(0, 0);
+        emit ICSModule.TopUpQueueItemProcessed(0, 0);
         vm.expectEmit(address(csm));
-        emit ICSModule.TopUpQueueItemPassed(0, 1);
+        emit ICSModule.TopUpQueueItemProcessed(0, 1);
         vm.expectEmit(address(csm));
-        emit ICSModule.TopUpQueueItemPassed(1, 0);
+        emit ICSModule.TopUpQueueItemProcessed(1, 0);
 
         csm.allocateDeposits({
             maxDepositAmount: 3 ether,
@@ -977,7 +977,7 @@ contract CSMTopUpQueue is CSMCommon {
         });
     }
 
-    function test_topUp_noPassedEventWhenPartialAllocation() public {
+    function test_topUp_noProcessedEventWhenPartialAllocation() public {
         createNodeOperator(1);
         csm.obtainDepositData(1, "");
 
@@ -994,7 +994,7 @@ contract CSMTopUpQueue is CSMCommon {
         Vm.Log[] memory entries = vm.getRecordedLogs();
 
         for (uint256 i; i < entries.length; ++i) {
-            assertNotEq(entries[i].topics[0], ICSModule.TopUpQueueItemPassed.selector);
+            assertNotEq(entries[i].topics[0], ICSModule.TopUpQueueItemProcessed.selector);
         }
     }
 


### PR DESCRIPTION
## Description

Rename `TopUpQueueItemPassed` to `TopUpQueueItemProcessed`.

## Checklist

- [x] Appropriate PR labels applied
- [x] Test coverage maintained (`just coverage`)
  - [x] No need to add/update tests
  - [ ] Tests are added/updated
- [x] Documentation maintained
  - [x] No need to update
  - [ ] Updated
