### PR TITLE
feat: add getDepositAllocationTargets and getTopUpAllocationTargets views

### DIFF
--- a/src/CuratedModule.sol
+++ b/src/CuratedModule.sol
@@ -210,6 +210,31 @@ contract CuratedModule is ICuratedModule, BaseModule {
     }
 
     /// @inheritdoc ICuratedModule
+    function getDepositAllocationTargets()
+        external
+        view
+        returns (uint256[] memory operatorIds, uint256[] memory currents, uint256[] memory targets)
+    {
+        _requireDepositInfoUpToDate();
+        BaseModuleStorage storage $ = _baseStorage();
+        return CuratedDepositAllocator.getDepositAllocationTargets($.nodeOperators, $.nodeOperatorsCount);
+    }
+
+    /// @inheritdoc ICuratedModule
+    function getTopUpAllocationTargets()
+        external
+        view
+        returns (uint256[] memory operatorIds, uint256[] memory currents, uint256[] memory targets)
+    {
+        _requireDepositInfoUpToDate();
+        return
+            CuratedDepositAllocator.getTopUpAllocationTargets(
+                _curatedStorage().operatorBalances,
+                _baseStorage().nodeOperatorsCount
+            );
+    }
+
+    /// @inheritdoc ICuratedModule
     function getDepositsAllocation(
         uint256 maxDepositAmount
     ) external view returns (uint256 allocated, uint256[] memory operatorIds, uint256[] memory allocations) {

--- a/src/CuratedModule.sol
+++ b/src/CuratedModule.sol
@@ -210,14 +210,22 @@ contract CuratedModule is ICuratedModule, BaseModule {
     }
 
     /// @inheritdoc ICuratedModule
-    function getDepositAllocationTargets() external view returns (uint256[] memory currents, uint256[] memory targets) {
+    function getDepositAllocationTargets()
+        external
+        view
+        returns (uint256[] memory currentValidators, uint256[] memory targetValidators)
+    {
         _requireDepositInfoUpToDate();
         BaseModuleStorage storage $ = _baseStorage();
         return CuratedDepositAllocator.getDepositAllocationTargets($.nodeOperators, $.nodeOperatorsCount);
     }
 
     /// @inheritdoc ICuratedModule
-    function getTopUpAllocationTargets() external view returns (uint256[] memory currents, uint256[] memory targets) {
+    function getTopUpAllocationTargets()
+        external
+        view
+        returns (uint256[] memory currentAllocations, uint256[] memory targetAllocations)
+    {
         _requireDepositInfoUpToDate();
         return
             CuratedDepositAllocator.getTopUpAllocationTargets(

--- a/src/CuratedModule.sol
+++ b/src/CuratedModule.sol
@@ -210,22 +210,14 @@ contract CuratedModule is ICuratedModule, BaseModule {
     }
 
     /// @inheritdoc ICuratedModule
-    function getDepositAllocationTargets()
-        external
-        view
-        returns (uint256[] memory operatorIds, uint256[] memory currents, uint256[] memory targets)
-    {
+    function getDepositAllocationTargets() external view returns (uint256[] memory currents, uint256[] memory targets) {
         _requireDepositInfoUpToDate();
         BaseModuleStorage storage $ = _baseStorage();
         return CuratedDepositAllocator.getDepositAllocationTargets($.nodeOperators, $.nodeOperatorsCount);
     }
 
     /// @inheritdoc ICuratedModule
-    function getTopUpAllocationTargets()
-        external
-        view
-        returns (uint256[] memory operatorIds, uint256[] memory currents, uint256[] memory targets)
-    {
+    function getTopUpAllocationTargets() external view returns (uint256[] memory currents, uint256[] memory targets) {
         _requireDepositInfoUpToDate();
         return
             CuratedDepositAllocator.getTopUpAllocationTargets(

--- a/src/interfaces/ICuratedModule.sol
+++ b/src/interfaces/ICuratedModule.sol
@@ -47,31 +47,25 @@ interface ICuratedModule is IBaseModule, IStakingModuleV2 {
         uint256[] calldata operatorIds
     ) external view returns (uint256[] memory operatorWeights);
 
-    /// @notice Returns current deposit allocation targets for all operators with non-zero weight.
+    /// @notice Returns current deposit allocation targets for all operators.
     /// @dev Target = totalCurrent * operatorWeight / totalWeight (in validator count).
     ///      Includes operators regardless of depositable capacity for informational purposes.
     ///      Actual allocation recalculates shares only across operators with available capacity,
     ///      so real per-operator amounts may differ from the targets shown here.
-    /// @return operatorIds Operator ids with non-zero weight.
+    ///      Arrays are indexed by operator id; zero-weight operators have zero values.
     /// @return currents Current active validator count per operator.
     /// @return targets Target validator count per operator.
-    function getDepositAllocationTargets()
-        external
-        view
-        returns (uint256[] memory operatorIds, uint256[] memory currents, uint256[] memory targets);
+    function getDepositAllocationTargets() external view returns (uint256[] memory currents, uint256[] memory targets);
 
-    /// @notice Returns current top-up allocation targets for all operators with non-zero weight.
+    /// @notice Returns current top-up allocation targets for all operators.
     /// @dev Target = totalCurrent * operatorWeight / totalWeight (in wei).
     ///      Includes operators regardless of top-up capacity for informational purposes.
     ///      Actual allocation recalculates shares only across operators with available capacity,
     ///      so real per-operator amounts may differ from the targets shown here.
-    /// @return operatorIds Operator ids with non-zero weight.
+    ///      Arrays are indexed by operator id; zero-weight operators have zero values.
     /// @return currents Current operator stake in wei.
     /// @return targets Target operator stake in wei.
-    function getTopUpAllocationTargets()
-        external
-        view
-        returns (uint256[] memory operatorIds, uint256[] memory currents, uint256[] memory targets);
+    function getTopUpAllocationTargets() external view returns (uint256[] memory currents, uint256[] memory targets);
 
     /// @notice  Method to get list of operators and amount of Eth that can be topped up to operator from depositAmount
     /// @param depositAmount Amount of Eth that can be deposited to module

--- a/src/interfaces/ICuratedModule.sol
+++ b/src/interfaces/ICuratedModule.sol
@@ -47,6 +47,32 @@ interface ICuratedModule is IBaseModule, IStakingModuleV2 {
         uint256[] calldata operatorIds
     ) external view returns (uint256[] memory operatorWeights);
 
+    /// @notice Returns current deposit allocation targets for all operators with non-zero weight.
+    /// @dev Target = totalCurrent * operatorWeight / totalWeight (in validator count).
+    ///      Includes operators regardless of depositable capacity for informational purposes.
+    ///      Actual allocation recalculates shares only across operators with available capacity,
+    ///      so real per-operator amounts may differ from the targets shown here.
+    /// @return operatorIds Operator ids with non-zero weight.
+    /// @return currents Current active validator count per operator.
+    /// @return targets Target validator count per operator.
+    function getDepositAllocationTargets()
+        external
+        view
+        returns (uint256[] memory operatorIds, uint256[] memory currents, uint256[] memory targets);
+
+    /// @notice Returns current top-up allocation targets for all operators with non-zero weight.
+    /// @dev Target = totalCurrent * operatorWeight / totalWeight (in wei).
+    ///      Includes operators regardless of top-up capacity for informational purposes.
+    ///      Actual allocation recalculates shares only across operators with available capacity,
+    ///      so real per-operator amounts may differ from the targets shown here.
+    /// @return operatorIds Operator ids with non-zero weight.
+    /// @return currents Current operator stake in wei.
+    /// @return targets Target operator stake in wei.
+    function getTopUpAllocationTargets()
+        external
+        view
+        returns (uint256[] memory operatorIds, uint256[] memory currents, uint256[] memory targets);
+
     /// @notice  Method to get list of operators and amount of Eth that can be topped up to operator from depositAmount
     /// @param depositAmount Amount of Eth that can be deposited to module
     function getDepositsAllocation(

--- a/src/interfaces/ICuratedModule.sol
+++ b/src/interfaces/ICuratedModule.sol
@@ -53,9 +53,12 @@ interface ICuratedModule is IBaseModule, IStakingModuleV2 {
     ///      Actual allocation recalculates shares only across operators with available capacity,
     ///      so real per-operator amounts may differ from the targets shown here.
     ///      Arrays are indexed by operator id; zero-weight operators have zero values.
-    /// @return currents Current active validator count per operator.
-    /// @return targets Target validator count per operator.
-    function getDepositAllocationTargets() external view returns (uint256[] memory currents, uint256[] memory targets);
+    /// @return currentValidators Current active validator count per operator.
+    /// @return targetValidators Target validator count per operator.
+    function getDepositAllocationTargets()
+        external
+        view
+        returns (uint256[] memory currentValidators, uint256[] memory targetValidators);
 
     /// @notice Returns current top-up allocation targets for all operators.
     /// @dev Target = totalCurrent * operatorWeight / totalWeight (in wei).
@@ -63,9 +66,12 @@ interface ICuratedModule is IBaseModule, IStakingModuleV2 {
     ///      Actual allocation recalculates shares only across operators with available capacity,
     ///      so real per-operator amounts may differ from the targets shown here.
     ///      Arrays are indexed by operator id; zero-weight operators have zero values.
-    /// @return currents Current operator stake in wei.
-    /// @return targets Target operator stake in wei.
-    function getTopUpAllocationTargets() external view returns (uint256[] memory currents, uint256[] memory targets);
+    /// @return currentAllocations Current operator stake in wei.
+    /// @return targetAllocations Target operator stake in wei.
+    function getTopUpAllocationTargets()
+        external
+        view
+        returns (uint256[] memory currentAllocations, uint256[] memory targetAllocations);
 
     /// @notice  Method to get list of operators and amount of Eth that can be topped up to operator from depositAmount
     /// @param depositAmount Amount of Eth that can be deposited to module

--- a/src/lib/allocator/CuratedDepositAllocator.sol
+++ b/src/lib/allocator/CuratedDepositAllocator.sol
@@ -257,23 +257,22 @@ library CuratedDepositAllocator {
         }
     }
 
-    /// @notice Returns current deposit allocation targets for all operators with non-zero weight.
+    /// @notice Returns current deposit allocation targets for all operators.
     /// @dev Target = totalCurrent * operatorWeight / totalWeight (in validator count).
     ///      Includes operators regardless of depositable capacity for informational purposes.
     ///      Actual allocation recalculates shares only across operators with available capacity,
     ///      so real per-operator amounts may differ from the targets shown here.
+    ///      Arrays are indexed by operator id; zero-weight operators have zero values.
     /// @param nodeOperators Node operator storage mapping from the module.
     /// @param operatorsCount Total operators count in the module.
-    /// @return operatorIds Eligible operator ids.
     /// @return currents Current active validator count per operator.
     /// @return targets Target validator count per operator.
     function getDepositAllocationTargets(
         mapping(uint256 => NodeOperator) storage nodeOperators,
         uint256 operatorsCount
-    ) external view returns (uint256[] memory operatorIds, uint256[] memory currents, uint256[] memory targets) {
-        if (operatorsCount == 0) return (operatorIds, currents, targets);
+    ) external view returns (uint256[] memory currents, uint256[] memory targets) {
+        if (operatorsCount == 0) return (currents, targets);
 
-        operatorIds = new uint256[](operatorsCount);
         currents = new uint256[](operatorsCount);
         targets = new uint256[](operatorsCount);
 
@@ -281,7 +280,6 @@ library CuratedDepositAllocator {
 
         uint256 weightSum;
         uint256 totalCurrent;
-        uint256 count;
         for (uint256 i; i < operatorsCount; ++i) {
             NodeOperator storage no = nodeOperators[i];
             (uint256 weight, uint256 externalStake) = metaRegistry.getNodeOperatorWeightAndExternalStake(i);
@@ -291,45 +289,38 @@ library CuratedDepositAllocator {
                 uint256 current = no.totalDepositedKeys - no.totalWithdrawnKeys;
                 if (externalStake > 0) current += externalStake / WithdrawnValidatorLib.MAX_EFFECTIVE_BALANCE;
 
-                operatorIds[count] = i;
-                currents[count] = current;
+                currents[i] = current;
                 // Temporarily store raw weight in targets; will be converted below.
-                targets[count] = weight;
+                targets[i] = weight;
                 weightSum += weight;
                 totalCurrent += current;
-                ++count;
             }
         }
 
-        if (count == 0) return (new uint256[](0), new uint256[](0), new uint256[](0));
+        if (weightSum == 0) return (currents, targets);
 
-        for (uint256 i; i < count; ++i) {
+        for (uint256 i; i < operatorsCount; ++i) {
+            if (targets[i] == 0) continue;
             targets[i] = Math.mulDiv(totalCurrent, targets[i], weightSum);
-        }
-        assembly {
-            mstore(operatorIds, count)
-            mstore(currents, count)
-            mstore(targets, count)
         }
     }
 
-    /// @notice Returns current top-up allocation targets for all operators with non-zero weight.
+    /// @notice Returns current top-up allocation targets for all operators.
     /// @dev Target = totalCurrent * operatorWeight / totalWeight (in wei).
     ///      Includes operators regardless of top-up capacity for informational purposes.
     ///      Actual allocation recalculates shares only across operators with available capacity,
     ///      so real per-operator amounts may differ from the targets shown here.
+    ///      Arrays are indexed by operator id; zero-weight operators have zero values.
     /// @param nodeOperatorBalances Per-operator balance (in wei) storage mapping from the module.
     /// @param operatorsCount Total operators count in the module.
-    /// @return operatorIds Eligible operator ids.
     /// @return currents Current operator stake in wei.
     /// @return targets Target operator stake in wei.
     function getTopUpAllocationTargets(
         mapping(uint256 => uint256) storage nodeOperatorBalances,
         uint256 operatorsCount
-    ) external view returns (uint256[] memory operatorIds, uint256[] memory currents, uint256[] memory targets) {
-        if (operatorsCount == 0) return (operatorIds, currents, targets);
+    ) external view returns (uint256[] memory currents, uint256[] memory targets) {
+        if (operatorsCount == 0) return (currents, targets);
 
-        operatorIds = new uint256[](operatorsCount);
         currents = new uint256[](operatorsCount);
         targets = new uint256[](operatorsCount);
 
@@ -337,30 +328,23 @@ library CuratedDepositAllocator {
 
         uint256 weightSum;
         uint256 totalCurrent;
-        uint256 count;
         for (uint256 i; i < operatorsCount; ++i) {
             (uint256 weight, uint256 externalStake) = metaRegistry.getNodeOperatorWeightAndExternalStake(i);
             if (weight == 0) continue;
 
             uint256 currentStake = nodeOperatorBalances[i] + externalStake;
-            operatorIds[count] = i;
-            currents[count] = currentStake;
+            currents[i] = currentStake;
             // Temporarily store raw weight in targets; will be converted below.
-            targets[count] = weight;
+            targets[i] = weight;
             weightSum += weight;
             totalCurrent += currentStake;
-            ++count;
         }
 
-        if (count == 0) return (new uint256[](0), new uint256[](0), new uint256[](0));
+        if (weightSum == 0) return (currents, targets);
 
-        for (uint256 i; i < count; ++i) {
+        for (uint256 i; i < operatorsCount; ++i) {
+            if (targets[i] == 0) continue;
             targets[i] = Math.mulDiv(totalCurrent, targets[i], weightSum);
-        }
-        assembly {
-            mstore(operatorIds, count)
-            mstore(currents, count)
-            mstore(targets, count)
         }
     }
 

--- a/src/lib/allocator/CuratedDepositAllocator.sol
+++ b/src/lib/allocator/CuratedDepositAllocator.sol
@@ -265,16 +265,16 @@ library CuratedDepositAllocator {
     ///      Arrays are indexed by operator id; zero-weight operators have zero values.
     /// @param nodeOperators Node operator storage mapping from the module.
     /// @param operatorsCount Total operators count in the module.
-    /// @return currents Current active validator count per operator.
-    /// @return targets Target validator count per operator.
+    /// @return currentValidators Current active validator count per operator.
+    /// @return targetValidators Target validator count per operator.
     function getDepositAllocationTargets(
         mapping(uint256 => NodeOperator) storage nodeOperators,
         uint256 operatorsCount
-    ) external view returns (uint256[] memory currents, uint256[] memory targets) {
-        if (operatorsCount == 0) return (currents, targets);
+    ) external view returns (uint256[] memory currentValidators, uint256[] memory targetValidators) {
+        if (operatorsCount == 0) return (currentValidators, targetValidators);
 
-        currents = new uint256[](operatorsCount);
-        targets = new uint256[](operatorsCount);
+        currentValidators = new uint256[](operatorsCount);
+        targetValidators = new uint256[](operatorsCount);
 
         IMetaRegistry metaRegistry = ICuratedModule(address(this)).META_REGISTRY();
 
@@ -289,19 +289,19 @@ library CuratedDepositAllocator {
                 uint256 current = no.totalDepositedKeys - no.totalWithdrawnKeys;
                 if (externalStake > 0) current += externalStake / WithdrawnValidatorLib.MAX_EFFECTIVE_BALANCE;
 
-                currents[i] = current;
-                // Temporarily store raw weight in targets; will be converted below.
-                targets[i] = weight;
+                currentValidators[i] = current;
+                // Temporarily store raw weight in targetValidators; will be converted below.
+                targetValidators[i] = weight;
                 weightSum += weight;
                 totalCurrent += current;
             }
         }
 
-        if (weightSum == 0) return (currents, targets);
+        if (weightSum == 0) return (currentValidators, targetValidators);
 
         for (uint256 i; i < operatorsCount; ++i) {
-            if (targets[i] == 0) continue;
-            targets[i] = Math.mulDiv(totalCurrent, targets[i], weightSum);
+            if (targetValidators[i] == 0) continue;
+            targetValidators[i] = Math.mulDiv(totalCurrent, targetValidators[i], weightSum);
         }
     }
 
@@ -313,16 +313,16 @@ library CuratedDepositAllocator {
     ///      Arrays are indexed by operator id; zero-weight operators have zero values.
     /// @param nodeOperatorBalances Per-operator balance (in wei) storage mapping from the module.
     /// @param operatorsCount Total operators count in the module.
-    /// @return currents Current operator stake in wei.
-    /// @return targets Target operator stake in wei.
+    /// @return currentAllocations Current operator stake in wei.
+    /// @return targetAllocations Target operator stake in wei.
     function getTopUpAllocationTargets(
         mapping(uint256 => uint256) storage nodeOperatorBalances,
         uint256 operatorsCount
-    ) external view returns (uint256[] memory currents, uint256[] memory targets) {
-        if (operatorsCount == 0) return (currents, targets);
+    ) external view returns (uint256[] memory currentAllocations, uint256[] memory targetAllocations) {
+        if (operatorsCount == 0) return (currentAllocations, targetAllocations);
 
-        currents = new uint256[](operatorsCount);
-        targets = new uint256[](operatorsCount);
+        currentAllocations = new uint256[](operatorsCount);
+        targetAllocations = new uint256[](operatorsCount);
 
         IMetaRegistry metaRegistry = ICuratedModule(address(this)).META_REGISTRY();
 
@@ -333,18 +333,18 @@ library CuratedDepositAllocator {
             if (weight == 0) continue;
 
             uint256 currentStake = nodeOperatorBalances[i] + externalStake;
-            currents[i] = currentStake;
-            // Temporarily store raw weight in targets; will be converted below.
-            targets[i] = weight;
+            currentAllocations[i] = currentStake;
+            // Temporarily store raw weight in targetAllocations; will be converted below.
+            targetAllocations[i] = weight;
             weightSum += weight;
             totalCurrent += currentStake;
         }
 
-        if (weightSum == 0) return (currents, targets);
+        if (weightSum == 0) return (currentAllocations, targetAllocations);
 
         for (uint256 i; i < operatorsCount; ++i) {
-            if (targets[i] == 0) continue;
-            targets[i] = Math.mulDiv(totalCurrent, targets[i], weightSum);
+            if (targetAllocations[i] == 0) continue;
+            targetAllocations[i] = Math.mulDiv(totalCurrent, targetAllocations[i], weightSum);
         }
     }
 

--- a/src/lib/allocator/CuratedDepositAllocator.sol
+++ b/src/lib/allocator/CuratedDepositAllocator.sol
@@ -257,6 +257,113 @@ library CuratedDepositAllocator {
         }
     }
 
+    /// @notice Returns current deposit allocation targets for all operators with non-zero weight.
+    /// @dev Target = totalCurrent * operatorWeight / totalWeight (in validator count).
+    ///      Includes operators regardless of depositable capacity for informational purposes.
+    ///      Actual allocation recalculates shares only across operators with available capacity,
+    ///      so real per-operator amounts may differ from the targets shown here.
+    /// @param nodeOperators Node operator storage mapping from the module.
+    /// @param operatorsCount Total operators count in the module.
+    /// @return operatorIds Eligible operator ids.
+    /// @return currents Current active validator count per operator.
+    /// @return targets Target validator count per operator.
+    function getDepositAllocationTargets(
+        mapping(uint256 => NodeOperator) storage nodeOperators,
+        uint256 operatorsCount
+    ) external view returns (uint256[] memory operatorIds, uint256[] memory currents, uint256[] memory targets) {
+        if (operatorsCount == 0) return (operatorIds, currents, targets);
+
+        operatorIds = new uint256[](operatorsCount);
+        currents = new uint256[](operatorsCount);
+        targets = new uint256[](operatorsCount);
+
+        IMetaRegistry metaRegistry = ICuratedModule(address(this)).META_REGISTRY();
+
+        uint256 weightSum;
+        uint256 totalCurrent;
+        uint256 count;
+        for (uint256 i; i < operatorsCount; ++i) {
+            NodeOperator storage no = nodeOperators[i];
+            (uint256 weight, uint256 externalStake) = metaRegistry.getNodeOperatorWeightAndExternalStake(i);
+            if (weight == 0) continue;
+
+            unchecked {
+                uint256 current = no.totalDepositedKeys - no.totalWithdrawnKeys;
+                if (externalStake > 0) current += externalStake / WithdrawnValidatorLib.MAX_EFFECTIVE_BALANCE;
+
+                operatorIds[count] = i;
+                currents[count] = current;
+                // Temporarily store raw weight in targets; will be converted below.
+                targets[count] = weight;
+                weightSum += weight;
+                totalCurrent += current;
+                ++count;
+            }
+        }
+
+        if (count == 0) return (new uint256[](0), new uint256[](0), new uint256[](0));
+
+        for (uint256 i; i < count; ++i) {
+            targets[i] = Math.mulDiv(totalCurrent, targets[i], weightSum);
+        }
+        assembly {
+            mstore(operatorIds, count)
+            mstore(currents, count)
+            mstore(targets, count)
+        }
+    }
+
+    /// @notice Returns current top-up allocation targets for all operators with non-zero weight.
+    /// @dev Target = totalCurrent * operatorWeight / totalWeight (in wei).
+    ///      Includes operators regardless of top-up capacity for informational purposes.
+    ///      Actual allocation recalculates shares only across operators with available capacity,
+    ///      so real per-operator amounts may differ from the targets shown here.
+    /// @param nodeOperatorBalances Per-operator balance (in wei) storage mapping from the module.
+    /// @param operatorsCount Total operators count in the module.
+    /// @return operatorIds Eligible operator ids.
+    /// @return currents Current operator stake in wei.
+    /// @return targets Target operator stake in wei.
+    function getTopUpAllocationTargets(
+        mapping(uint256 => uint256) storage nodeOperatorBalances,
+        uint256 operatorsCount
+    ) external view returns (uint256[] memory operatorIds, uint256[] memory currents, uint256[] memory targets) {
+        if (operatorsCount == 0) return (operatorIds, currents, targets);
+
+        operatorIds = new uint256[](operatorsCount);
+        currents = new uint256[](operatorsCount);
+        targets = new uint256[](operatorsCount);
+
+        IMetaRegistry metaRegistry = ICuratedModule(address(this)).META_REGISTRY();
+
+        uint256 weightSum;
+        uint256 totalCurrent;
+        uint256 count;
+        for (uint256 i; i < operatorsCount; ++i) {
+            (uint256 weight, uint256 externalStake) = metaRegistry.getNodeOperatorWeightAndExternalStake(i);
+            if (weight == 0) continue;
+
+            uint256 currentStake = nodeOperatorBalances[i] + externalStake;
+            operatorIds[count] = i;
+            currents[count] = currentStake;
+            // Temporarily store raw weight in targets; will be converted below.
+            targets[count] = weight;
+            weightSum += weight;
+            totalCurrent += currentStake;
+            ++count;
+        }
+
+        if (count == 0) return (new uint256[](0), new uint256[](0), new uint256[](0));
+
+        for (uint256 i; i < count; ++i) {
+            targets[i] = Math.mulDiv(totalCurrent, targets[i], weightSum);
+        }
+        assembly {
+            mstore(operatorIds, count)
+            mstore(currents, count)
+            mstore(targets, count)
+        }
+    }
+
     /// @dev Quantizes a value down to the nearest multiple of TOP_UP_STEP.
     function quantizeForTopUp(uint256 value) internal pure returns (uint256) {
         return DepositAllocatorGreedy._quantize(value, TOP_UP_STEP);
@@ -271,22 +378,9 @@ library CuratedDepositAllocator {
     ) internal pure returns (uint256 allocated, uint256[] memory allocations) {
         // allocationAmount > 0, n > 0, and step > 0 are guaranteed by the callers.
 
-        AllocationState memory state = operatorsData.alloc;
+        _normalizeWeightsToShares(operatorsData);
 
-        for (uint256 i; i < state.sharesX96.length; ++i) {
-            // NOTE: no zero-check here. Collectors filter out zero weights and truncate
-            //       arrays to eligible node operators count, so sharesX96 entries are non-zero.
-
-            // Convert raw weights to X96 shares in-place (reuses the same array).
-            state.sharesX96[i] = Math.mulDiv(
-                state.sharesX96[i],
-                DepositAllocatorGreedy.S_SCALE,
-                // weightSum > 0 is guaranteed by the collectors for any non-empty input.
-                operatorsData.weightSum
-            );
-        }
-
-        (allocated, allocations) = DepositAllocatorGreedy._allocate(state, allocationAmount, step);
+        (allocated, allocations) = DepositAllocatorGreedy._allocate(operatorsData.alloc, allocationAmount, step);
     }
 
     function _compactAllocations(
@@ -309,6 +403,21 @@ library CuratedDepositAllocator {
                 mstore(compactIds, compactIndex)
                 mstore(allocations, compactIndex)
             }
+        }
+    }
+
+    /// @dev Converts raw weights in alloc.sharesX96 to X96-scaled shares in-place.
+    function _normalizeWeightsToShares(DepositableOperatorsData memory data) internal pure {
+        uint256[] memory sharesX96 = data.alloc.sharesX96;
+        for (uint256 i; i < sharesX96.length; ++i) {
+            // NOTE: no zero-check here. Collectors filter out zero weights and truncate
+            //       arrays to eligible node operators count, so sharesX96 entries are non-zero.
+            sharesX96[i] = Math.mulDiv(
+                sharesX96[i],
+                DepositAllocatorGreedy.S_SCALE,
+                // weightSum > 0 is guaranteed by the collectors for any non-empty input.
+                data.weightSum
+            );
         }
     }
 

--- a/test/unit/CuratedModule.t.sol
+++ b/test/unit/CuratedModule.t.sol
@@ -1597,6 +1597,302 @@ contract CuratedGetOperatorsWeights is CuratedCommon {
     }
 }
 
+contract CuratedGetDepositAllocationTargets is CuratedCommon {
+    function test_getDepositAllocationTargets() public assertInvariants {
+        uint256 firstId = createNodeOperator(2);
+        uint256 secondId = createNodeOperator(3);
+        _mockOperatorWeight(firstId, 1);
+        _mockOperatorWeight(secondId, 3);
+
+        (uint256[] memory ids, uint256[] memory currents, uint256[] memory targets) = cm.getDepositAllocationTargets();
+
+        assertEq(ids.length, 2);
+        assertEq(ids[0], firstId);
+        assertEq(ids[1], secondId);
+        // No deposits yet, currents and targets are zero.
+        assertEq(currents[0], 0);
+        assertEq(currents[1], 0);
+        assertEq(targets[0], 0);
+        assertEq(targets[1], 0);
+    }
+
+    function test_getDepositAllocationTargets_withDepositedKeys() public assertInvariants {
+        uint256 firstId = createNodeOperator(2);
+        uint256 secondId = createNodeOperator(2);
+        module.obtainDepositData(2, "");
+
+        (uint256[] memory ids, uint256[] memory currents, uint256[] memory targets) = cm.getDepositAllocationTargets();
+
+        assertEq(ids.length, 2);
+        // Each operator has 1 deposited key and 1 remaining capacity.
+        assertEq(currents[0], 1);
+        assertEq(currents[1], 1);
+        // Equal weights → equal targets: totalCurrent=2, each gets 1.
+        assertEq(targets[0], 1);
+        assertEq(targets[1], 1);
+    }
+
+    function test_getDepositAllocationTargets_unequalWeights() public assertInvariants {
+        uint256 firstId = createNodeOperator(4);
+        uint256 secondId = createNodeOperator(4);
+        _mockOperatorWeight(firstId, 1);
+        _mockOperatorWeight(secondId, 3);
+        // Allocation distributes 1:3 per weights → firstId gets 1, secondId gets 3.
+        module.obtainDepositData(4, "");
+
+        (uint256[] memory ids, uint256[] memory currents, uint256[] memory targets) = cm.getDepositAllocationTargets();
+
+        assertEq(ids.length, 2);
+        assertEq(currents[0], 1);
+        assertEq(currents[1], 3);
+        // totalCurrent=4, weights 1:3 → targets 1:3.
+        assertEq(targets[0], 1);
+        assertEq(targets[1], 3);
+    }
+
+    function test_getDepositAllocationTargets_noOperatorsReturnsEmpty() public assertInvariants {
+        (uint256[] memory ids, uint256[] memory currents, uint256[] memory targets) = cm.getDepositAllocationTargets();
+
+        assertEq(ids.length, 0);
+        assertEq(currents.length, 0);
+        assertEq(targets.length, 0);
+    }
+
+    function test_getDepositAllocationTargets_zeroWeightsReturnsEmpty() public assertInvariants {
+        createNodeOperator(1);
+        createNodeOperator(1);
+        _mockAllOperatorWeights(0);
+
+        (uint256[] memory ids, uint256[] memory currents, uint256[] memory targets) = cm.getDepositAllocationTargets();
+
+        assertEq(ids.length, 0);
+        assertEq(currents.length, 0);
+        assertEq(targets.length, 0);
+    }
+
+    function test_getDepositAllocationTargets_zeroCapacityIncluded() public assertInvariants {
+        uint256 firstId = createNodeOperator(1);
+        uint256 secondId = createNodeOperator(1);
+        // Consume all capacity.
+        module.obtainDepositData(2, "");
+
+        (uint256[] memory ids, uint256[] memory currents, uint256[] memory targets) = cm.getDepositAllocationTargets();
+
+        // Both operators still included despite 0 depositable keys.
+        assertEq(ids.length, 2);
+        assertEq(ids[0], firstId);
+        assertEq(ids[1], secondId);
+        assertEq(currents[0], 1);
+        assertEq(currents[1], 1);
+        // Equal weights → equal targets.
+        assertEq(targets[0], 1);
+        assertEq(targets[1], 1);
+    }
+
+    function test_getDepositAllocationTargets_revertWhen_DepositInfoIsNotUpToDate() public assertInvariants {
+        createNodeOperator(1);
+
+        vm.prank(address(accounting));
+        module.requestFullDepositInfoUpdate();
+
+        vm.expectRevert(IBaseModule.DepositInfoIsNotUpToDate.selector);
+        cm.getDepositAllocationTargets();
+    }
+
+    function test_getDepositAllocationTargets_matchesAllocationWhenAllHaveCapacity() public assertInvariants {
+        uint256 firstId = createNodeOperator(4);
+        uint256 secondId = createNodeOperator(4);
+        _mockOperatorWeight(firstId, 1);
+        _mockOperatorWeight(secondId, 3);
+        // Deposit 4 → allocated 1:3 by weights. Both still have capacity.
+        module.obtainDepositData(4, "");
+
+        (, uint256[] memory currents, uint256[] memory targets) = cm.getDepositAllocationTargets();
+
+        // All operators have capacity → targets reflect the same weight set as real allocation.
+        // totalCurrent=4, weights 1:3 → targets [1, 3]. Matches the 1:3 allocation above.
+        assertEq(currents[0], targets[0]);
+        assertEq(currents[1], targets[1]);
+    }
+
+    function test_getDepositAllocationTargets_differsFromAllocationWhenNoCapacity() public assertInvariants {
+        uint256 firstId = createNodeOperator(1);
+        uint256 secondId = createNodeOperator(2);
+        // Deposit 2 → 1 each. firstId has 0 remaining keys, secondId has 1.
+        module.obtainDepositData(2, "");
+
+        (, uint256[] memory currents, uint256[] memory targets) = cm.getDepositAllocationTargets();
+
+        // View includes both (equal weights) → targets [1, 1].
+        assertEq(targets[0], 1);
+        assertEq(targets[1], 1);
+
+        // Real allocation: only secondId is eligible (firstId has no capacity).
+        // Allocator recalculates shares across eligible operators only → secondId gets everything.
+        uint256 snapshot = vm.snapshotState();
+        module.obtainDepositData(1, "");
+        assertEq(module.getNodeOperator(firstId).totalDepositedKeys, 1); // unchanged
+        assertEq(module.getNodeOperator(secondId).totalDepositedKeys, 2); // got the deposit
+        vm.revertToState(snapshot);
+    }
+
+    function test_getDepositAllocationTargets_externalStakeIncludedInCurrent() public assertInvariants {
+        uint256 firstId = createNodeOperator(2);
+        uint256 secondId = createNodeOperator(2);
+
+        _mockOperatorWeightAndExternalStake(firstId, 1, 2048 ether);
+        _mockOperatorWeightAndExternalStake(secondId, 1, 0);
+
+        (uint256[] memory ids, uint256[] memory currents, ) = cm.getDepositAllocationTargets();
+
+        assertEq(ids.length, 2);
+        // firstId: 0 deposited keys + 2048 ether / 2048 ether = 1 external validator.
+        assertEq(currents[0], 1);
+        assertEq(currents[1], 0);
+    }
+}
+
+contract CuratedGetTopUpAllocationTargets is CuratedCommon {
+    function test_getTopUpAllocationTargets() public assertInvariants {
+        uint256 firstId = createNodeOperator(1);
+        uint256 secondId = createNodeOperator(1);
+        module.obtainDepositData(2, "");
+
+        _mockOperatorWeight(firstId, 1);
+        _mockOperatorWeight(secondId, 3);
+
+        (uint256[] memory ids, uint256[] memory currents, uint256[] memory targets) = cm.getTopUpAllocationTargets();
+
+        assertEq(ids.length, 2);
+        assertEq(ids[0], firstId);
+        assertEq(ids[1], secondId);
+        // Balance is 32 ether per operator from initial deposit.
+        assertEq(currents[0], 32 ether);
+        assertEq(currents[1], 32 ether);
+        // totalCurrent=64 ether, weights 1:3 → targets 16:48 ether.
+        assertEq(targets[0], 16 ether);
+        assertEq(targets[1], 48 ether);
+    }
+
+    function test_getTopUpAllocationTargets_noOperatorsReturnsEmpty() public assertInvariants {
+        (uint256[] memory ids, uint256[] memory currents, uint256[] memory targets) = cm.getTopUpAllocationTargets();
+
+        assertEq(ids.length, 0);
+        assertEq(currents.length, 0);
+        assertEq(targets.length, 0);
+    }
+
+    function test_getTopUpAllocationTargets_zeroWeightsReturnsEmpty() public assertInvariants {
+        createNodeOperator(1);
+        createNodeOperator(1);
+        module.obtainDepositData(2, "");
+        _mockAllOperatorWeights(0);
+
+        (uint256[] memory ids, uint256[] memory currents, uint256[] memory targets) = cm.getTopUpAllocationTargets();
+
+        assertEq(ids.length, 0);
+        assertEq(currents.length, 0);
+        assertEq(targets.length, 0);
+    }
+
+    function test_getTopUpAllocationTargets_zeroCapacityIncluded() public assertInvariants {
+        uint256 firstId = createNodeOperator(1);
+        uint256 secondId = createNodeOperator(1);
+        module.obtainDepositData(2, "");
+
+        // Max out balance for firstId so capacity = 0.
+        cm.updateOperatorBalances(
+            _encodeNodeOperatorIds(UintArr(firstId)),
+            _encodeUint128Values(UintArr(2048 ether / 1 gwei))
+        );
+
+        (uint256[] memory ids, uint256[] memory currents, uint256[] memory targets) = cm.getTopUpAllocationTargets();
+
+        // Both operators included despite firstId having zero top-up capacity.
+        assertEq(ids.length, 2);
+        assertEq(ids[0], firstId);
+        assertEq(ids[1], secondId);
+        // firstId: 2048 ether, secondId: 32 ether. Total = 2080 ether. Equal weights → equal targets.
+        assertEq(currents[0], 2048 ether);
+        assertEq(currents[1], 32 ether);
+        assertEq(targets[0], 1040 ether);
+        assertEq(targets[1], 1040 ether);
+    }
+
+    function test_getTopUpAllocationTargets_matchesAllocationWhenAllHaveCapacity() public assertInvariants {
+        uint256 firstId = createNodeOperator(1);
+        uint256 secondId = createNodeOperator(1);
+        module.obtainDepositData(2, "");
+
+        // Equal weights, both at 32 ether → both below 2048 ether capacity.
+        (, , uint256[] memory targets) = cm.getTopUpAllocationTargets();
+
+        // totalCurrent=64 ether, equal weights → targets [32, 32] ether.
+        assertEq(targets[0], 32 ether);
+        assertEq(targets[1], 32 ether);
+
+        // Both have capacity → real allocation uses the same weight set.
+        (, uint256[] memory allocIds, uint256[] memory allocs) = cm.getDepositsAllocation(4 ether);
+
+        // Real allocation distributes equally → [2, 2] ether.
+        assertEq(allocIds.length, 2);
+        assertEq(allocs[0], 2 ether);
+        assertEq(allocs[1], 2 ether);
+        // Allocation ratio matches target ratio.
+        assertEq(allocs[0] * targets[1], allocs[1] * targets[0]);
+    }
+
+    function test_getTopUpAllocationTargets_differsFromAllocationWhenNoCapacity() public assertInvariants {
+        uint256 firstId = createNodeOperator(1);
+        uint256 secondId = createNodeOperator(1);
+        module.obtainDepositData(2, "");
+
+        // Max out balance for firstId so capacity = 0.
+        cm.updateOperatorBalances(
+            _encodeNodeOperatorIds(UintArr(firstId)),
+            _encodeUint128Values(UintArr(2048 ether / 1 gwei))
+        );
+
+        (, , uint256[] memory targets) = cm.getTopUpAllocationTargets();
+
+        // View includes both (equal weights) → equal targets.
+        assertEq(targets[0], targets[1]);
+
+        // Real allocation: only secondId is eligible (firstId at max balance).
+        // Allocator recalculates shares → secondId gets everything.
+        (, uint256[] memory allocIds, uint256[] memory allocs) = cm.getDepositsAllocation(10 ether);
+        assertEq(allocIds.length, 1);
+        assertEq(allocIds[0], secondId);
+        assertEq(allocs[0], 10 ether);
+    }
+
+    function test_getTopUpAllocationTargets_revertWhen_DepositInfoIsNotUpToDate() public assertInvariants {
+        createNodeOperator(1);
+
+        vm.prank(address(accounting));
+        module.requestFullDepositInfoUpdate();
+
+        vm.expectRevert(IBaseModule.DepositInfoIsNotUpToDate.selector);
+        cm.getTopUpAllocationTargets();
+    }
+
+    function test_getTopUpAllocationTargets_externalStakeIncludedInCurrent() public assertInvariants {
+        uint256 firstId = createNodeOperator(1);
+        uint256 secondId = createNodeOperator(1);
+        module.obtainDepositData(2, "");
+
+        _mockOperatorWeightAndExternalStake(firstId, 1, 100 ether);
+        _mockOperatorWeightAndExternalStake(secondId, 1, 0);
+
+        (uint256[] memory ids, uint256[] memory currents, ) = cm.getTopUpAllocationTargets();
+
+        assertEq(ids.length, 2);
+        // firstId: 32 ether balance + 100 ether external.
+        assertEq(currents[0], 32 ether + 100 ether);
+        assertEq(currents[1], 32 ether);
+    }
+}
+
 contract CuratedProposeNodeOperatorManagerAddressChange is
     ModuleProposeNodeOperatorManagerAddressChange,
     CuratedCommon

--- a/test/unit/CuratedModule.t.sol
+++ b/test/unit/CuratedModule.t.sol
@@ -1604,16 +1604,14 @@ contract CuratedGetDepositAllocationTargets is CuratedCommon {
         _mockOperatorWeight(firstId, 1);
         _mockOperatorWeight(secondId, 3);
 
-        (uint256[] memory ids, uint256[] memory currents, uint256[] memory targets) = cm.getDepositAllocationTargets();
+        (uint256[] memory currents, uint256[] memory targets) = cm.getDepositAllocationTargets();
 
-        assertEq(ids.length, 2);
-        assertEq(ids[0], firstId);
-        assertEq(ids[1], secondId);
+        assertEq(currents.length, 2);
         // No deposits yet, currents and targets are zero.
-        assertEq(currents[0], 0);
-        assertEq(currents[1], 0);
-        assertEq(targets[0], 0);
-        assertEq(targets[1], 0);
+        assertEq(currents[firstId], 0);
+        assertEq(currents[secondId], 0);
+        assertEq(targets[firstId], 0);
+        assertEq(targets[secondId], 0);
     }
 
     function test_getDepositAllocationTargets_withDepositedKeys() public assertInvariants {
@@ -1621,15 +1619,14 @@ contract CuratedGetDepositAllocationTargets is CuratedCommon {
         uint256 secondId = createNodeOperator(2);
         module.obtainDepositData(2, "");
 
-        (uint256[] memory ids, uint256[] memory currents, uint256[] memory targets) = cm.getDepositAllocationTargets();
+        (uint256[] memory currents, uint256[] memory targets) = cm.getDepositAllocationTargets();
 
-        assertEq(ids.length, 2);
         // Each operator has 1 deposited key and 1 remaining capacity.
-        assertEq(currents[0], 1);
-        assertEq(currents[1], 1);
+        assertEq(currents[firstId], 1);
+        assertEq(currents[secondId], 1);
         // Equal weights → equal targets: totalCurrent=2, each gets 1.
-        assertEq(targets[0], 1);
-        assertEq(targets[1], 1);
+        assertEq(targets[firstId], 1);
+        assertEq(targets[secondId], 1);
     }
 
     function test_getDepositAllocationTargets_unequalWeights() public assertInvariants {
@@ -1640,34 +1637,34 @@ contract CuratedGetDepositAllocationTargets is CuratedCommon {
         // Allocation distributes 1:3 per weights → firstId gets 1, secondId gets 3.
         module.obtainDepositData(4, "");
 
-        (uint256[] memory ids, uint256[] memory currents, uint256[] memory targets) = cm.getDepositAllocationTargets();
+        (uint256[] memory currents, uint256[] memory targets) = cm.getDepositAllocationTargets();
 
-        assertEq(ids.length, 2);
-        assertEq(currents[0], 1);
-        assertEq(currents[1], 3);
+        assertEq(currents[firstId], 1);
+        assertEq(currents[secondId], 3);
         // totalCurrent=4, weights 1:3 → targets 1:3.
-        assertEq(targets[0], 1);
-        assertEq(targets[1], 3);
+        assertEq(targets[firstId], 1);
+        assertEq(targets[secondId], 3);
     }
 
     function test_getDepositAllocationTargets_noOperatorsReturnsEmpty() public assertInvariants {
-        (uint256[] memory ids, uint256[] memory currents, uint256[] memory targets) = cm.getDepositAllocationTargets();
+        (uint256[] memory currents, uint256[] memory targets) = cm.getDepositAllocationTargets();
 
-        assertEq(ids.length, 0);
         assertEq(currents.length, 0);
         assertEq(targets.length, 0);
     }
 
-    function test_getDepositAllocationTargets_zeroWeightsReturnsEmpty() public assertInvariants {
-        createNodeOperator(1);
-        createNodeOperator(1);
+    function test_getDepositAllocationTargets_zeroWeightsReturnZeros() public assertInvariants {
+        uint256 firstId = createNodeOperator(1);
+        uint256 secondId = createNodeOperator(1);
         _mockAllOperatorWeights(0);
 
-        (uint256[] memory ids, uint256[] memory currents, uint256[] memory targets) = cm.getDepositAllocationTargets();
+        (uint256[] memory currents, uint256[] memory targets) = cm.getDepositAllocationTargets();
 
-        assertEq(ids.length, 0);
-        assertEq(currents.length, 0);
-        assertEq(targets.length, 0);
+        assertEq(currents.length, 2);
+        assertEq(currents[firstId], 0);
+        assertEq(currents[secondId], 0);
+        assertEq(targets[firstId], 0);
+        assertEq(targets[secondId], 0);
     }
 
     function test_getDepositAllocationTargets_zeroCapacityIncluded() public assertInvariants {
@@ -1676,17 +1673,14 @@ contract CuratedGetDepositAllocationTargets is CuratedCommon {
         // Consume all capacity.
         module.obtainDepositData(2, "");
 
-        (uint256[] memory ids, uint256[] memory currents, uint256[] memory targets) = cm.getDepositAllocationTargets();
+        (uint256[] memory currents, uint256[] memory targets) = cm.getDepositAllocationTargets();
 
         // Both operators still included despite 0 depositable keys.
-        assertEq(ids.length, 2);
-        assertEq(ids[0], firstId);
-        assertEq(ids[1], secondId);
-        assertEq(currents[0], 1);
-        assertEq(currents[1], 1);
+        assertEq(currents[firstId], 1);
+        assertEq(currents[secondId], 1);
         // Equal weights → equal targets.
-        assertEq(targets[0], 1);
-        assertEq(targets[1], 1);
+        assertEq(targets[firstId], 1);
+        assertEq(targets[secondId], 1);
     }
 
     function test_getDepositAllocationTargets_revertWhen_DepositInfoIsNotUpToDate() public assertInvariants {
@@ -1707,12 +1701,12 @@ contract CuratedGetDepositAllocationTargets is CuratedCommon {
         // Deposit 4 → allocated 1:3 by weights. Both still have capacity.
         module.obtainDepositData(4, "");
 
-        (, uint256[] memory currents, uint256[] memory targets) = cm.getDepositAllocationTargets();
+        (uint256[] memory currents, uint256[] memory targets) = cm.getDepositAllocationTargets();
 
         // All operators have capacity → targets reflect the same weight set as real allocation.
         // totalCurrent=4, weights 1:3 → targets [1, 3]. Matches the 1:3 allocation above.
-        assertEq(currents[0], targets[0]);
-        assertEq(currents[1], targets[1]);
+        assertEq(currents[firstId], targets[firstId]);
+        assertEq(currents[secondId], targets[secondId]);
     }
 
     function test_getDepositAllocationTargets_differsFromAllocationWhenNoCapacity() public assertInvariants {
@@ -1721,11 +1715,11 @@ contract CuratedGetDepositAllocationTargets is CuratedCommon {
         // Deposit 2 → 1 each. firstId has 0 remaining keys, secondId has 1.
         module.obtainDepositData(2, "");
 
-        (, uint256[] memory currents, uint256[] memory targets) = cm.getDepositAllocationTargets();
+        (, uint256[] memory targets) = cm.getDepositAllocationTargets();
 
         // View includes both (equal weights) → targets [1, 1].
-        assertEq(targets[0], 1);
-        assertEq(targets[1], 1);
+        assertEq(targets[firstId], 1);
+        assertEq(targets[secondId], 1);
 
         // Real allocation: only secondId is eligible (firstId has no capacity).
         // Allocator recalculates shares across eligible operators only → secondId gets everything.
@@ -1743,12 +1737,11 @@ contract CuratedGetDepositAllocationTargets is CuratedCommon {
         _mockOperatorWeightAndExternalStake(firstId, 1, 2048 ether);
         _mockOperatorWeightAndExternalStake(secondId, 1, 0);
 
-        (uint256[] memory ids, uint256[] memory currents, ) = cm.getDepositAllocationTargets();
+        (uint256[] memory currents, ) = cm.getDepositAllocationTargets();
 
-        assertEq(ids.length, 2);
         // firstId: 0 deposited keys + 2048 ether / 2048 ether = 1 external validator.
-        assertEq(currents[0], 1);
-        assertEq(currents[1], 0);
+        assertEq(currents[firstId], 1);
+        assertEq(currents[secondId], 0);
     }
 }
 
@@ -1761,38 +1754,37 @@ contract CuratedGetTopUpAllocationTargets is CuratedCommon {
         _mockOperatorWeight(firstId, 1);
         _mockOperatorWeight(secondId, 3);
 
-        (uint256[] memory ids, uint256[] memory currents, uint256[] memory targets) = cm.getTopUpAllocationTargets();
+        (uint256[] memory currents, uint256[] memory targets) = cm.getTopUpAllocationTargets();
 
-        assertEq(ids.length, 2);
-        assertEq(ids[0], firstId);
-        assertEq(ids[1], secondId);
+        assertEq(currents.length, 2);
         // Balance is 32 ether per operator from initial deposit.
-        assertEq(currents[0], 32 ether);
-        assertEq(currents[1], 32 ether);
+        assertEq(currents[firstId], 32 ether);
+        assertEq(currents[secondId], 32 ether);
         // totalCurrent=64 ether, weights 1:3 → targets 16:48 ether.
-        assertEq(targets[0], 16 ether);
-        assertEq(targets[1], 48 ether);
+        assertEq(targets[firstId], 16 ether);
+        assertEq(targets[secondId], 48 ether);
     }
 
     function test_getTopUpAllocationTargets_noOperatorsReturnsEmpty() public assertInvariants {
-        (uint256[] memory ids, uint256[] memory currents, uint256[] memory targets) = cm.getTopUpAllocationTargets();
+        (uint256[] memory currents, uint256[] memory targets) = cm.getTopUpAllocationTargets();
 
-        assertEq(ids.length, 0);
         assertEq(currents.length, 0);
         assertEq(targets.length, 0);
     }
 
-    function test_getTopUpAllocationTargets_zeroWeightsReturnsEmpty() public assertInvariants {
-        createNodeOperator(1);
-        createNodeOperator(1);
+    function test_getTopUpAllocationTargets_zeroWeightsReturnZeros() public assertInvariants {
+        uint256 firstId = createNodeOperator(1);
+        uint256 secondId = createNodeOperator(1);
         module.obtainDepositData(2, "");
         _mockAllOperatorWeights(0);
 
-        (uint256[] memory ids, uint256[] memory currents, uint256[] memory targets) = cm.getTopUpAllocationTargets();
+        (uint256[] memory currents, uint256[] memory targets) = cm.getTopUpAllocationTargets();
 
-        assertEq(ids.length, 0);
-        assertEq(currents.length, 0);
-        assertEq(targets.length, 0);
+        assertEq(currents.length, 2);
+        assertEq(currents[firstId], 0);
+        assertEq(currents[secondId], 0);
+        assertEq(targets[firstId], 0);
+        assertEq(targets[secondId], 0);
     }
 
     function test_getTopUpAllocationTargets_zeroCapacityIncluded() public assertInvariants {
@@ -1806,17 +1798,14 @@ contract CuratedGetTopUpAllocationTargets is CuratedCommon {
             _encodeUint128Values(UintArr(2048 ether / 1 gwei))
         );
 
-        (uint256[] memory ids, uint256[] memory currents, uint256[] memory targets) = cm.getTopUpAllocationTargets();
+        (uint256[] memory currents, uint256[] memory targets) = cm.getTopUpAllocationTargets();
 
         // Both operators included despite firstId having zero top-up capacity.
-        assertEq(ids.length, 2);
-        assertEq(ids[0], firstId);
-        assertEq(ids[1], secondId);
         // firstId: 2048 ether, secondId: 32 ether. Total = 2080 ether. Equal weights → equal targets.
-        assertEq(currents[0], 2048 ether);
-        assertEq(currents[1], 32 ether);
-        assertEq(targets[0], 1040 ether);
-        assertEq(targets[1], 1040 ether);
+        assertEq(currents[firstId], 2048 ether);
+        assertEq(currents[secondId], 32 ether);
+        assertEq(targets[firstId], 1040 ether);
+        assertEq(targets[secondId], 1040 ether);
     }
 
     function test_getTopUpAllocationTargets_matchesAllocationWhenAllHaveCapacity() public assertInvariants {
@@ -1825,11 +1814,11 @@ contract CuratedGetTopUpAllocationTargets is CuratedCommon {
         module.obtainDepositData(2, "");
 
         // Equal weights, both at 32 ether → both below 2048 ether capacity.
-        (, , uint256[] memory targets) = cm.getTopUpAllocationTargets();
+        (, uint256[] memory targets) = cm.getTopUpAllocationTargets();
 
         // totalCurrent=64 ether, equal weights → targets [32, 32] ether.
-        assertEq(targets[0], 32 ether);
-        assertEq(targets[1], 32 ether);
+        assertEq(targets[firstId], 32 ether);
+        assertEq(targets[secondId], 32 ether);
 
         // Both have capacity → real allocation uses the same weight set.
         (, uint256[] memory allocIds, uint256[] memory allocs) = cm.getDepositsAllocation(4 ether);
@@ -1839,7 +1828,7 @@ contract CuratedGetTopUpAllocationTargets is CuratedCommon {
         assertEq(allocs[0], 2 ether);
         assertEq(allocs[1], 2 ether);
         // Allocation ratio matches target ratio.
-        assertEq(allocs[0] * targets[1], allocs[1] * targets[0]);
+        assertEq(allocs[0] * targets[secondId], allocs[1] * targets[firstId]);
     }
 
     function test_getTopUpAllocationTargets_differsFromAllocationWhenNoCapacity() public assertInvariants {
@@ -1853,10 +1842,10 @@ contract CuratedGetTopUpAllocationTargets is CuratedCommon {
             _encodeUint128Values(UintArr(2048 ether / 1 gwei))
         );
 
-        (, , uint256[] memory targets) = cm.getTopUpAllocationTargets();
+        (, uint256[] memory targets) = cm.getTopUpAllocationTargets();
 
         // View includes both (equal weights) → equal targets.
-        assertEq(targets[0], targets[1]);
+        assertEq(targets[firstId], targets[secondId]);
 
         // Real allocation: only secondId is eligible (firstId at max balance).
         // Allocator recalculates shares → secondId gets everything.
@@ -1884,12 +1873,11 @@ contract CuratedGetTopUpAllocationTargets is CuratedCommon {
         _mockOperatorWeightAndExternalStake(firstId, 1, 100 ether);
         _mockOperatorWeightAndExternalStake(secondId, 1, 0);
 
-        (uint256[] memory ids, uint256[] memory currents, ) = cm.getTopUpAllocationTargets();
+        (uint256[] memory currents, ) = cm.getTopUpAllocationTargets();
 
-        assertEq(ids.length, 2);
         // firstId: 32 ether balance + 100 ether external.
-        assertEq(currents[0], 32 ether + 100 ether);
-        assertEq(currents[1], 32 ether);
+        assertEq(currents[firstId], 32 ether + 100 ether);
+        assertEq(currents[secondId], 32 ether);
     }
 }
 


### PR DESCRIPTION
## Description

Add UI-facing view functions to CuratedModule that return current vs target stake per operator. Targets are computed as totalCurrent * operatorWeight / totalWeight. All operators with non-zero weight are included regardless of depositable/top-up capacity, so the UI shows the full allocation picture. Actual allocation recalculates shares only across operators with available capacity.

## Checklist

- [x] Appropriate PR labels applied
- [x] Test coverage maintained (`just coverage`)
  - [x] Tests are added/updated
- [x] Documentation maintained
  - [x] Updated
