### PR TITLE
Fix review findings for top-up quantization and deposit info refresh

### DIFF
--- a/src/Accounting.sol
+++ b/src/Accounting.sol
@@ -150,7 +150,7 @@ contract Accounting is
     function setBondCurve(uint256 nodeOperatorId, uint256 curveId) external onlyRole(SET_BOND_CURVE_ROLE) {
         _onlyExistingNodeOperator(nodeOperatorId);
         BondCurve._setBondCurve(nodeOperatorId, curveId);
-        MODULE.onNodeOperatorBondCurveChange(nodeOperatorId);
+        MODULE.updateDepositInfo(nodeOperatorId);
     }
 
     /// @inheritdoc IAccounting

--- a/src/CuratedModule.sol
+++ b/src/CuratedModule.sol
@@ -205,6 +205,14 @@ contract CuratedModule is ICuratedModule, BaseModule {
     }
 
     /// @inheritdoc ICuratedModule
+    function getNodeOperatorWeightAndExternalStake(
+        uint256 nodeOperatorId
+    ) external view returns (uint256 weight, uint256 externalStake) {
+        _requireDepositInfoUpToDate();
+        return _metaRegistry().getNodeOperatorWeightAndExternalStake(nodeOperatorId);
+    }
+
+    /// @inheritdoc ICuratedModule
     function getNodeOperatorBalance(uint256 operatorId) external view returns (uint256) {
         return _curatedStorage().operatorBalances[operatorId];
     }

--- a/src/MetaRegistry.sol
+++ b/src/MetaRegistry.sol
@@ -32,6 +32,7 @@ contract MetaRegistry is IMetaRegistry, Initializable, AccessControlEnumerableUp
     }
 
     struct EffectiveWeightCache {
+        // Invariant: operators outside any group must have zero cached effective weight.
         mapping(uint256 nodeOperatorId => uint256 weight) operatorEffectiveWeight;
         mapping(uint256 groupId => uint256 weight) groupEffectiveWeightSum;
     }
@@ -191,11 +192,7 @@ contract MetaRegistry is IMetaRegistry, Initializable, AccessControlEnumerableUp
 
     /// @inheritdoc IMetaRegistry
     function getNodeOperatorWeight(uint256 noId) external view returns (uint256 weight) {
-        MetaRegistryStorage storage $ = _storage();
-        uint256 groupId = $.groupIndex.groupIdByOperatorId[noId];
-        // If Node Operator is not in any group, it has no weight.
-        if (groupId == NO_GROUP_ID) return 0;
-        weight = $.effectiveWeightCache.operatorEffectiveWeight[noId];
+        weight = _storage().effectiveWeightCache.operatorEffectiveWeight[noId];
     }
 
     /// @inheritdoc IMetaRegistry
@@ -271,6 +268,7 @@ contract MetaRegistry is IMetaRegistry, Initializable, AccessControlEnumerableUp
             uint256 noId = group.subNodeOperatorIds[i];
             delete $.groupIndex.groupIdByOperatorId[noId];
             delete $.groupIndex.shareByOperatorId[noId];
+            // Keep removed operators consistent with direct cache-backed weight reads.
             _setEffectiveWeight(noId, 0);
         }
 

--- a/src/abstract/BaseModule.sol
+++ b/src/abstract/BaseModule.sol
@@ -371,7 +371,7 @@ abstract contract BaseModule is
     }
 
     /// @inheritdoc IBaseModule
-    function onNodeOperatorBondCurveChange(uint256 nodeOperatorId) external {
+    function updateDepositInfo(uint256 nodeOperatorId) external {
         _updateDepositInfo(nodeOperatorId);
     }
 

--- a/src/interfaces/IBaseModule.sol
+++ b/src/interfaces/IBaseModule.sol
@@ -253,9 +253,10 @@ interface IBaseModule is IStakingModule, IAccessControlEnumerable, INOAddresses,
     /// @param maxAmounts Maximum amounts to settle for each Node Operator
     function settleGeneralDelayedPenalty(uint256[] memory nodeOperatorIds, uint256[] memory maxAmounts) external;
 
-    /// @notice Propose a new manager address for the Node Operator
+    /// @notice Propose a new manager address for the Node Operator.
+    /// @dev Passing address(0) clears the pending proposal without changing the current manager address.
     /// @param nodeOperatorId ID of the Node Operator
-    /// @param proposedAddress Proposed manager address
+    /// @param proposedAddress Proposed manager address, or address(0) to cancel the current proposal
     function proposeNodeOperatorManagerAddressChange(uint256 nodeOperatorId, address proposedAddress) external;
 
     /// @notice Confirm a new manager address for the Node Operator.
@@ -268,9 +269,10 @@ interface IBaseModule is IStakingModule, IAccessControlEnumerable, INOAddresses,
     /// @param nodeOperatorId ID of the Node Operator
     function resetNodeOperatorManagerAddress(uint256 nodeOperatorId) external;
 
-    /// @notice Propose a new reward address for the Node Operator
+    /// @notice Propose a new reward address for the Node Operator.
+    /// @dev Passing address(0) clears the pending proposal without changing the current reward address.
     /// @param nodeOperatorId ID of the Node Operator
-    /// @param proposedAddress Proposed reward address
+    /// @param proposedAddress Proposed reward address, or address(0) to cancel the current proposal
     function proposeNodeOperatorRewardAddressChange(uint256 nodeOperatorId, address proposedAddress) external;
 
     /// @notice Confirm a new reward address for the Node Operator.

--- a/src/interfaces/IBaseModule.sol
+++ b/src/interfaces/IBaseModule.sol
@@ -293,9 +293,9 @@ interface IBaseModule is IStakingModule, IAccessControlEnumerable, INOAddresses,
     /// @param nodeOperatorId ID of the Node Operator
     function updateDepositableValidatorsCount(uint256 nodeOperatorId) external;
 
-    /// @notice Notify the module about a node operator bond curve change.
+    /// @notice Update deposit info for the given Node Operator.
     /// @param nodeOperatorId ID of the Node Operator
-    function onNodeOperatorBondCurveChange(uint256 nodeOperatorId) external;
+    function updateDepositInfo(uint256 nodeOperatorId) external;
 
     /// @notice Request a full update of deposit info for all node operators.
     ///         Should be called after external changes that can affect deposit info such as bond curve change or parameters update.

--- a/src/interfaces/ICuratedModule.sol
+++ b/src/interfaces/ICuratedModule.sol
@@ -47,6 +47,15 @@ interface ICuratedModule is IBaseModule, IStakingModuleV2 {
         uint256[] calldata operatorIds
     ) external view returns (uint256[] memory operatorWeights);
 
+    /// @notice Returns effective weight and external stake for a node operator.
+    /// @dev Reverts until the module deposit info cache is fully refreshed.
+    /// @param nodeOperatorId Node operator ID to query.
+    /// @return weight Effective allocation weight.
+    /// @return externalStake External stake amount in wei.
+    function getNodeOperatorWeightAndExternalStake(
+        uint256 nodeOperatorId
+    ) external view returns (uint256 weight, uint256 externalStake);
+
     /// @notice Returns current deposit allocation targets for all operators.
     /// @dev Target = totalCurrent * operatorWeight / totalWeight (in validator count).
     ///      Includes operators regardless of depositable capacity for informational purposes.

--- a/src/interfaces/IMetaRegistry.sol
+++ b/src/interfaces/IMetaRegistry.sol
@@ -138,7 +138,8 @@ interface IMetaRegistry {
     /// @notice Returns effective weight for the node operator.
     /// @param nodeOperatorId Node operator ID to query.
     /// @return weight Effective allocation weight.
-    /// @dev Returns 0 if the operator is not in a group.
+    /// @dev Returns the cached effective weight.
+    /// @dev Operators outside any group are expected to have zero cached weight.
     function getNodeOperatorWeight(uint256 nodeOperatorId) external view returns (uint256 weight);
 
     /// @notice Returns effective weight and external stake for the node operator.

--- a/src/interfaces/IMetaRegistry.sol
+++ b/src/interfaces/IMetaRegistry.sol
@@ -146,6 +146,9 @@ interface IMetaRegistry {
     /// @return weight Effective allocation weight.
     /// @return externalStake External stake amount in wei.
     /// @dev Returns (0, 0) if the operator is not in a group.
+    /// @dev During partial deposit info refreshes, cached weights may be updated only for a subset
+    ///      of operators, so direct reads can transiently reflect mixed-state group totals.
+    ///      Integrations that require a fully refreshed view should prefer the curated module getter.
     function getNodeOperatorWeightAndExternalStake(
         uint256 nodeOperatorId
     ) external view returns (uint256 weight, uint256 externalStake);

--- a/src/lib/NOAddresses.sol
+++ b/src/lib/NOAddresses.sol
@@ -41,9 +41,10 @@ interface INOAddresses {
 }
 
 library NOAddresses {
-    /// @notice Propose a new manager address for the Node Operator
+    /// @notice Propose a new manager address for the Node Operator.
+    /// @dev Passing address(0) clears the pending proposal without changing the current manager address.
     /// @param nodeOperatorId ID of the Node Operator
-    /// @param proposedAddress Proposed manager address
+    /// @param proposedAddress Proposed manager address, or address(0) to cancel the current proposal
     function proposeNodeOperatorManagerAddressChange(
         mapping(uint256 => NodeOperator) storage nodeOperators,
         uint256 nodeOperatorId,
@@ -84,9 +85,10 @@ library NOAddresses {
         emit INOAddresses.NodeOperatorManagerAddressChanged(nodeOperatorId, oldManagerAddress, msg.sender);
     }
 
-    /// @notice Propose a new reward address for the Node Operator
+    /// @notice Propose a new reward address for the Node Operator.
+    /// @dev Passing address(0) clears the pending proposal without changing the current reward address.
     /// @param nodeOperatorId ID of the Node Operator
-    /// @param proposedAddress Proposed reward address
+    /// @param proposedAddress Proposed reward address, or address(0) to cancel the current proposal
     function proposeNodeOperatorRewardAddressChange(
         mapping(uint256 => NodeOperator) storage nodeOperators,
         uint256 nodeOperatorId,

--- a/src/lib/NodeOperatorOps.sol
+++ b/src/lib/NodeOperatorOps.sol
@@ -397,8 +397,8 @@ library NodeOperatorOps {
                 uint256 remaining = perOperatorAllocations[operatorId] - perOperatorIncrements[operatorId];
                 if (remaining == 0) continue;
 
-                // Curated allocations are quantized to 1 ether, matching StakingRouter's
-                // expectation that non-zero top-up allocations are >= 1 ether.
+                // Curated allocations are quantized to 2 ether multiples so they
+                // satisfy StakingRouter's top-up allocation requirements.
                 uint256 limit = CuratedDepositAllocator.quantizeForTopUp(topUpLimits[i]);
                 if (limit == 0) continue;
 

--- a/src/lib/TopUpQueueOps.sol
+++ b/src/lib/TopUpQueueOps.sol
@@ -59,6 +59,9 @@ library TopUpQueueOps {
         bytes[] calldata pubkeys,
         TopUpKeyParams memory data
     ) private returns (uint256[] memory allocations) {
+        // Keep batch allocations on the same top-up step as per-key limits.
+        maxDepositAmount = _quantizeAmount(maxDepositAmount);
+
         uint256 keyCount = pubkeys.length;
         allocations = new uint256[](keyCount);
 

--- a/test/unit/Accounting/BondCalculations.t.sol
+++ b/test/unit/Accounting/BondCalculations.t.sol
@@ -73,10 +73,7 @@ contract BondCurveTest is BaseTest {
 
         uint256 addedId = accounting.addBondCurve(curvePoints);
 
-        vm.expectCall(
-            address(accounting.MODULE()),
-            abi.encodeWithSelector(IBaseModule.onNodeOperatorBondCurveChange.selector, 0)
-        );
+        vm.expectCall(address(accounting.MODULE()), abi.encodeWithSelector(IBaseModule.updateDepositInfo.selector, 0));
         accounting.setBondCurve({ nodeOperatorId: 0, curveId: addedId });
 
         vm.stopPrank();

--- a/test/unit/Accounting/_Base.t.sol
+++ b/test/unit/Accounting/_Base.t.sol
@@ -83,10 +83,10 @@ contract AccountingFixtures is Test, Fixtures, Utilities, InvariantAsserts {
         );
     }
 
-    function mock_onNodeOperatorBondCurveChange(uint256 nodeOperatorId) internal {
+    function mock_updateDepositInfo(uint256 nodeOperatorId) internal {
         vm.mockCall(
             address(stakingModule),
-            abi.encodeWithSelector(IBaseModule.onNodeOperatorBondCurveChange.selector, nodeOperatorId),
+            abi.encodeWithSelector(IBaseModule.updateDepositInfo.selector, nodeOperatorId),
             ""
         );
     }
@@ -142,7 +142,7 @@ contract BaseTest is AccountingFixtures {
 
         stakingModule = new Stub();
         mock_updateDepositableValidatorsCount();
-        mock_onNodeOperatorBondCurveChange(0);
+        mock_updateDepositInfo(0);
         mock_requestFullDepositInfoUpdate();
 
         IBondCurve.BondCurveIntervalInput[] memory curve = new IBondCurve.BondCurveIntervalInput[](1);

--- a/test/unit/CSModule.t.sol
+++ b/test/unit/CSModule.t.sol
@@ -2157,14 +2157,14 @@ contract CSMMisc is ModuleMisc, CSMCommon {
         assertEq(module.getInitializedVersion(), 3);
     }
 
-    function test_onNodeOperatorBondCurveChange_updatesDepositable() public assertInvariants {
+    function test_updateDepositInfo_updatesDepositable() public assertInvariants {
         uint256 noId = createNodeOperator(4);
 
         uint256 depositableBefore = module.getNodeOperator(noId).depositableValidatorsCount;
         assertEq(depositableBefore, 4);
 
         accounting.updateBondCurve(0, BOND_SIZE * 2);
-        csm.onNodeOperatorBondCurveChange(0);
+        csm.updateDepositInfo(0);
 
         uint256 depositableAfter = module.getNodeOperator(noId).depositableValidatorsCount;
         assertEq(depositableAfter, 2);

--- a/test/unit/CSModule.t.sol
+++ b/test/unit/CSModule.t.sol
@@ -998,6 +998,37 @@ contract CSMTopUpQueue is CSMCommon {
         }
     }
 
+    function test_topUp_quantizesDepositAmountToStep() public {
+        createNodeOperator(1);
+        csm.obtainDepositData(1, "");
+
+        bytes memory key = csm.getSigningKeys(0, 0, 1);
+
+        uint256[] memory firstAllocations = csm.allocateDeposits({
+            maxDepositAmount: 3 ether,
+            pubkeys: BytesArr(key),
+            keyIndices: UintArr(0),
+            operatorIds: UintArr(0),
+            topUpLimits: UintArr(4 ether)
+        });
+
+        assertEq(firstAllocations, UintArr(2 ether));
+        assertEq(_getTopUpQueueLength(), 1);
+        assertEq(csm.getKeyAddedBalance(0, 0), 2 ether);
+
+        uint256[] memory secondAllocations = csm.allocateDeposits({
+            maxDepositAmount: 2 ether,
+            pubkeys: BytesArr(key),
+            keyIndices: UintArr(0),
+            operatorIds: UintArr(0),
+            topUpLimits: UintArr(2 ether)
+        });
+
+        assertEq(secondAllocations, UintArr(2 ether));
+        assertEq(_getTopUpQueueLength(), 0);
+        assertEq(csm.getKeyAddedBalance(0, 0), 4 ether);
+    }
+
     function test_topUp_noEmitWhenKeyAtCap() public {
         createNodeOperator(1);
         csm.obtainDepositData(1, "");

--- a/test/unit/CuratedModule.t.sol
+++ b/test/unit/CuratedModule.t.sol
@@ -2051,27 +2051,27 @@ contract CuratedMisc is ModuleMisc, CuratedCommon {
         assertEq(module.getInitializedVersion(), 1);
     }
 
-    function test_onNodeOperatorBondCurveChange_updatesDepositable() public assertInvariants {
+    function test_updateDepositInfo_updatesDepositable() public assertInvariants {
         uint256 noId = createNodeOperator(4);
 
         uint256 depositableBefore = module.getNodeOperator(noId).depositableValidatorsCount;
         assertEq(depositableBefore, 4);
 
         accounting.updateBondCurve(0, BOND_SIZE * 2);
-        cm.onNodeOperatorBondCurveChange(noId);
+        cm.updateDepositInfo(noId);
 
         uint256 depositableAfter = module.getNodeOperator(noId).depositableValidatorsCount;
         assertEq(depositableAfter, 2);
     }
 
-    function test_onNodeOperatorBondCurveChange_ZeroDepositableIfWeightIsZero() public assertInvariants {
+    function test_updateDepositInfo_ZeroDepositableIfWeightIsZero() public assertInvariants {
         uint256 noId = createNodeOperator(4);
 
         uint256 depositableBefore = module.getNodeOperator(noId).depositableValidatorsCount;
         assertEq(depositableBefore, 4);
 
         _mockOperatorWeight(noId, 0);
-        cm.onNodeOperatorBondCurveChange(noId);
+        cm.updateDepositInfo(noId);
 
         uint256 depositableAfter = module.getNodeOperator(noId).depositableValidatorsCount;
         assertEq(depositableAfter, 0);

--- a/test/unit/CuratedModule.t.sol
+++ b/test/unit/CuratedModule.t.sol
@@ -1597,6 +1597,40 @@ contract CuratedGetOperatorsWeights is CuratedCommon {
     }
 }
 
+contract CuratedGetNodeOperatorWeightAndExternalStake is CuratedCommon {
+    function test_getNodeOperatorWeightAndExternalStake_ReturnsMetaRegistryValues() public assertInvariants {
+        createNodeOperator(1);
+
+        uint256 nodeOperatorId = 0;
+        vm.mockCall(
+            address(metaRegistry),
+            abi.encodeWithSelector(IMetaRegistry.getNodeOperatorWeightAndExternalStake.selector, nodeOperatorId),
+            abi.encode(42, 7 ether)
+        );
+
+        (uint256 weight, uint256 externalStake) = cm.getNodeOperatorWeightAndExternalStake(nodeOperatorId);
+        assertEq(weight, 42);
+        assertEq(externalStake, 7 ether);
+    }
+
+    function test_getNodeOperatorWeightAndExternalStake_revertWhen_DepositInfoIsNotUpToDate() public assertInvariants {
+        createNodeOperator(1);
+
+        uint256 nodeOperatorId = 0;
+        vm.mockCall(
+            address(metaRegistry),
+            abi.encodeWithSelector(IMetaRegistry.getNodeOperatorWeightAndExternalStake.selector, nodeOperatorId),
+            abi.encode(42, 7 ether)
+        );
+
+        vm.prank(address(accounting));
+        module.requestFullDepositInfoUpdate();
+
+        vm.expectRevert(IBaseModule.DepositInfoIsNotUpToDate.selector);
+        cm.getNodeOperatorWeightAndExternalStake(nodeOperatorId);
+    }
+}
+
 contract CuratedGetDepositAllocationTargets is CuratedCommon {
     function test_getDepositAllocationTargets() public assertInvariants {
         uint256 firstId = createNodeOperator(2);


### PR DESCRIPTION
## Description

- Quantize CSM top-up batch allocations to the configured step and add regression coverage for odd-sized budgets.
- Add a curated-module getter for operator weight and external stake that is gated by fresh deposit info.
- Align MetaRegistry cached-weight getter semantics with the cache invariant and rename the public deposit-info refresh hook to `updateDepositInfo`.
- Clarify zero-address proposal semantics for manager and reward address changes and refresh the related inline comments.

## Checklist

- [x] Appropriate PR labels applied
- [x] Test coverage maintained (`just coverage`)
  - [ ] No need to add/update tests
  - [x] Tests are added/updated
- [x] Documentation maintained
  - [ ] No need to update
  - [x] Updated
