### PR TITLE
chore: Add generalised view methdos

### DIFF
--- a/src/Accounting.sol
+++ b/src/Accounting.sol
@@ -430,7 +430,8 @@ contract Accounting is
 
     /// @inheritdoc IAccounting
     function getNodeOperatorBondInfo(uint256 nodeOperatorId) external view returns (NodeOperatorBondInfo memory info) {
-        info.current = BondCore.getBond(nodeOperatorId);
+        info.currentBond = BondCore.getBond(nodeOperatorId);
+        info.requiredBond = _getRequiredBond(nodeOperatorId, 0);
         info.lockedBond = BondLock.getLockedBond(nodeOperatorId);
         info.bondDebt = BondCore.getBondDebt(nodeOperatorId);
         info.pendingSharesToSplit = FeeSplits.getPendingSharesToSplit(nodeOperatorId);

--- a/src/Accounting.sol
+++ b/src/Accounting.sol
@@ -429,6 +429,14 @@ contract Accounting is
     }
 
     /// @inheritdoc IAccounting
+    function getNodeOperatorBondInfo(uint256 nodeOperatorId) external view returns (NodeOperatorBondInfo memory info) {
+        info.current = BondCore.getBond(nodeOperatorId);
+        info.lockedBond = BondLock.getLockedBond(nodeOperatorId);
+        info.bondDebt = BondCore.getBondDebt(nodeOperatorId);
+        info.pendingSharesToSplit = FeeSplits.getPendingSharesToSplit(nodeOperatorId);
+    }
+
+    /// @inheritdoc IAccounting
     function getBondSummary(uint256 nodeOperatorId) public view returns (uint256 current, uint256 required) {
         current = BondCore.getBond(nodeOperatorId);
         required = _getRequiredBond(nodeOperatorId, 0);

--- a/src/ParametersRegistry.sol
+++ b/src/ParametersRegistry.sol
@@ -460,93 +460,80 @@ contract ParametersRegistry is IParametersRegistry, Initializable, AccessControl
 
     /// @inheritdoc IParametersRegistry
     function getKeyRemovalCharge(uint256 curveId) external view returns (uint256 keyRemovalCharge) {
-        MarkedUint248 storage data = _keyRemovalCharges[curveId];
-        return data.isValue ? data.value : defaultKeyRemovalCharge;
+        return _getKeyRemovalCharge(curveId);
     }
 
     /// @inheritdoc IParametersRegistry
     function getGeneralDelayedPenaltyAdditionalFine(uint256 curveId) external view returns (uint256 fine) {
-        MarkedUint248 storage data = _generalDelayedPenaltyAdditionalFines[curveId];
-        return data.isValue ? data.value : defaultGeneralDelayedPenaltyAdditionalFine;
+        return _getGeneralDelayedPenaltyAdditionalFine(curveId);
     }
 
     /// @inheritdoc IParametersRegistry
     function getKeysLimit(uint256 curveId) external view returns (uint256 limit) {
-        MarkedUint248 storage data = _keysLimits[curveId];
-        return data.isValue ? data.value : defaultKeysLimit;
+        return _getKeysLimit(curveId);
     }
 
     /// @inheritdoc IParametersRegistry
     function getQueueConfig(uint256 curveId) external view returns (uint32 queuePriority, uint32 maxDeposits) {
-        QueueConfig storage config = _queueConfigs[curveId];
-
-        if (config.maxDeposits == 0) return (defaultQueueConfig.priority, defaultQueueConfig.maxDeposits);
-
-        return (config.priority, config.maxDeposits);
+        return _getQueueConfig(curveId);
     }
 
     /// @inheritdoc IParametersRegistry
     function getRewardShareData(uint256 curveId) external view returns (KeyNumberValueInterval[] memory data) {
-        data = _rewardShareData[curveId];
-        if (data.length == 0) {
-            data = new KeyNumberValueInterval[](1);
-            data[0] = KeyNumberValueInterval(1, defaultRewardShare);
-        }
+        return _getRewardShareData(curveId);
     }
 
     /// @inheritdoc IParametersRegistry
     function getPerformanceLeewayData(uint256 curveId) external view returns (KeyNumberValueInterval[] memory data) {
-        data = _performanceLeewayData[curveId];
-        if (data.length == 0) {
-            data = new KeyNumberValueInterval[](1);
-            data[0] = KeyNumberValueInterval(1, defaultPerformanceLeeway);
-        }
+        return _getPerformanceLeewayData(curveId);
     }
 
     /// @inheritdoc IParametersRegistry
     function getStrikesParams(uint256 curveId) external view returns (uint256 lifetime, uint256 threshold) {
-        StrikesParams storage params = _strikesParams[curveId];
-        if (params.threshold == 0) return (defaultStrikesParams.lifetime, defaultStrikesParams.threshold);
-        return (params.lifetime, params.threshold);
+        return _getStrikesParams(curveId);
     }
 
     /// @inheritdoc IParametersRegistry
     function getBadPerformancePenalty(uint256 curveId) external view returns (uint256 penalty) {
-        MarkedUint248 storage data = _badPerformancePenalties[curveId];
-        return data.isValue ? data.value : defaultBadPerformancePenalty;
+        return _getBadPerformancePenalty(curveId);
     }
 
     /// @inheritdoc IParametersRegistry
     function getPerformanceCoefficients(
         uint256 curveId
     ) external view returns (uint256 attestationsWeight, uint256 blocksWeight, uint256 syncWeight) {
-        PerformanceCoefficients storage coefficients = _performanceCoefficients[curveId];
-        if (coefficients.attestationsWeight == 0 && coefficients.blocksWeight == 0 && coefficients.syncWeight == 0) {
-            return (
-                defaultPerformanceCoefficients.attestationsWeight,
-                defaultPerformanceCoefficients.blocksWeight,
-                defaultPerformanceCoefficients.syncWeight
-            );
-        }
-        return (coefficients.attestationsWeight, coefficients.blocksWeight, coefficients.syncWeight);
+        return _getPerformanceCoefficients(curveId);
     }
 
     /// @inheritdoc IParametersRegistry
     function getAllowedExitDelay(uint256 curveId) external view returns (uint256 delay) {
-        delay = _allowedExitDelay[curveId];
-        if (delay == 0) return defaultAllowedExitDelay;
+        return _getAllowedExitDelay(curveId);
     }
 
     /// @inheritdoc IParametersRegistry
     function getExitDelayFee(uint256 curveId) external view returns (uint256 penalty) {
-        MarkedUint248 memory data = _exitDelayFees[curveId];
-        return data.isValue ? data.value : defaultExitDelayFee;
+        return _getExitDelayFee(curveId);
     }
 
     /// @inheritdoc IParametersRegistry
     function getMaxElWithdrawalRequestFee(uint256 curveId) external view returns (uint256 fee) {
-        MarkedUint248 memory data = _maxElWithdrawalRequestFees[curveId];
-        return data.isValue ? data.value : defaultMaxElWithdrawalRequestFee;
+        return _getMaxElWithdrawalRequestFee(curveId);
+    }
+
+    /// @inheritdoc IParametersRegistry
+    function getCurveParameters(uint256 curveId) external view returns (CurveParameters memory params) {
+        params.keyRemovalCharge = _getKeyRemovalCharge(curveId);
+        params.generalDelayedPenaltyAdditionalFine = _getGeneralDelayedPenaltyAdditionalFine(curveId);
+        params.keysLimit = _getKeysLimit(curveId);
+        (params.queuePriority, params.queueMaxDeposits) = _getQueueConfig(curveId);
+        params.rewardShareData = _getRewardShareData(curveId);
+        params.performanceLeewayData = _getPerformanceLeewayData(curveId);
+        (params.strikesLifetime, params.strikesThreshold) = _getStrikesParams(curveId);
+        params.badPerformancePenalty = _getBadPerformancePenalty(curveId);
+        (params.attestationsWeight, params.blocksWeight, params.syncWeight) = _getPerformanceCoefficients(curveId);
+        params.allowedExitDelay = _getAllowedExitDelay(curveId);
+        params.exitDelayFee = _getExitDelayFee(curveId);
+        params.maxElWithdrawalRequestFee = _getMaxElWithdrawalRequestFee(curveId);
     }
 
     /// @inheritdoc IParametersRegistry
@@ -632,6 +619,81 @@ contract ParametersRegistry is IParametersRegistry, Initializable, AccessControl
     function _setDefaultMaxElWithdrawalRequestFee(uint256 fee) internal {
         defaultMaxElWithdrawalRequestFee = fee;
         emit DefaultMaxElWithdrawalRequestFeeSet(fee);
+    }
+
+    function _getKeyRemovalCharge(uint256 curveId) internal view returns (uint256) {
+        MarkedUint248 storage data = _keyRemovalCharges[curveId];
+        return data.isValue ? data.value : defaultKeyRemovalCharge;
+    }
+
+    function _getGeneralDelayedPenaltyAdditionalFine(uint256 curveId) internal view returns (uint256) {
+        MarkedUint248 storage data = _generalDelayedPenaltyAdditionalFines[curveId];
+        return data.isValue ? data.value : defaultGeneralDelayedPenaltyAdditionalFine;
+    }
+
+    function _getKeysLimit(uint256 curveId) internal view returns (uint256) {
+        MarkedUint248 storage data = _keysLimits[curveId];
+        return data.isValue ? data.value : defaultKeysLimit;
+    }
+
+    function _getQueueConfig(uint256 curveId) internal view returns (uint32, uint32) {
+        QueueConfig storage config = _queueConfigs[curveId];
+        if (config.maxDeposits == 0) return (defaultQueueConfig.priority, defaultQueueConfig.maxDeposits);
+        return (config.priority, config.maxDeposits);
+    }
+
+    function _getRewardShareData(uint256 curveId) internal view returns (KeyNumberValueInterval[] memory data) {
+        data = _rewardShareData[curveId];
+        if (data.length == 0) {
+            data = new KeyNumberValueInterval[](1);
+            data[0] = KeyNumberValueInterval(1, defaultRewardShare);
+        }
+    }
+
+    function _getPerformanceLeewayData(uint256 curveId) internal view returns (KeyNumberValueInterval[] memory data) {
+        data = _performanceLeewayData[curveId];
+        if (data.length == 0) {
+            data = new KeyNumberValueInterval[](1);
+            data[0] = KeyNumberValueInterval(1, defaultPerformanceLeeway);
+        }
+    }
+
+    function _getStrikesParams(uint256 curveId) internal view returns (uint256, uint256) {
+        StrikesParams storage params = _strikesParams[curveId];
+        if (params.threshold == 0) return (defaultStrikesParams.lifetime, defaultStrikesParams.threshold);
+        return (params.lifetime, params.threshold);
+    }
+
+    function _getBadPerformancePenalty(uint256 curveId) internal view returns (uint256) {
+        MarkedUint248 storage data = _badPerformancePenalties[curveId];
+        return data.isValue ? data.value : defaultBadPerformancePenalty;
+    }
+
+    function _getPerformanceCoefficients(uint256 curveId) internal view returns (uint256, uint256, uint256) {
+        PerformanceCoefficients storage coefficients = _performanceCoefficients[curveId];
+        if (coefficients.attestationsWeight == 0 && coefficients.blocksWeight == 0 && coefficients.syncWeight == 0) {
+            return (
+                defaultPerformanceCoefficients.attestationsWeight,
+                defaultPerformanceCoefficients.blocksWeight,
+                defaultPerformanceCoefficients.syncWeight
+            );
+        }
+        return (coefficients.attestationsWeight, coefficients.blocksWeight, coefficients.syncWeight);
+    }
+
+    function _getAllowedExitDelay(uint256 curveId) internal view returns (uint256 delay) {
+        delay = _allowedExitDelay[curveId];
+        if (delay == 0) return defaultAllowedExitDelay;
+    }
+
+    function _getExitDelayFee(uint256 curveId) internal view returns (uint256) {
+        MarkedUint248 memory data = _exitDelayFees[curveId];
+        return data.isValue ? data.value : defaultExitDelayFee;
+    }
+
+    function _getMaxElWithdrawalRequestFee(uint256 curveId) internal view returns (uint256) {
+        MarkedUint248 memory data = _maxElWithdrawalRequestFees[curveId];
+        return data.isValue ? data.value : defaultMaxElWithdrawalRequestFee;
     }
 
     function _onlyRoleMemberOrAdmin(bytes32 role) internal view {

--- a/src/interfaces/IAccounting.sol
+++ b/src/interfaces/IAccounting.sol
@@ -22,7 +22,8 @@ interface IAccounting is IBondCore, IBondCurve, IBondLock, IFeeSplits, IAssetRec
     }
 
     struct NodeOperatorBondInfo {
-        uint256 current;
+        uint256 currentBond;
+        uint256 requiredBond;
         uint256 lockedBond;
         uint256 bondDebt;
         uint256 pendingSharesToSplit;
@@ -144,8 +145,8 @@ interface IAccounting is IBondCore, IBondCurve, IBondLock, IFeeSplits, IAssetRec
 
     /// @notice Get all bond-related info for the given Node Operator in one call
     /// @param nodeOperatorId ID of the Node Operator
-    /// @return info Bond info containing current bond, locked bond, bond debt,
-    ///         and pending shares to split
+    /// @return info Bond info containing current bond, required bond, locked bond,
+    ///         bond debt, and pending shares to split
     function getNodeOperatorBondInfo(uint256 nodeOperatorId) external view returns (NodeOperatorBondInfo memory info);
 
     /// @notice Get current and required bond amounts in ETH (stETH) for the given Node Operator

--- a/src/interfaces/IAccounting.sol
+++ b/src/interfaces/IAccounting.sol
@@ -21,6 +21,13 @@ interface IAccounting is IBondCore, IBondCurve, IBondLock, IFeeSplits, IAssetRec
         bytes32 s;
     }
 
+    struct NodeOperatorBondInfo {
+        uint256 current;
+        uint256 lockedBond;
+        uint256 bondDebt;
+        uint256 pendingSharesToSplit;
+    }
+
     event BondLockCompensated(uint256 indexed nodeOperatorId, uint256 amount);
     event ChargePenaltyRecipientSet(address chargePenaltyRecipient);
     event CustomRewardsClaimerSet(uint256 indexed nodeOperatorId, address rewardsClaimer);
@@ -134,6 +141,12 @@ interface IAccounting is IBondCore, IBondCurve, IBondLock, IFeeSplits, IAssetRec
     /// @param nodeOperatorId ID of the Node Operator
     /// @return Unbonded keys count
     function getUnbondedKeysCountToEject(uint256 nodeOperatorId) external view returns (uint256);
+
+    /// @notice Get all bond-related info for the given Node Operator in one call
+    /// @param nodeOperatorId ID of the Node Operator
+    /// @return info Bond info containing current bond, locked bond, bond debt,
+    ///         and pending shares to split
+    function getNodeOperatorBondInfo(uint256 nodeOperatorId) external view returns (NodeOperatorBondInfo memory info);
 
     /// @notice Get current and required bond amounts in ETH (stETH) for the given Node Operator
     /// @dev To calculate excess bond amount subtract `required` from `current` value.

--- a/src/interfaces/IParametersRegistry.sol
+++ b/src/interfaces/IParametersRegistry.sol
@@ -54,6 +54,25 @@ interface IParametersRegistry {
         uint256 defaultMaxElWithdrawalRequestFee;
     }
 
+    struct CurveParameters {
+        uint256 keyRemovalCharge;
+        uint256 generalDelayedPenaltyAdditionalFine;
+        uint256 keysLimit;
+        uint32 queuePriority;
+        uint32 queueMaxDeposits;
+        KeyNumberValueInterval[] rewardShareData;
+        KeyNumberValueInterval[] performanceLeewayData;
+        uint256 strikesLifetime;
+        uint256 strikesThreshold;
+        uint256 badPerformancePenalty;
+        uint256 attestationsWeight;
+        uint256 blocksWeight;
+        uint256 syncWeight;
+        uint256 allowedExitDelay;
+        uint256 exitDelayFee;
+        uint256 maxElWithdrawalRequestFee;
+    }
+
     event DefaultKeyRemovalChargeSet(uint256 value);
     event DefaultGeneralDelayedPenaltyAdditionalFineSet(uint256 value);
     event DefaultKeysLimitSet(uint256 value);
@@ -439,6 +458,12 @@ interface IParametersRegistry {
     /// @dev `defaultMaxElWithdrawalRequestFee` is returned if the value is not set for the given curveId.
     /// @param curveId Curve Id to get max EL withdrawal request fee for
     function getMaxElWithdrawalRequestFee(uint256 curveId) external view returns (uint256 fee);
+
+    /// @notice Get all parameters resolved for the given curveId in one call
+    /// @dev Per-curve values are returned where set, otherwise defaults are used
+    /// @param curveId Curve Id to get all parameters for
+    /// @return params All resolved parameters for the given curveId
+    function getCurveParameters(uint256 curveId) external view returns (CurveParameters memory params);
 
     /// @notice Returns the initialized version of the contract
     function getInitializedVersion() external view returns (uint64);

--- a/test/unit/Accounting/NodeOperatorBondInfo.t.sol
+++ b/test/unit/Accounting/NodeOperatorBondInfo.t.sol
@@ -19,7 +19,8 @@ contract NodeOperatorBondInfoTest is BaseTest {
     function test_allZeros() public view {
         IAccounting.NodeOperatorBondInfo memory info = accounting.getNodeOperatorBondInfo(0);
 
-        assertEq(info.current, 0, "current should be 0");
+        assertEq(info.currentBond, 0, "currentBond should be 0");
+        assertEq(info.requiredBond, 0, "requiredBond should be 0");
         assertEq(info.lockedBond, 0, "lockedBond should be 0");
         assertEq(info.bondDebt, 0, "bondDebt should be 0");
         assertEq(info.pendingSharesToSplit, 0, "pendingSharesToSplit should be 0");
@@ -33,7 +34,8 @@ contract NodeOperatorBondInfoTest is BaseTest {
 
         IAccounting.NodeOperatorBondInfo memory info = accounting.getNodeOperatorBondInfo(0);
 
-        assertApproxEqAbs(info.current, bond, 1 wei, "current should be approximately bond");
+        assertApproxEqAbs(info.currentBond, bond, 1 wei, "currentBond should be approximately bond");
+        assertEq(info.requiredBond, 0, "requiredBond should be 0");
         assertEq(info.lockedBond, 0, "lockedBond should be 0");
         assertEq(info.bondDebt, 0, "bondDebt should be 0");
         assertEq(info.pendingSharesToSplit, 0, "pendingSharesToSplit should be 0");
@@ -48,7 +50,8 @@ contract NodeOperatorBondInfoTest is BaseTest {
 
         IAccounting.NodeOperatorBondInfo memory info = accounting.getNodeOperatorBondInfo(0);
 
-        assertEq(info.current, 0, "current should be 0");
+        assertEq(info.currentBond, 0, "currentBond should be 0");
+        assertEq(info.requiredBond, locked, "requiredBond should equal locked bond");
         assertEq(info.lockedBond, locked, "lockedBond should match locked");
         assertEq(info.bondDebt, 0, "bondDebt should be 0");
         assertEq(info.pendingSharesToSplit, 0, "pendingSharesToSplit should be 0");
@@ -63,7 +66,8 @@ contract NodeOperatorBondInfoTest is BaseTest {
 
         IAccounting.NodeOperatorBondInfo memory info = accounting.getNodeOperatorBondInfo(0);
 
-        assertEq(info.current, 0, "current should be 0");
+        assertEq(info.currentBond, 0, "currentBond should be 0");
+        assertEq(info.requiredBond, debt, "requiredBond should be equal to debt when currentBond is 0");
         assertEq(info.lockedBond, 0, "lockedBond should be 0");
         assertEq(info.bondDebt, debt, "bondDebt should match debt");
         assertEq(info.pendingSharesToSplit, 0, "pendingSharesToSplit should be 0");
@@ -89,10 +93,11 @@ contract NodeOperatorBondInfoTest is BaseTest {
         IAccounting.NodeOperatorBondInfo memory info = accounting.getNodeOperatorBondInfo(0);
 
         assertEq(
-            info.current,
+            info.currentBond,
             stETH.getPooledEthByShares(feeShares),
-            "current should be stETH.getPooledEthByShares(feeShares)"
+            "currentBond should be stETH.getPooledEthByShares(feeShares)"
         );
+        assertEq(info.requiredBond, 2 ether, "requiredBond should match required bond");
         assertEq(info.lockedBond, 0, "lockedBond should be 0");
         assertEq(info.bondDebt, 0, "bondDebt should be 0");
         assertEq(info.pendingSharesToSplit, feeShares, "pendingSharesToSplit should match feeShares");
@@ -133,7 +138,13 @@ contract NodeOperatorBondInfoTest is BaseTest {
 
         IAccounting.NodeOperatorBondInfo memory info = accounting.getNodeOperatorBondInfo(0);
 
-        assertEq(info.current, 0, "current should be 0");
+        assertEq(info.currentBond, 0, "currentBond should be 0");
+        assertApproxEqAbs(
+            info.requiredBond,
+            20 ether + locked + debt,
+            1 wei,
+            "requiredBond should be approximately 20 ether + locked + debt"
+        );
         assertEq(info.lockedBond, locked, "lockedBond should match locked");
         assertApproxEqAbs(info.bondDebt, debt, 2 wei, "bondDebt should be approximately debt");
         assertEq(info.pendingSharesToSplit, feeShares, "pendingSharesToSplit should match feeShares");
@@ -143,8 +154,10 @@ contract NodeOperatorBondInfoTest is BaseTest {
 
     function _assertConsistency(uint256 noId) internal view {
         IAccounting.NodeOperatorBondInfo memory info = accounting.getNodeOperatorBondInfo(noId);
+        (uint256 currentBond, uint256 requiredBond) = accounting.getBondSummary(noId);
 
-        assertEq(info.current, accounting.getBond(noId));
+        assertEq(info.currentBond, currentBond);
+        assertEq(info.requiredBond, requiredBond);
         assertEq(info.lockedBond, accounting.getLockedBond(noId));
         assertEq(info.bondDebt, accounting.getBondDebt(noId));
         assertEq(info.pendingSharesToSplit, accounting.getPendingSharesToSplit(noId));

--- a/test/unit/Accounting/NodeOperatorBondInfo.t.sol
+++ b/test/unit/Accounting/NodeOperatorBondInfo.t.sol
@@ -1,0 +1,152 @@
+// SPDX-FileCopyrightText: 2025 Lido <info@lido.fi>
+// SPDX-License-Identifier: GPL-3.0
+
+pragma solidity 0.8.33;
+
+import { BaseTest } from "./_Base.t.sol";
+import { IAccounting } from "src/interfaces/IAccounting.sol";
+import { IFeeSplits } from "src/interfaces/IFeeSplits.sol";
+
+contract NodeOperatorBondInfoTest is BaseTest {
+    function setUp() public override {
+        super.setUp();
+        mock_getNodeOperatorOwner(user);
+        mock_getNodeOperatorsCount(1);
+        mock_getNodeOperatorNonWithdrawnKeys(0);
+        mock_getNodeOperatorManagementProperties(user, user, false);
+    }
+
+    function test_allZeros() public view {
+        IAccounting.NodeOperatorBondInfo memory info = accounting.getNodeOperatorBondInfo(0);
+
+        assertEq(info.current, 0, "current should be 0");
+        assertEq(info.lockedBond, 0, "lockedBond should be 0");
+        assertEq(info.bondDebt, 0, "bondDebt should be 0");
+        assertEq(info.pendingSharesToSplit, 0, "pendingSharesToSplit should be 0");
+
+        _assertConsistency(0);
+    }
+
+    function test_nonZeroCurrent() public assertInvariants {
+        uint256 bond = 10 ether;
+        _deposit({ bond: bond });
+
+        IAccounting.NodeOperatorBondInfo memory info = accounting.getNodeOperatorBondInfo(0);
+
+        assertApproxEqAbs(info.current, bond, 1 wei, "current should be approximately bond");
+        assertEq(info.lockedBond, 0, "lockedBond should be 0");
+        assertEq(info.bondDebt, 0, "bondDebt should be 0");
+        assertEq(info.pendingSharesToSplit, 0, "pendingSharesToSplit should be 0");
+
+        _assertConsistency(0);
+    }
+
+    function test_nonZeroLockedBond() public assertInvariants {
+        uint256 locked = 1 ether;
+        vm.prank(address(stakingModule));
+        accounting.lockBond(0, locked);
+
+        IAccounting.NodeOperatorBondInfo memory info = accounting.getNodeOperatorBondInfo(0);
+
+        assertEq(info.current, 0, "current should be 0");
+        assertEq(info.lockedBond, locked, "lockedBond should match locked");
+        assertEq(info.bondDebt, 0, "bondDebt should be 0");
+        assertEq(info.pendingSharesToSplit, 0, "pendingSharesToSplit should be 0");
+
+        _assertConsistency(0);
+    }
+
+    function test_nonZeroBondDebt() public assertInvariants {
+        uint256 debt = 2 ether;
+        vm.prank(address(stakingModule));
+        accounting.penalize(0, debt);
+
+        IAccounting.NodeOperatorBondInfo memory info = accounting.getNodeOperatorBondInfo(0);
+
+        assertEq(info.current, 0, "current should be 0");
+        assertEq(info.lockedBond, 0, "lockedBond should be 0");
+        assertEq(info.bondDebt, debt, "bondDebt should match debt");
+        assertEq(info.pendingSharesToSplit, 0, "pendingSharesToSplit should be 0");
+
+        _assertConsistency(0);
+    }
+
+    function test_nonZeroPendingSharesToSplit() public assertInvariants {
+        // Set up fee splits
+        IFeeSplits.FeeSplit[] memory splits = new IFeeSplits.FeeSplit[](1);
+        splits[0] = IFeeSplits.FeeSplit({ recipient: address(1), share: 5000 });
+        vm.prank(user);
+        accounting.updateFeeSplits(0, splits, 0, new bytes32[](0));
+
+        // Set up keys so required bond > 0
+        mock_getNodeOperatorNonWithdrawnKeys(1);
+
+        // Mint fee shares and distribute (no bond deposited, so claimable = 0, pending stays)
+        uint256 feeShares = 154;
+        stETH.mintShares(address(feeDistributor), feeShares);
+        accounting.pullAndSplitFeeRewards(0, feeShares, new bytes32[](1));
+
+        IAccounting.NodeOperatorBondInfo memory info = accounting.getNodeOperatorBondInfo(0);
+
+        assertEq(
+            info.current,
+            stETH.getPooledEthByShares(feeShares),
+            "current should be stETH.getPooledEthByShares(feeShares)"
+        );
+        assertEq(info.lockedBond, 0, "lockedBond should be 0");
+        assertEq(info.bondDebt, 0, "bondDebt should be 0");
+        assertEq(info.pendingSharesToSplit, feeShares, "pendingSharesToSplit should match feeShares");
+
+        _assertConsistency(0);
+    }
+
+    function test_allNonZero() public assertInvariants {
+        // Deposit bond
+        uint256 bond = 5 ether;
+        _deposit({ bond: bond });
+
+        // Lock some bond
+        uint256 locked = 1 ether;
+        vm.prank(address(stakingModule));
+        accounting.lockBond(0, locked);
+
+        // Set up fee splits
+        IFeeSplits.FeeSplit[] memory splits = new IFeeSplits.FeeSplit[](1);
+        splits[0] = IFeeSplits.FeeSplit({ recipient: address(1), share: 5000 });
+        vm.prank(user);
+        accounting.updateFeeSplits(0, splits, 0, new bytes32[](0));
+
+        // Set up keys so required bond > current (no claimable → pending stays)
+        mock_getNodeOperatorNonWithdrawnKeys(10);
+
+        // Distribute rewards
+        uint256 feeShares = 154;
+        stETH.mintShares(address(feeDistributor), feeShares);
+        accounting.pullAndSplitFeeRewards(0, feeShares, new bytes32[](1));
+
+        // Penalize to create debt
+        uint256 currentBond = accounting.getBond(0);
+        uint256 debt = 0.5 ether;
+        uint256 penalty = currentBond + debt;
+        vm.prank(address(stakingModule));
+        accounting.penalize(0, penalty);
+
+        IAccounting.NodeOperatorBondInfo memory info = accounting.getNodeOperatorBondInfo(0);
+
+        assertEq(info.current, 0, "current should be 0");
+        assertEq(info.lockedBond, locked, "lockedBond should match locked");
+        assertApproxEqAbs(info.bondDebt, debt, 2 wei, "bondDebt should be approximately debt");
+        assertEq(info.pendingSharesToSplit, feeShares, "pendingSharesToSplit should match feeShares");
+
+        _assertConsistency(0);
+    }
+
+    function _assertConsistency(uint256 noId) internal view {
+        IAccounting.NodeOperatorBondInfo memory info = accounting.getNodeOperatorBondInfo(noId);
+
+        assertEq(info.current, accounting.getBond(noId));
+        assertEq(info.lockedBond, accounting.getLockedBond(noId));
+        assertEq(info.bondDebt, accounting.getBondDebt(noId));
+        assertEq(info.pendingSharesToSplit, accounting.getPendingSharesToSplit(noId));
+    }
+}

--- a/test/unit/ParametersRegistry.t.sol
+++ b/test/unit/ParametersRegistry.t.sol
@@ -2231,3 +2231,148 @@ contract ParametersRegistryMaxElWithdrawalRequestFeeTest is ParametersRegistryBa
         assertEq(feeOut, defaultInitData.defaultMaxElWithdrawalRequestFee);
     }
 }
+
+contract ParametersRegistryCurveParametersTest is ParametersRegistryBaseTestInitialized {
+    uint256 constant CURVE_ID = 1;
+
+    function test_getCurveParameters_defaultData() public view {
+        IParametersRegistry.CurveParameters memory p = parametersRegistry.getCurveParameters(CURVE_ID);
+
+        assertEq(p.keyRemovalCharge, defaultInitData.defaultKeyRemovalCharge);
+        assertEq(p.generalDelayedPenaltyAdditionalFine, defaultInitData.defaultGeneralDelayedPenaltyAdditionalFine);
+        assertEq(p.keysLimit, defaultInitData.defaultKeysLimit);
+        assertEq(p.queuePriority, defaultInitData.defaultQueuePriority);
+        assertEq(p.queueMaxDeposits, defaultInitData.defaultQueueMaxDeposits);
+
+        assertEq(p.rewardShareData.length, 1);
+        assertEq(p.rewardShareData[0].minKeyNumber, 1);
+        assertEq(p.rewardShareData[0].value, defaultInitData.defaultRewardShare);
+
+        assertEq(p.performanceLeewayData.length, 1);
+        assertEq(p.performanceLeewayData[0].minKeyNumber, 1);
+        assertEq(p.performanceLeewayData[0].value, defaultInitData.defaultPerformanceLeeway);
+
+        assertEq(p.strikesLifetime, defaultInitData.defaultStrikesLifetime);
+        assertEq(p.strikesThreshold, defaultInitData.defaultStrikesThreshold);
+        assertEq(p.badPerformancePenalty, defaultInitData.defaultBadPerformancePenalty);
+        assertEq(p.attestationsWeight, defaultInitData.defaultAttestationsWeight);
+        assertEq(p.blocksWeight, defaultInitData.defaultBlocksWeight);
+        assertEq(p.syncWeight, defaultInitData.defaultSyncWeight);
+        assertEq(p.allowedExitDelay, defaultInitData.defaultAllowedExitDelay);
+        assertEq(p.exitDelayFee, defaultInitData.defaultExitDelayFee);
+        assertEq(p.maxElWithdrawalRequestFee, defaultInitData.defaultMaxElWithdrawalRequestFee);
+
+        _assertConsistency(CURVE_ID);
+    }
+
+    function test_getCurveParameters_customData() public {
+        _setAllCurveParameters();
+
+        IParametersRegistry.CurveParameters memory p = parametersRegistry.getCurveParameters(CURVE_ID);
+
+        assertEq(p.keyRemovalCharge, 1 ether);
+        assertEq(p.generalDelayedPenaltyAdditionalFine, 2 ether);
+        assertEq(p.keysLimit, 500);
+        assertEq(p.queuePriority, 3);
+        assertEq(p.queueMaxDeposits, 42);
+
+        assertEq(p.rewardShareData.length, 2);
+        assertEq(p.rewardShareData[0].minKeyNumber, 1);
+        assertEq(p.rewardShareData[0].value, 10000);
+        assertEq(p.rewardShareData[1].minKeyNumber, 10);
+        assertEq(p.rewardShareData[1].value, 8000);
+
+        assertEq(p.performanceLeewayData.length, 2);
+        assertEq(p.performanceLeewayData[0].minKeyNumber, 1);
+        assertEq(p.performanceLeewayData[0].value, 500);
+        assertEq(p.performanceLeewayData[1].minKeyNumber, 100);
+        assertEq(p.performanceLeewayData[1].value, 400);
+
+        assertEq(p.strikesLifetime, 12);
+        assertEq(p.strikesThreshold, 6);
+        assertEq(p.badPerformancePenalty, 0.5 ether);
+        assertEq(p.attestationsWeight, 100);
+        assertEq(p.blocksWeight, 20);
+        assertEq(p.syncWeight, 5);
+        assertEq(p.allowedExitDelay, 3 days);
+        assertEq(p.exitDelayFee, 0.2 ether);
+        assertEq(p.maxElWithdrawalRequestFee, 0.3 ether);
+
+        _assertConsistency(CURVE_ID);
+    }
+
+    function _setAllCurveParameters() internal {
+        IParametersRegistry.KeyNumberValueInterval[] memory rsData = new IParametersRegistry.KeyNumberValueInterval[](
+            2
+        );
+        rsData[0] = IParametersRegistry.KeyNumberValueInterval(1, 10000);
+        rsData[1] = IParametersRegistry.KeyNumberValueInterval(10, 8000);
+
+        IParametersRegistry.KeyNumberValueInterval[] memory plData = new IParametersRegistry.KeyNumberValueInterval[](
+            2
+        );
+        plData[0] = IParametersRegistry.KeyNumberValueInterval(1, 500);
+        plData[1] = IParametersRegistry.KeyNumberValueInterval(100, 400);
+
+        vm.startPrank(admin);
+        parametersRegistry.setKeyRemovalCharge(CURVE_ID, 1 ether);
+        parametersRegistry.setGeneralDelayedPenaltyAdditionalFine(CURVE_ID, 2 ether);
+        parametersRegistry.setKeysLimit(CURVE_ID, 500);
+        parametersRegistry.setQueueConfig(CURVE_ID, 3, 42);
+        parametersRegistry.setRewardShareData(CURVE_ID, rsData);
+        parametersRegistry.setPerformanceLeewayData(CURVE_ID, plData);
+        parametersRegistry.setStrikesParams(CURVE_ID, 12, 6);
+        parametersRegistry.setBadPerformancePenalty(CURVE_ID, 0.5 ether);
+        parametersRegistry.setPerformanceCoefficients(CURVE_ID, 100, 20, 5);
+        parametersRegistry.setAllowedExitDelay(CURVE_ID, 3 days);
+        parametersRegistry.setExitDelayFee(CURVE_ID, 0.2 ether);
+        parametersRegistry.setMaxElWithdrawalRequestFee(CURVE_ID, 0.3 ether);
+        vm.stopPrank();
+    }
+
+    function _assertConsistency(uint256 curveId) internal view {
+        IParametersRegistry.CurveParameters memory p = parametersRegistry.getCurveParameters(curveId);
+
+        assertEq(p.keyRemovalCharge, parametersRegistry.getKeyRemovalCharge(curveId));
+        assertEq(
+            p.generalDelayedPenaltyAdditionalFine,
+            parametersRegistry.getGeneralDelayedPenaltyAdditionalFine(curveId)
+        );
+        assertEq(p.keysLimit, parametersRegistry.getKeysLimit(curveId));
+
+        (uint32 qp, uint32 md) = parametersRegistry.getQueueConfig(curveId);
+        assertEq(p.queuePriority, qp);
+        assertEq(p.queueMaxDeposits, md);
+
+        IParametersRegistry.KeyNumberValueInterval[] memory rsOut = parametersRegistry.getRewardShareData(curveId);
+        assertEq(p.rewardShareData.length, rsOut.length);
+        for (uint256 i = 0; i < rsOut.length; ++i) {
+            assertEq(p.rewardShareData[i].minKeyNumber, rsOut[i].minKeyNumber);
+            assertEq(p.rewardShareData[i].value, rsOut[i].value);
+        }
+
+        IParametersRegistry.KeyNumberValueInterval[] memory plOut = parametersRegistry.getPerformanceLeewayData(
+            curveId
+        );
+        assertEq(p.performanceLeewayData.length, plOut.length);
+        for (uint256 i = 0; i < plOut.length; ++i) {
+            assertEq(p.performanceLeewayData[i].minKeyNumber, plOut[i].minKeyNumber);
+            assertEq(p.performanceLeewayData[i].value, plOut[i].value);
+        }
+
+        (uint256 lt, uint256 th) = parametersRegistry.getStrikesParams(curveId);
+        assertEq(p.strikesLifetime, lt);
+        assertEq(p.strikesThreshold, th);
+
+        assertEq(p.badPerformancePenalty, parametersRegistry.getBadPerformancePenalty(curveId));
+
+        (uint256 aw, uint256 bw, uint256 sw) = parametersRegistry.getPerformanceCoefficients(curveId);
+        assertEq(p.attestationsWeight, aw);
+        assertEq(p.blocksWeight, bw);
+        assertEq(p.syncWeight, sw);
+
+        assertEq(p.allowedExitDelay, parametersRegistry.getAllowedExitDelay(curveId));
+        assertEq(p.exitDelayFee, parametersRegistry.getExitDelayFee(curveId));
+        assertEq(p.maxElWithdrawalRequestFee, parametersRegistry.getMaxElWithdrawalRequestFee(curveId));
+    }
+}


### PR DESCRIPTION
## Description

- Add `getCurveParameters` to `ParametersRegistry.sol` to get all curve params in one call
- Add `getNodeOperatorBondInfo` to `Accounting.sol` to get bond state params in one call

## Checklist

- [x] Appropriate PR labels applied
- [x] Test coverage maintained (`just coverage`)
  - [x] Tests are added/updated
- [x] Documentation maintained
  - [x] Updated
