### PR TITLE
refactor: embed AllocationState in DepositableOperatorsData and clean up allocation TODOs

### DIFF
--- a/src/CuratedModule.sol
+++ b/src/CuratedModule.sol
@@ -60,7 +60,6 @@ contract CuratedModule is ICuratedModule, BaseModule {
         _checkStakingRouterRole();
         _requireDepositInfoUpToDate();
 
-        // TODO: think about changing to list of structs
         BaseModuleStorage storage $ = _baseStorage();
         (uint256 allocated, uint256[] memory operatorIds, uint256[] memory allocations) = CuratedDepositAllocator
             .allocateInitialDeposits($.nodeOperators, $.nodeOperatorsCount, depositsCount);

--- a/src/lib/allocator/CuratedDepositAllocator.sol
+++ b/src/lib/allocator/CuratedDepositAllocator.sol
@@ -16,17 +16,13 @@ import { WithdrawnValidatorLib } from "../WithdrawnValidatorLib.sol";
 ///      - each operatorId < operatorsCount.
 library CuratedDepositAllocator {
     struct DepositableOperatorsData {
-        // Per-operator allocation shares scaled by DepositAllocatorGreedy.S_SCALE (2^96).
-        // During collection this temporarily stores raw weights and is normalized in-place
-        // right before allocation.
-        // TODO: use AllocationState
-        uint256[] sharesX96;
-        uint256[] currents; // Current amounts per operator (units depend on caller: validator count for deposits, wei for top-ups).
-        uint256[] capacities; // Remaining capacity per operator (units match `currents`).
+        // Shared allocation arrays + totalCurrent — passed directly to the allocator.
+        // During collection, alloc.sharesX96 temporarily stores raw weights
+        // and is normalized in-place right before allocation.
+        AllocationState alloc;
         uint256[] operatorIds; // Operator ids aligned with arrays above (compacted to operators included in allocation).
         uint256 count; // Number of operators included in allocation (filled entries in the arrays above).
         uint256 weightSum; // Sum of weights across eligible operators (for share calculation).
-        uint256 totalCurrent; // Sum of current amounts across eligible operators (units match `currents`).
     }
 
     uint256 public constant MAX_EFFECTIVE_BALANCE = 2048 ether;
@@ -124,9 +120,9 @@ library CuratedDepositAllocator {
         mapping(uint256 => NodeOperator) storage nodeOperators,
         uint256 operatorsCount
     ) internal view returns (DepositableOperatorsData memory data) {
-        data.sharesX96 = new uint256[](operatorsCount);
-        data.currents = new uint256[](operatorsCount);
-        data.capacities = new uint256[](operatorsCount);
+        data.alloc.sharesX96 = new uint256[](operatorsCount);
+        data.alloc.currents = new uint256[](operatorsCount);
+        data.alloc.capacities = new uint256[](operatorsCount);
         data.operatorIds = new uint256[](operatorsCount);
 
         IMetaRegistry metaRegistry = ICuratedModule(address(this)).META_REGISTRY();
@@ -147,12 +143,12 @@ library CuratedDepositAllocator {
                 uint256 current = no.totalDepositedKeys - no.totalWithdrawnKeys;
                 if (externalStake > 0) current += externalStake / WithdrawnValidatorLib.MAX_EFFECTIVE_BALANCE;
 
-                data.sharesX96[eligibleCount] = weight;
-                data.currents[eligibleCount] = current;
-                data.capacities[eligibleCount] = capacity;
+                data.alloc.sharesX96[eligibleCount] = weight;
+                data.alloc.currents[eligibleCount] = current;
+                data.alloc.capacities[eligibleCount] = capacity;
                 data.operatorIds[eligibleCount] = i;
                 data.weightSum += weight;
-                data.totalCurrent += current;
+                data.alloc.totalCurrent += current;
                 ++eligibleCount;
             }
         }
@@ -170,9 +166,9 @@ library CuratedDepositAllocator {
         uint256 operatorsCount,
         uint256[] calldata operatorIds
     ) internal view returns (DepositableOperatorsData memory data) {
-        data.sharesX96 = new uint256[](operatorIds.length);
-        data.currents = new uint256[](operatorIds.length);
-        data.capacities = new uint256[](operatorIds.length);
+        data.alloc.sharesX96 = new uint256[](operatorIds.length);
+        data.alloc.currents = new uint256[](operatorIds.length);
+        data.alloc.capacities = new uint256[](operatorIds.length);
         data.operatorIds = new uint256[](operatorIds.length);
 
         uint256[] memory weightsByOperatorId;
@@ -180,7 +176,7 @@ library CuratedDepositAllocator {
         uint256[] memory currentStakeByOperatorId;
         (
             data.weightSum,
-            data.totalCurrent,
+            data.alloc.totalCurrent,
             weightsByOperatorId,
             capacitiesByOperatorId,
             currentStakeByOperatorId
@@ -201,9 +197,9 @@ library CuratedDepositAllocator {
             uint256 weight = weightsByOperatorId[operatorId];
             if (weight == 0) continue;
 
-            data.sharesX96[eligibleCount] = weight;
-            data.currents[eligibleCount] = currentStakeByOperatorId[operatorId];
-            data.capacities[eligibleCount] = capacity;
+            data.alloc.sharesX96[eligibleCount] = weight;
+            data.alloc.currents[eligibleCount] = currentStakeByOperatorId[operatorId];
+            data.alloc.capacities[eligibleCount] = capacity;
             data.operatorIds[eligibleCount] = operatorId;
             ++eligibleCount;
         }
@@ -266,7 +262,7 @@ library CuratedDepositAllocator {
         return DepositAllocatorGreedy._quantize(value, TOP_UP_STEP);
     }
 
-    /// @dev Builds AllocationState and runs the configured allocator in-memory.
+    /// @dev Normalizes raw weights into X96 shares and runs the allocator in-memory.
     ///      Expects operatorsData arrays already filtered/truncated to eligible operators.
     function _computeAllocations(
         DepositableOperatorsData memory operatorsData,
@@ -275,13 +271,9 @@ library CuratedDepositAllocator {
     ) internal pure returns (uint256 allocated, uint256[] memory allocations) {
         // allocationAmount > 0, n > 0, and step > 0 are guaranteed by the callers.
 
-        AllocationState memory state;
-        state.sharesX96 = operatorsData.sharesX96;
-        state.currents = operatorsData.currents;
-        state.capacities = operatorsData.capacities;
-        state.totalCurrent = operatorsData.totalCurrent;
+        AllocationState memory state = operatorsData.alloc;
 
-        for (uint256 i; i < operatorsData.sharesX96.length; ++i) {
+        for (uint256 i; i < state.sharesX96.length; ++i) {
             // NOTE: no zero-check here. Collectors filter out zero weights and truncate
             //       arrays to eligible node operators count, so sharesX96 entries are non-zero.
 
@@ -323,10 +315,10 @@ library CuratedDepositAllocator {
     /// @dev Shrinks eligible arrays to the collected eligible count.
     function _truncateDepositable(DepositableOperatorsData memory data) internal pure {
         uint256 count = data.count;
-        if (count == data.sharesX96.length) return;
-        uint256[] memory sharesX96 = data.sharesX96;
-        uint256[] memory currents = data.currents;
-        uint256[] memory capacities = data.capacities;
+        if (count == data.alloc.sharesX96.length) return;
+        uint256[] memory sharesX96 = data.alloc.sharesX96;
+        uint256[] memory currents = data.alloc.currents;
+        uint256[] memory capacities = data.alloc.capacities;
         uint256[] memory operatorIds = data.operatorIds;
         assembly {
             mstore(sharesX96, count)


### PR DESCRIPTION
## Description

- Embed `AllocationState` directly inside `DepositableOperatorsData`, removing duplicated fields and the field-by-field copy in `_computeAllocations`.
- Remove stale TODO about struct-of-arrays refactor — parallel arrays are the right fit for the allocation pipeline.

## Checklist

- [x] Appropriate PR labels applied
- [x] Test coverage maintained (`just coverage`)
  - [x] No need to add/update tests
  - [ ] Tests are added/updated
- [x] Documentation maintained
  - [x] No need to update
  - [ ] Updated
