### PR TITLE
feat: use separate counters for validator balances

### DIFF
--- a/script/csm/DeployBase.s.sol
+++ b/script/csm/DeployBase.s.sol
@@ -57,6 +57,7 @@ struct DeployParams {
     GIndex gIFirstBalanceNode;
     uint256 verifierFirstSupportedSlot;
     uint256 capellaSlot;
+    uint256 minWithdrawalRatio;
     // Accounting
     uint256[2][] defaultBondCurve;
     uint256[2][] legacyEaBondCurve;
@@ -258,6 +259,7 @@ abstract contract DeployBase is Script {
                 firstSupportedSlot: Slot.wrap(uint64(config.verifierFirstSupportedSlot)),
                 pivotSlot: Slot.wrap(uint64(config.verifierFirstSupportedSlot)),
                 capellaSlot: Slot.wrap(uint64(config.capellaSlot)),
+                minWithdrawalRatio: config.minWithdrawalRatio,
                 admin: deployer
             });
 

--- a/script/csm/DeployCSMImplementationsBase.s.sol
+++ b/script/csm/DeployCSMImplementationsBase.s.sol
@@ -106,6 +106,7 @@ abstract contract DeployCSMImplementationsBase is DeployBase {
                 firstSupportedSlot: Slot.wrap(uint64(config.verifierFirstSupportedSlot)),
                 pivotSlot: Slot.wrap(uint64(config.verifierFirstSupportedSlot)),
                 capellaSlot: Slot.wrap(uint64(config.capellaSlot)),
+                minWithdrawalRatio: config.minWithdrawalRatio,
                 admin: deployer
             });
 

--- a/script/csm/DeployHoodi.s.sol
+++ b/script/csm/DeployHoodi.s.sol
@@ -45,6 +45,7 @@ contract DeployHoodi is DeployBase {
         config.gIFirstBalanceNode = GIndices.FIRST_BALANCE_NODE_ELECTRA;
         config.verifierFirstSupportedSlot = 2048 * config.slotsPerEpoch; // @see https://github.com/eth-clients/hoodi/blob/main/metadata/config.yaml#L41
         config.capellaSlot = 0; // @see https://github.com/eth-clients/hoodi/blob/main/metadata/config.yaml#L33
+        config.minWithdrawalRatio = 9900;
 
         // Accounting
         // 2.4 -> 1.3

--- a/script/csm/DeployLocalDevNet.s.sol
+++ b/script/csm/DeployLocalDevNet.s.sol
@@ -35,6 +35,7 @@ contract DeployLocalDevNet is DeployBase {
         config.gIFirstBalanceNode = GIndices.FIRST_BALANCE_NODE_ELECTRA;
         config.verifierFirstSupportedSlot = vm.envUint("DEVNET_ELECTRA_EPOCH") * config.slotsPerEpoch;
         config.capellaSlot = vm.envUint("DEVNET_CAPELLA_EPOCH") * config.slotsPerEpoch;
+        config.minWithdrawalRatio = 9900;
 
         // Accounting
         // 2.4 -> 1.3

--- a/script/csm/DeployMainnet.s.sol
+++ b/script/csm/DeployMainnet.s.sol
@@ -18,8 +18,8 @@ contract DeployMainnet is DeployBase {
         config.secondsPerSlot = 12; // https://github.com/eth-clients/mainnet/blob/f6b7882618a5ad2c1d2731ae35e5d16a660d5bb7/metadata/config.yaml#L58
         config.slotsPerEpoch = 32; // https://github.com/ethereum/consensus-specs/blob/7df1ce30384b13d01617f8ddf930f4035da0f689/specs/phase0/beacon-chain.md?plain=1#L246
         config.clGenesisTime = 1606824023; // https://github.com/eth-clients/mainnet/blob/f6b7882618a5ad2c1d2731ae35e5d16a660d5bb7/README.md?plain=1#L10
-        config.oracleReportEpochsPerFrame = 225 * 31; // 28 days TODO: Change back to 225 * 28  after phase 2 execution
-        config.fastLaneLengthSlots = 0; // TODO: Change to 300 after phase 2 execution
+        config.oracleReportEpochsPerFrame = 225 * 28;
+        config.fastLaneLengthSlots = 300;
         config.consensusVersion = 4;
         config.oracleMembers = new address[](9);
         config.oracleMembers[0] = 0x73181107c8D9ED4ce0bbeF7A0b4ccf3320C41d12; // Instadapp

--- a/script/csm/DeployMainnet.s.sol
+++ b/script/csm/DeployMainnet.s.sol
@@ -42,6 +42,7 @@ contract DeployMainnet is DeployBase {
         config.gIFirstBalanceNode = GIndices.FIRST_BALANCE_NODE_ELECTRA;
         config.verifierFirstSupportedSlot = 364032 * config.slotsPerEpoch; // https://github.com/ethereum/EIPs/blob/master/EIPS/eip-7600.md#activation
         config.capellaSlot = 194048 * config.slotsPerEpoch; // @see https://github.com/eth-clients/mainnet/blob/main/metadata/config.yaml#L50
+        config.minWithdrawalRatio = 9900;
 
         // Accounting
         // 2.4 -> 1.3

--- a/script/csm0x02/DeployCSM0x02Base.s.sol
+++ b/script/csm0x02/DeployCSM0x02Base.s.sol
@@ -55,6 +55,7 @@ struct DeployCSM0x02Params {
     GIndex gIFirstBalanceNode;
     uint256 verifierFirstSupportedSlot;
     uint256 capellaSlot;
+    uint256 minWithdrawalRatio;
     // Accounting
     uint256[2][] defaultBondCurve;
     uint256[2][][] extraBondCurves;
@@ -231,6 +232,7 @@ abstract contract DeployCSM0x02Base is Script {
                 firstSupportedSlot: Slot.wrap(uint64(config.verifierFirstSupportedSlot)),
                 pivotSlot: Slot.wrap(uint64(config.verifierFirstSupportedSlot)),
                 capellaSlot: Slot.wrap(uint64(config.capellaSlot)),
+                minWithdrawalRatio: config.minWithdrawalRatio,
                 admin: deployer
             });
 

--- a/script/csm0x02/DeployCSM0x02Hoodi.s.sol
+++ b/script/csm0x02/DeployCSM0x02Hoodi.s.sol
@@ -45,6 +45,7 @@ contract DeployCSM0x02Hoodi is DeployCSM0x02Base {
         config.gIFirstBalanceNode = GIndices.FIRST_BALANCE_NODE_ELECTRA;
         config.verifierFirstSupportedSlot = 2048 * config.slotsPerEpoch; // @see https://github.com/eth-clients/hoodi/blob/main/metadata/config.yaml#L41
         config.capellaSlot = 0; // @see https://github.com/eth-clients/hoodi/blob/main/metadata/config.yaml#L33
+        config.minWithdrawalRatio = 9900;
 
         // Accounting
         config.defaultBondCurve.push([1, 32 ether]);

--- a/script/csm0x02/DeployCSM0x02LocalDevNet.s.sol
+++ b/script/csm0x02/DeployCSM0x02LocalDevNet.s.sol
@@ -35,6 +35,7 @@ contract DeployCSM0x02LocalDevNet is DeployCSM0x02Base {
         config.gIFirstBalanceNode = GIndices.FIRST_BALANCE_NODE_ELECTRA;
         config.verifierFirstSupportedSlot = vm.envUint("DEVNET_ELECTRA_EPOCH") * config.slotsPerEpoch;
         config.capellaSlot = vm.envUint("DEVNET_CAPELLA_EPOCH") * config.slotsPerEpoch;
+        config.minWithdrawalRatio = 9900;
 
         // Accounting
         config.defaultBondCurve.push([1, 32 ether]);

--- a/script/csm0x02/DeployCSM0x02Mainnet.s.sol
+++ b/script/csm0x02/DeployCSM0x02Mainnet.s.sol
@@ -42,6 +42,7 @@ contract DeployCSM0x02Mainnet is DeployCSM0x02Base {
         config.gIFirstBalanceNode = GIndices.FIRST_BALANCE_NODE_ELECTRA;
         config.verifierFirstSupportedSlot = 364032 * config.slotsPerEpoch; // https://github.com/ethereum/EIPs/blob/master/EIPS/eip-7600.md#activation
         config.capellaSlot = 194048 * config.slotsPerEpoch; // @see https://github.com/eth-clients/mainnet/blob/main/metadata/config.yaml#L50
+        config.minWithdrawalRatio = 9900;
 
         // Accounting
         // TODO: Set proper default bond curve values for CSM0x02.

--- a/script/curated/DeployBase.s.sol
+++ b/script/curated/DeployBase.s.sol
@@ -81,6 +81,7 @@ struct CuratedDeployParams {
     GIndex gIFirstBalanceNode;
     uint256 verifierFirstSupportedSlot;
     uint256 capellaSlot;
+    uint256 minWithdrawalRatio;
     // Accounting
     uint256[2][] defaultBondCurve;
     uint256 minBondLockPeriod;
@@ -267,6 +268,7 @@ abstract contract DeployBase is Script {
                 firstSupportedSlot: Slot.wrap(uint64(config.verifierFirstSupportedSlot)),
                 pivotSlot: Slot.wrap(uint64(config.verifierFirstSupportedSlot)),
                 capellaSlot: Slot.wrap(uint64(config.capellaSlot)),
+                minWithdrawalRatio: config.minWithdrawalRatio,
                 admin: deployer
             });
 

--- a/script/curated/DeployHoodi.s.sol
+++ b/script/curated/DeployHoodi.s.sol
@@ -45,6 +45,7 @@ contract DeployHoodi is DeployBase {
         config.gIFirstBalanceNode = GIndices.FIRST_BALANCE_NODE_ELECTRA;
         config.verifierFirstSupportedSlot = 2048 * config.slotsPerEpoch; // @see https://github.com/eth-clients/hoodi/blob/main/metadata/config.yaml#L41
         config.capellaSlot = 0; // @see https://github.com/eth-clients/hoodi/blob/main/metadata/config.yaml#L33
+        config.minWithdrawalRatio = 9950;
 
         // Accounting
         // 11 -> 1

--- a/script/curated/DeployLocalDevNet.s.sol
+++ b/script/curated/DeployLocalDevNet.s.sol
@@ -35,6 +35,7 @@ contract DeployLocalDevNet is DeployBase {
         config.gIFirstBlockRootInSummary = GIndices.FIRST_BLOCK_ROOT_IN_SUMMARY_ELECTRA; // prettier-ignore
         config.verifierFirstSupportedSlot = vm.envUint("DEVNET_ELECTRA_EPOCH") * config.slotsPerEpoch;
         config.capellaSlot = vm.envUint("DEVNET_CAPELLA_EPOCH") * config.slotsPerEpoch;
+        config.minWithdrawalRatio = 9950;
 
         // Accounting
         // 11 -> 1

--- a/script/curated/DeployMainnet.s.sol
+++ b/script/curated/DeployMainnet.s.sol
@@ -42,6 +42,7 @@ contract DeployMainnet is DeployBase {
         config.gIFirstBalanceNode = GIndices.FIRST_BALANCE_NODE_ELECTRA;
         config.verifierFirstSupportedSlot = 364032 * config.slotsPerEpoch; // https://github.com/ethereum/EIPs/blob/master/EIPS/eip-7600.md#activation
         config.capellaSlot = 194048 * config.slotsPerEpoch; // @see https://github.com/eth-clients/mainnet/blob/main/metadata/config.yaml#L50
+        config.minWithdrawalRatio = 9950;
 
         // Accounting
         // 11 -> 1

--- a/src/CSModule.sol
+++ b/src/CSModule.sol
@@ -63,9 +63,12 @@ contract CSModule is ICSModule, BaseModule {
     ///      To prevent possible frontrun this method should strictly be called in the same TX as the upgrade transaction and should not be called separately.
     function finalizeUpgradeV3() external reinitializer(INITIALIZED_VERSION) {
         BaseModuleStorage storage $ = _baseStorage();
-        // Clean `Layout.freeSlot1` since the storage slot is no longer needed in version 3.
-        $.freeSlot1 = 0;
         // NOTE: Don't call `_initTopUpQueue` because it is disabled by default and existing CSM deployment can only support 0x01 validators mode.
+
+        assembly {
+            // clean slot `1` since it has old QueueLib.Queue struct data from _legacyQueue variable
+            sstore(1, 0x00)
+        }
 
         // NOTE: Rebuild the global withdrawn counter for the future.
         uint256 totalWithdrawnValidators;
@@ -218,7 +221,7 @@ contract CSModule is ICSModule, BaseModule {
 
         // Cap top-ups so we don't over-allocate to keys that lost balance due to CL penalties.
         uint256[] memory cappedTopUpLimits = NodeOperatorOps.capTopUpLimitsByKeyBalance(
-            _baseStorage().keyAddedBalances,
+            _baseStorage(),
             operatorIds,
             keyIndices,
             topUpLimits
@@ -235,8 +238,8 @@ contract CSModule is ICSModule, BaseModule {
 
         if (allocations.length == 0) return allocations;
 
-        NodeOperatorOps.increaseKeyAddedBalancesByAllocations(
-            _baseStorage().keyAddedBalances,
+        NodeOperatorOps.increaseKeyAllocatedBalance(
+            _baseStorage().keyAllocatedBalance,
             operatorIds,
             keyIndices,
             allocations

--- a/src/CuratedModule.sol
+++ b/src/CuratedModule.sol
@@ -140,7 +140,7 @@ contract CuratedModule is ICuratedModule, BaseModule {
 
         // Cap top-ups so we don't over-allocate to keys that lost balance due to CL penalties.
         uint256[] memory cappedTopUpLimits = NodeOperatorOps.capTopUpLimitsByKeyBalance(
-            _baseStorage().keyAddedBalances,
+            _baseStorage(),
             operatorIds,
             keyIndices,
             topUpLimits
@@ -315,7 +315,7 @@ contract CuratedModule is ICuratedModule, BaseModule {
             operatorsCount: $.nodeOperatorsCount
         });
 
-        NodeOperatorOps.increaseKeyAddedBalancesByAllocations($.keyAddedBalances, operatorIds, keyIndices, allocations);
+        NodeOperatorOps.increaseKeyAllocatedBalance($.keyAllocatedBalance, operatorIds, keyIndices, allocations);
         CuratedOperatorBalancesOps.increaseByAllocations(
             _curatedStorage().operatorBalances,
             uniqueOperatorIds,

--- a/src/Verifier.sol
+++ b/src/Verifier.sol
@@ -359,6 +359,10 @@ contract Verifier is IVerifier, AccessControlEnumerable, PausableWithRoles {
         bytes32 stateRoot,
         Slot stateSlot
     ) internal view returns (uint64 balanceGwei) {
+        if (_computeEpochAtSlot(stateSlot) >= validator.object.withdrawableEpoch) {
+            revert ValidatorIsWithdrawable();
+        }
+
         {
             bytes memory pubkey = MODULE.getSigningKeys(validator.nodeOperatorId, validator.keyIndex, 1);
             if (keccak256(pubkey) != keccak256(validator.object.pubkey)) revert InvalidPublicKey();

--- a/src/Verifier.sol
+++ b/src/Verifier.sol
@@ -7,12 +7,12 @@ import { AccessControlEnumerable } from "@openzeppelin/contracts/access/extensio
 
 import { BeaconBlockHeader, Slot, Validator, Withdrawal } from "./lib/Types.sol";
 import { PausableWithRoles } from "./abstract/PausableWithRoles.sol";
-import { WithdrawnValidatorLib } from "./lib/WithdrawnValidatorLib.sol";
 import { GIndex } from "./lib/GIndex.sol";
 import { SSZ } from "./lib/SSZ.sol";
 
 import { IVerifier } from "./interfaces/IVerifier.sol";
 import { IBaseModule, WithdrawnValidatorInfo } from "./interfaces/IBaseModule.sol";
+import { WithdrawnValidatorLib } from "./lib/WithdrawnValidatorLib.sol";
 
 /// @notice Convert withdrawal amount to wei
 /// @param withdrawal Withdrawal struct
@@ -38,12 +38,9 @@ contract Verifier is IVerifier, AccessControlEnumerable, PausableWithRoles {
 
     uint256 internal constant MAX_BP = 10_000;
 
-    /// @dev Minimum withdrawal amount as a ratio of total ether deposited to the validator,
-    ///      expressed in basis points (10 000 = 100%). At ~3% top APY, losing >10% of balance
-    ///      requires ~3 years offline — implausible for any legitimately run validator.
-    ///      We do not accept slashed validators in normal withdrawal processing, so we do not need to account for slashing penalties here.
-    ///      In case of unexpected network conditions, the DAO can always replace the verifier contract with one having a different threshold.
-    uint256 internal constant MIN_WITHDRAWAL_RATIO = 9000;
+    /// @dev Minimum withdrawal amount as a ratio of the expected validator balance,
+    ///      expressed in basis points (10 000 = 100%).
+    uint256 public immutable MIN_WITHDRAWAL_RATIO;
 
     uint64 public immutable SLOTS_PER_EPOCH;
 
@@ -106,6 +103,7 @@ contract Verifier is IVerifier, AccessControlEnumerable, PausableWithRoles {
         Slot firstSupportedSlot,
         Slot pivotSlot,
         Slot capellaSlot,
+        uint256 minWithdrawalRatio,
         address admin
     ) {
         if (withdrawalAddress == address(0)) revert ZeroWithdrawalAddress();
@@ -115,9 +113,11 @@ contract Verifier is IVerifier, AccessControlEnumerable, PausableWithRoles {
         if (slotsPerHistoricalRoot == 0) revert InvalidChainConfig();
         if (firstSupportedSlot > pivotSlot) revert InvalidPivotSlot();
         if (capellaSlot > firstSupportedSlot) revert InvalidCapellaSlot();
+        if (minWithdrawalRatio == 0 || minWithdrawalRatio > MAX_BP) revert InvalidMinWithdrawalRatio();
 
         WITHDRAWAL_ADDRESS = withdrawalAddress;
         MODULE = IBaseModule(module);
+        MIN_WITHDRAWAL_RATIO = minWithdrawalRatio;
 
         SLOTS_PER_EPOCH = slotsPerEpoch;
         SLOTS_PER_HISTORICAL_ROOT = slotsPerHistoricalRoot;
@@ -333,13 +333,10 @@ contract Verifier is IVerifier, AccessControlEnumerable, PausableWithRoles {
         if (_computeEpochAtSlot(header.slot) < validator.object.withdrawableEpoch) revert ValidatorIsNotWithdrawable();
         if (withdrawal.object.validatorIndex != validator.index) revert InvalidValidatorIndex();
 
-        // The full withdrawal threshold is derived from the total ether deposited to the validator (activation balance
-        // + tracked top-ups/consolidations). The ratio (MIN_WITHDRAWAL_RATIO / MAX_BP) accounts for possible CL losses
-        // such as inactivity penalties.
-        uint256 totalDepositedEther = WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE +
-            MODULE.getKeyAddedBalance(nodeOperatorId, keyIndex);
+        uint256 expectedBalance = MODULE.getKeyConfirmedBalance(nodeOperatorId, keyIndex) +
+            WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE;
         withdrawalAmount = withdrawal.object.amountWei();
-        if (withdrawalAmount < (totalDepositedEther * MIN_WITHDRAWAL_RATIO) / MAX_BP) revert PartialWithdrawal();
+        if (withdrawalAmount < (expectedBalance * MIN_WITHDRAWAL_RATIO) / MAX_BP) revert PartialWithdrawal();
 
         SSZ.verifyProof({
             proof: validator.proof,

--- a/src/abstract/BaseModule.sol
+++ b/src/abstract/BaseModule.sol
@@ -583,8 +583,13 @@ abstract contract BaseModule is
     }
 
     /// @inheritdoc IBaseModule
-    function getKeyAddedBalance(uint256 nodeOperatorId, uint256 keyIndex) external view returns (uint256) {
-        return _baseStorage().keyAddedBalances[KeyPointerLib.keyPointer(nodeOperatorId, keyIndex)];
+    function getKeyAllocatedBalance(uint256 nodeOperatorId, uint256 keyIndex) external view returns (uint256) {
+        return _baseStorage().keyAllocatedBalance[KeyPointerLib.keyPointer(nodeOperatorId, keyIndex)];
+    }
+
+    /// @inheritdoc IBaseModule
+    function getKeyConfirmedBalance(uint256 nodeOperatorId, uint256 keyIndex) external view returns (uint256) {
+        return _baseStorage().keyConfirmedBalance[KeyPointerLib.keyPointer(nodeOperatorId, keyIndex)];
     }
 
     /// @inheritdoc IBaseModule

--- a/src/abstract/ModuleLinearStorage.sol
+++ b/src/abstract/ModuleLinearStorage.sol
@@ -12,21 +12,21 @@ abstract contract ModuleLinearStorage {
     ///      accessed via `_baseStorage()` at slot 0.
     struct BaseModuleStorage {
         /// @dev Having this mapping here to preserve the current layout of the storage of the CSModule.
-        mapping(uint256 priority => DepositQueueLib.Queue queue) depositQueueByPriority;
-        bytes32 freeSlot1;
-        uint256 upToDateOperatorDepositInfoCount;
+        /* 0 */ mapping(uint256 priority => DepositQueueLib.Queue queue) depositQueueByPriority;
+        /* 1 */ mapping(uint256 noKeyIndexPacked => uint256) keyAllocatedBalance;
+        /* 2 */ mapping(uint256 noKeyIndexPacked => uint256) keyConfirmedBalance;
         /// @dev Total number of withdrawn validators reported for the module.
-        uint256 totalWithdrawnValidators;
-        mapping(uint256 noKeyIndexPacked => uint256) keyAddedBalances;
-        uint256 nonce;
-        mapping(uint256 nodeOperatorId => NodeOperator) nodeOperators;
+        /* 3 */ uint256 totalWithdrawnValidators;
+        /* 4 */ uint256 upToDateOperatorDepositInfoCount;
+        /* 5 */ uint256 nonce;
+        /* 6 */ mapping(uint256 nodeOperatorId => NodeOperator) nodeOperators;
         /// @dev see KeyPointerLib.keyPointer function for details of noKeyIndexPacked structure
-        mapping(uint256 noKeyIndexPacked => bool) isValidatorWithdrawn;
-        mapping(uint256 noKeyIndexPacked => bool) isValidatorSlashed;
-        uint64 totalDepositedValidators;
-        uint64 totalExitedValidators;
-        uint64 depositableValidatorsCount;
-        uint64 nodeOperatorsCount;
+        /* 7 */ mapping(uint256 noKeyIndexPacked => bool) isValidatorWithdrawn;
+        /* 8 */ mapping(uint256 noKeyIndexPacked => bool) isValidatorSlashed;
+        /* 9 */ uint64 totalDepositedValidators;
+        /* 9 */ uint64 totalExitedValidators;
+        /* 9 */ uint64 depositableValidatorsCount;
+        /* 9 */ uint64 nodeOperatorsCount;
     }
 
     function _baseStorage() internal pure returns (BaseModuleStorage storage $) {

--- a/src/interfaces/IBaseModule.sol
+++ b/src/interfaces/IBaseModule.sol
@@ -82,7 +82,8 @@ interface IBaseModule is IStakingModule, IAccessControlEnumerable, INOAddresses,
         bytes pubkey
     );
     event ValidatorSlashingReported(uint256 indexed nodeOperatorId, uint256 keyIndex, bytes pubkey);
-    event KeyAddedBalanceChanged(uint256 indexed nodeOperatorId, uint256 indexed keyIndex, uint256 newTotal);
+    event KeyAllocatedBalanceChanged(uint256 indexed nodeOperatorId, uint256 indexed keyIndex, uint256 newTotal);
+    event KeyConfirmedBalanceChanged(uint256 indexed nodeOperatorId, uint256 indexed keyIndex, uint256 newBalance);
     event KeyRemovalChargeApplied(uint256 indexed nodeOperatorId);
 
     event GeneralDelayedPenaltyReported(
@@ -363,18 +364,24 @@ interface IBaseModule is IStakingModule, IAccessControlEnumerable, INOAddresses,
     /// @param keyIndex Index of the key in the Node Operator's keys storage
     function reportValidatorSlashing(uint256 nodeOperatorId, uint256 keyIndex) external;
 
-    /// @notice Sync tracked added balance for a key based on proven validator balance.
-    /// @dev The function only increases the key added value at the moment.
+    /// @notice Update verified on-chain balance for a key.
+    /// @dev The function stores balance relative to MIN_ACTIVATION_BALANCE.
     /// @param nodeOperatorId ID of the Node Operator
     /// @param keyIndex Index of the key in the Node Operator's keys storage
     /// @param currentBalanceWei Proven current validator balance in wei
     function reportValidatorBalance(uint256 nodeOperatorId, uint256 keyIndex, uint256 currentBalanceWei) external;
 
-    /// @notice Get tracked added balance for a particular key
+    /// @notice Get cumulative top-up amount allocated to a particular key (above MIN_ACTIVATION_BALANCE)
     /// @param nodeOperatorId ID of the Node Operator
     /// @param keyIndex Index of the Key in the Node Operator's keys storage
-    /// @return Tracked added balance (wei)
-    function getKeyAddedBalance(uint256 nodeOperatorId, uint256 keyIndex) external view returns (uint256);
+    /// @return Allocated balance above MIN_ACTIVATION_BALANCE (wei)
+    function getKeyAllocatedBalance(uint256 nodeOperatorId, uint256 keyIndex) external view returns (uint256);
+
+    /// @notice Get verifier-confirmed balance for a particular key (above MIN_ACTIVATION_BALANCE)
+    /// @param nodeOperatorId ID of the Node Operator
+    /// @param keyIndex Index of the Key in the Node Operator's keys storage
+    /// @return Confirmed balance above MIN_ACTIVATION_BALANCE (wei)
+    function getKeyConfirmedBalance(uint256 nodeOperatorId, uint256 keyIndex) external view returns (uint256);
 
     /// @notice Report Node Operator's keys as withdrawn and charge penalties associated with exit if any.
     ///         A validator is considered withdrawn in the following cases:

--- a/src/interfaces/IVerifier.sol
+++ b/src/interfaces/IVerifier.sol
@@ -99,6 +99,7 @@ interface IVerifier {
     error ZeroAdminAddress();
     error InvalidPivotSlot();
     error InvalidCapellaSlot();
+    error InvalidMinWithdrawalRatio();
     error HistoricalSummaryDoesNotExist();
 
     function BEACON_ROOTS() external view returns (address);
@@ -130,6 +131,8 @@ interface IVerifier {
     function CAPELLA_SLOT() external view returns (Slot);
 
     function WITHDRAWAL_ADDRESS() external view returns (address);
+
+    function MIN_WITHDRAWAL_RATIO() external view returns (uint256);
 
     function MODULE() external view returns (IBaseModule);
 

--- a/src/interfaces/IVerifier.sol
+++ b/src/interfaces/IVerifier.sol
@@ -90,6 +90,7 @@ interface IVerifier {
     error ValidatorIsSlashed();
     error ValidatorIsNotSlashed();
     error ValidatorIsNotWithdrawable();
+    error ValidatorIsWithdrawable();
     error InvalidWithdrawalAddress();
     error InvalidPublicKey();
     error InvalidValidatorIndex();

--- a/src/lib/NodeOperatorOps.sol
+++ b/src/lib/NodeOperatorOps.sol
@@ -160,6 +160,11 @@ library NodeOperatorOps {
         if (newConfirmed <= $.keyConfirmedBalance[pointer]) revert IBaseModule.UnreportableBalance();
         $.keyConfirmedBalance[pointer] = newConfirmed;
         emit IBaseModule.KeyConfirmedBalanceChanged(nodeOperatorId, keyIndex, newConfirmed);
+
+        if ($.keyAllocatedBalance[pointer] < newConfirmed) {
+            $.keyAllocatedBalance[pointer] = newConfirmed;
+            emit IBaseModule.KeyAllocatedBalanceChanged(nodeOperatorId, keyIndex, newConfirmed);
+        }
     }
 
     function increaseKeyAllocatedBalance(
@@ -354,8 +359,7 @@ library NodeOperatorOps {
         cappedTopUpLimits = new uint256[](len);
         uint256 cap = _keyBalanceCap();
         for (uint256 i; i < len; ++i) {
-            uint256 pointer = KeyPointerLib.keyPointer(operatorIds[i], keyIndices[i]);
-            uint256 balance = Math.max($.keyAllocatedBalance[pointer], $.keyConfirmedBalance[pointer]);
+            uint256 balance = $.keyAllocatedBalance[KeyPointerLib.keyPointer(operatorIds[i], keyIndices[i])];
             uint256 remaining = balance > cap ? 0 : cap - balance;
             cappedTopUpLimits[i] = Math.min(topUpLimits[i], remaining);
         }

--- a/src/lib/NodeOperatorOps.sol
+++ b/src/lib/NodeOperatorOps.sol
@@ -151,19 +151,19 @@ library NodeOperatorOps {
             currentBalanceWei = WithdrawnValidatorLib.MAX_EFFECTIVE_BALANCE;
         }
 
-        uint256 newKeyAddedBalance;
+        uint256 newConfirmed;
         unchecked {
-            newKeyAddedBalance = currentBalanceWei - WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE;
+            newConfirmed = currentBalanceWei - WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE;
         }
 
         uint256 pointer = KeyPointerLib.keyPointer(nodeOperatorId, keyIndex);
-        if (newKeyAddedBalance <= $.keyAddedBalances[pointer]) revert IBaseModule.UnreportableBalance();
-        $.keyAddedBalances[pointer] = newKeyAddedBalance;
-        emit IBaseModule.KeyAddedBalanceChanged(nodeOperatorId, keyIndex, newKeyAddedBalance);
+        if (newConfirmed <= $.keyConfirmedBalance[pointer]) revert IBaseModule.UnreportableBalance();
+        $.keyConfirmedBalance[pointer] = newConfirmed;
+        emit IBaseModule.KeyConfirmedBalanceChanged(nodeOperatorId, keyIndex, newConfirmed);
     }
 
-    function increaseKeyAddedBalancesByAllocations(
-        mapping(uint256 => uint256) storage keyAddedBalances,
+    function increaseKeyAllocatedBalance(
+        mapping(uint256 => uint256) storage keyAllocatedBalance,
         uint256[] calldata operatorIds,
         uint256[] calldata keyIndices,
         uint256[] calldata allocations
@@ -171,7 +171,7 @@ library NodeOperatorOps {
         for (uint256 i; i < allocations.length; ++i) {
             uint256 allocationWei = allocations[i];
             if (allocationWei == 0) continue;
-            _increaseKeyAddedBalance(keyAddedBalances, operatorIds[i], keyIndices[i], allocationWei);
+            _increaseKeyAllocatedBalance(keyAllocatedBalance, operatorIds[i], keyIndices[i], allocationWei);
         }
     }
 
@@ -345,17 +345,18 @@ library NodeOperatorOps {
     }
 
     function capTopUpLimitsByKeyBalance(
-        mapping(uint256 => uint256) storage keyAddedBalances,
+        ModuleLinearStorage.BaseModuleStorage storage $,
         uint256[] calldata operatorIds,
         uint256[] calldata keyIndices,
         uint256[] calldata topUpLimits
     ) external view returns (uint256[] memory cappedTopUpLimits) {
         uint256 len = topUpLimits.length;
         cappedTopUpLimits = new uint256[](len);
-        uint256 cap = _keyAddedBalanceCap();
+        uint256 cap = _keyBalanceCap();
         for (uint256 i; i < len; ++i) {
-            uint256 keyAddedBalance = keyAddedBalances[KeyPointerLib.keyPointer(operatorIds[i], keyIndices[i])];
-            uint256 remaining = keyAddedBalance >= cap ? 0 : cap - keyAddedBalance;
+            uint256 pointer = KeyPointerLib.keyPointer(operatorIds[i], keyIndices[i]);
+            uint256 balance = Math.max($.keyAllocatedBalance[pointer], $.keyConfirmedBalance[pointer]);
+            uint256 remaining = balance > cap ? 0 : cap - balance;
             cappedTopUpLimits[i] = Math.min(topUpLimits[i], remaining);
         }
     }
@@ -414,16 +415,16 @@ library NodeOperatorOps {
         }
     }
 
-    function _increaseKeyAddedBalance(
-        mapping(uint256 => uint256) storage keyAddedBalances,
+    function _increaseKeyAllocatedBalance(
+        mapping(uint256 => uint256) storage keyAllocatedBalance,
         uint256 nodeOperatorId,
         uint256 keyIndex,
         uint256 incrementWei
     ) internal {
         uint256 pointer = KeyPointerLib.keyPointer(nodeOperatorId, keyIndex);
-        uint256 updatedBalance = Math.min(_keyAddedBalanceCap(), keyAddedBalances[pointer] + incrementWei);
-        keyAddedBalances[pointer] = updatedBalance;
-        emit IBaseModule.KeyAddedBalanceChanged(nodeOperatorId, keyIndex, updatedBalance);
+        uint256 updated = Math.min(_keyBalanceCap(), keyAllocatedBalance[pointer] + incrementWei);
+        keyAllocatedBalance[pointer] = updated;
+        emit IBaseModule.KeyAllocatedBalanceChanged(nodeOperatorId, keyIndex, updated);
     }
 
     function _updateExitedValidatorsCount(
@@ -458,7 +459,7 @@ library NodeOperatorOps {
         revert IBaseModule.NodeOperatorDoesNotExist();
     }
 
-    function _keyAddedBalanceCap() private pure returns (uint256) {
+    function _keyBalanceCap() private pure returns (uint256) {
         return WithdrawnValidatorLib.MAX_EFFECTIVE_BALANCE - WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE;
     }
 }

--- a/src/lib/WithdrawnValidatorLib.sol
+++ b/src/lib/WithdrawnValidatorLib.sol
@@ -37,7 +37,7 @@ library WithdrawnValidatorLib {
             if (info.isSlashed != slashed) revert IBaseModule.InvalidWithdrawnValidatorInfo();
             if (info.isSlashed && !$.isValidatorSlashed[pointer]) revert IBaseModule.SlashingPenaltyIsNotApplicable();
 
-            _process($.nodeOperators[info.nodeOperatorId], info, $.keyAddedBalances[pointer]);
+            _process($.nodeOperators[info.nodeOperatorId], info, $.keyConfirmedBalance[pointer]);
 
             $.isValidatorWithdrawn[pointer] = true;
             touchedOperatorIds[touchedCount] = info.nodeOperatorId;
@@ -89,7 +89,7 @@ library WithdrawnValidatorLib {
         WithdrawnValidatorInfo calldata validatorInfo,
         ExitPenaltyInfo memory penaltyInfo,
         uint256 keyAddedBalance
-    ) internal {
+    ) private {
         bool chargeElWithdrawalRequestFee = false;
 
         uint256 minExpectedBalance = MIN_ACTIVATION_BALANCE + keyAddedBalance;

--- a/src/lib/WithdrawnValidatorLib.sol
+++ b/src/lib/WithdrawnValidatorLib.sol
@@ -50,7 +50,7 @@ library WithdrawnValidatorLib {
     function _process(
         NodeOperator storage no,
         WithdrawnValidatorInfo calldata validatorInfo,
-        uint256 keyAddedBalance
+        uint256 keyConfirmedBalance
     ) private {
         if (validatorInfo.slashingPenalty > 0 && !validatorInfo.isSlashed) {
             revert IBaseModule.InvalidWithdrawnValidatorInfo();
@@ -72,7 +72,7 @@ library WithdrawnValidatorLib {
             pubkey
         );
 
-        _fulfillExitObligations(validatorInfo, penaltyInfo, keyAddedBalance);
+        _fulfillExitObligations(validatorInfo, penaltyInfo, keyConfirmedBalance);
 
         emit IBaseModule.ValidatorWithdrawn({
             nodeOperatorId: validatorInfo.nodeOperatorId,
@@ -88,11 +88,11 @@ library WithdrawnValidatorLib {
     function _fulfillExitObligations(
         WithdrawnValidatorInfo calldata validatorInfo,
         ExitPenaltyInfo memory penaltyInfo,
-        uint256 keyAddedBalance
+        uint256 keyConfirmedBalance
     ) private {
         bool chargeElWithdrawalRequestFee = false;
 
-        uint256 minExpectedBalance = MIN_ACTIVATION_BALANCE + keyAddedBalance;
+        uint256 minExpectedBalance = MIN_ACTIVATION_BALANCE + keyConfirmedBalance;
         uint256 penaltyMultiplier = _getPenaltyMultiplier(Math.max(minExpectedBalance, validatorInfo.exitBalance));
         uint256 penaltySum;
         uint256 feeSum;

--- a/test/fixtures/Verifier/balance.mjs
+++ b/test/fixtures/Verifier/balance.mjs
@@ -41,6 +41,8 @@ function main(opts) {
     ...new Uint8Array(11),
     ...hexStrToBytesArr("b3e29c46ee1745724417c0c51eb2351a1c01cf36"),
   ]);
+  validator.exitEpoch = Number.MAX_SAFE_INTEGER;
+  validator.withdrawableEpoch = Number.MAX_SAFE_INTEGER;
 
   const state = Fork.BeaconState.defaultView();
   state.slot = opts.epoch * SLOTS_PER_EPOCH;

--- a/test/fixtures/Verifier/historical_balance.mjs
+++ b/test/fixtures/Verifier/historical_balance.mjs
@@ -53,6 +53,8 @@ function main(opts) {
     ...new Uint8Array(11),
     ...hexStrToBytesArr("b3e29c46ee1745724417c0c51eb2351a1c01cf36"),
   ]);
+  validator.exitEpoch = Number.MAX_SAFE_INTEGER;
+  validator.withdrawableEpoch = Number.MAX_SAFE_INTEGER;
 
   while (historicalState.validators.length < MAX_VALIDATORS) {
     historicalState.validators.push(Validator.defaultView());

--- a/test/fork/integration/csm0x02/StakingRouter.t.sol
+++ b/test/fork/integration/csm0x02/StakingRouter.t.sol
@@ -14,7 +14,7 @@ import { CSM0x02IntegrationBase } from "../common/ModuleTypeBase.sol";
 import { StakingRouterIntegrationTestBase } from "../common/StakingRouter.t.sol";
 
 contract StakingRouterIntegrationTestCSM0x02 is StakingRouterIntegrationTestBase, CSM0x02IntegrationBase {
-    uint256 internal constant KEY_ADDED_BALANCE_CAP =
+    uint256 internal constant KEY_BALANCE_CAP =
         WithdrawnValidatorLib.MAX_EFFECTIVE_BALANCE - WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE;
     uint256 internal constant TOP_UP_ALLOCATION_PROBE_AMOUNT = 100_000 ether;
 
@@ -100,14 +100,14 @@ contract StakingRouterIntegrationTestCSM0x02 is StakingRouterIntegrationTestBase
         assertEq(module.getNonce(), nonceBefore + 1);
     }
 
-    function test_routerTopUp_updatesKeyAddedBalance() public assertInvariants {
+    function test_routerTopUp_updatesKeyAllocatedBalance() public assertInvariants {
         (uint256 noId, uint256 keyIndex, bytes memory pubkey) = integrationHelpers.getDepositableTopUpNodeOperator(
             nextAddress()
         );
 
         uint256 topUpLimit = 1 ether;
         (uint256 expectedMaxDepositAmount, ) = stakingRouter.getTopUpAllocation(TOP_UP_ALLOCATION_PROBE_AMOUNT);
-        uint256 keyAddedBalanceBefore = module.getKeyAddedBalance(noId, keyIndex);
+        uint256 keyAllocatedBalanceBefore = module.getKeyAllocatedBalance(noId, keyIndex);
         uint256 remainingCapacity = _remainingTopUpCapacity(noId, keyIndex);
         uint256 cappedLimit = topUpLimit < remainingCapacity ? topUpLimit : remainingCapacity;
         uint256 expectedAllocation = expectedMaxDepositAmount < cappedLimit ? expectedMaxDepositAmount : cappedLimit;
@@ -122,8 +122,8 @@ contract StakingRouterIntegrationTestCSM0x02 is StakingRouterIntegrationTestBase
         vm.prank(topUpGateway);
         stakingRouter.topUp(moduleId, keyIndices, operatorIds, pubkeys, topUpLimits);
 
-        uint256 keyAddedBalanceAfter = module.getKeyAddedBalance(noId, keyIndex);
-        assertEq(keyAddedBalanceAfter - keyAddedBalanceBefore, expectedAllocation);
+        uint256 keyAllocatedBalanceAfter = module.getKeyAllocatedBalance(noId, keyIndex);
+        assertEq(keyAllocatedBalanceAfter - keyAllocatedBalanceBefore, expectedAllocation);
     }
 
     function test_routerTopUp_fullTopUpDequeuesOneQueueItem() public assertInvariants {
@@ -259,7 +259,7 @@ contract StakingRouterIntegrationTestCSM0x02 is StakingRouterIntegrationTestBase
             uint256 checkedAt
         ) = _topUpAndDeepRewind(type(uint256).max);
 
-        uint256 keyAddedBalanceBefore = module.getKeyAddedBalance(noIds[checkedAt], keyIdxs[checkedAt]);
+        uint256 keyAllocatedBalanceBefore = module.getKeyAllocatedBalance(noIds[checkedAt], keyIdxs[checkedAt]);
         assertEq(_remainingTopUpCapacity(noIds[checkedAt], keyIdxs[checkedAt]), 0);
 
         (, , uint256 queueLengthBefore, ) = module.getTopUpQueue();
@@ -273,8 +273,8 @@ contract StakingRouterIntegrationTestCSM0x02 is StakingRouterIntegrationTestBase
         vm.prank(topUpGateway);
         stakingRouter.topUp(moduleId, keyIdxs, noIds, pubs, topUpLimits);
 
-        assertEq(_countKeyAddedBalanceChangedEvents(), 0);
-        assertEq(module.getKeyAddedBalance(noIds[checkedAt], keyIdxs[checkedAt]), keyAddedBalanceBefore);
+        assertEq(_countKeyAllocatedBalanceChangedEvents(), 0);
+        assertEq(module.getKeyAllocatedBalance(noIds[checkedAt], keyIdxs[checkedAt]), keyAllocatedBalanceBefore);
         (, , uint256 queueLengthAfter, ) = module.getTopUpQueue();
         assertEq(queueLengthAfter + noIds.length, queueLengthBefore);
     }
@@ -287,7 +287,7 @@ contract StakingRouterIntegrationTestCSM0x02 is StakingRouterIntegrationTestBase
             uint256 checkedAt
         ) = _topUpAndDeepRewind(1 ether);
 
-        uint256 keyAddedBalanceBefore = module.getKeyAddedBalance(noIds[checkedAt], keyIdxs[checkedAt]);
+        uint256 keyAllocatedBalanceBefore = module.getKeyAllocatedBalance(noIds[checkedAt], keyIdxs[checkedAt]);
         uint256 remainingCapacity = _remainingTopUpCapacity(noIds[checkedAt], keyIdxs[checkedAt]);
         assertGt(remainingCapacity, 0);
 
@@ -302,10 +302,10 @@ contract StakingRouterIntegrationTestCSM0x02 is StakingRouterIntegrationTestBase
         vm.prank(topUpGateway);
         stakingRouter.topUp(moduleId, keyIdxs, noIds, pubs, topUpLimits);
 
-        assertEq(_countKeyAddedBalanceChangedEvents(), 1);
+        assertEq(_countKeyAllocatedBalanceChangedEvents(), 1);
         assertEq(
-            module.getKeyAddedBalance(noIds[checkedAt], keyIdxs[checkedAt]),
-            keyAddedBalanceBefore + remainingCapacity
+            module.getKeyAllocatedBalance(noIds[checkedAt], keyIdxs[checkedAt]),
+            keyAllocatedBalanceBefore + remainingCapacity
         );
         (, , uint256 queueLengthAfter, ) = module.getTopUpQueue();
         assertEq(queueLengthAfter + noIds.length, queueLengthBefore);
@@ -377,8 +377,8 @@ contract StakingRouterIntegrationTestCSM0x02 is StakingRouterIntegrationTestBase
         stakingRouter.topUp(moduleId, keyIndices, operatorIds, pubkeys, topUpLimits);
     }
 
-    function _countKeyAddedBalanceChangedEvents() internal returns (uint256 count) {
-        bytes32 topic = IBaseModule.KeyAddedBalanceChanged.selector;
+    function _countKeyAllocatedBalanceChangedEvents() internal returns (uint256 count) {
+        bytes32 topic = IBaseModule.KeyAllocatedBalanceChanged.selector;
         Vm.Log[] memory logs = vm.getRecordedLogs();
         for (uint256 i; i < logs.length; i++) {
             if (logs[i].topics.length > 0 && logs[i].topics[0] == topic) count++;
@@ -386,9 +386,9 @@ contract StakingRouterIntegrationTestCSM0x02 is StakingRouterIntegrationTestBase
     }
 
     function _remainingTopUpCapacity(uint256 noId, uint256 keyIndex) internal view returns (uint256) {
-        uint256 keyAddedBalance = module.getKeyAddedBalance(noId, keyIndex);
-        if (keyAddedBalance >= KEY_ADDED_BALANCE_CAP) return 0;
-        return KEY_ADDED_BALANCE_CAP - keyAddedBalance;
+        uint256 keyAllocatedBalance = module.getKeyAllocatedBalance(noId, keyIndex);
+        if (keyAllocatedBalance >= KEY_BALANCE_CAP) return 0;
+        return KEY_BALANCE_CAP - keyAllocatedBalance;
     }
 
     function _forceTopUpQueueOneFreeSlot() internal returns (uint256 appliedLimit) {

--- a/test/fork/integration/curated/StakingRouter.t.sol
+++ b/test/fork/integration/curated/StakingRouter.t.sol
@@ -90,7 +90,7 @@ contract StakingRouterIntegrationTestCurated is StakingRouterIntegrationTestBase
         ) = _singleTopUpArrays(noId, keyIndex, pubkey, 1 ether);
 
         (uint256 expectedMaxDepositAmount, ) = stakingRouter.getTopUpAllocation(TOP_UP_ALLOCATION_PROBE_AMOUNT);
-        uint256 keyAddedBalanceBefore = module.getKeyAddedBalance(noId, keyIndex);
+        uint256 keyAllocatedBalanceBefore = module.getKeyAllocatedBalance(noId, keyIndex);
         ICuratedModule curatedModule = ICuratedModule(address(module));
         uint256 operatorBalanceBefore = curatedModule.getNodeOperatorBalance(noId);
 
@@ -109,9 +109,9 @@ contract StakingRouterIntegrationTestCurated is StakingRouterIntegrationTestBase
         vm.prank(topUpGateway);
         stakingRouter.topUp(moduleId, keyIndices, operatorIds, pubkeys, topUpLimits);
 
-        uint256 keyAddedBalanceAfter = module.getKeyAddedBalance(noId, keyIndex);
+        uint256 keyAllocatedBalanceAfter = module.getKeyAllocatedBalance(noId, keyIndex);
         uint256 operatorBalanceAfter = curatedModule.getNodeOperatorBalance(noId);
-        uint256 keyDelta = keyAddedBalanceAfter - keyAddedBalanceBefore;
+        uint256 keyDelta = keyAllocatedBalanceAfter - keyAllocatedBalanceBefore;
         uint256 operatorDelta = operatorBalanceAfter - operatorBalanceBefore;
 
         assertEq(operatorDelta, keyDelta);
@@ -133,13 +133,13 @@ contract StakingRouterIntegrationTestCurated is StakingRouterIntegrationTestBase
         ) = _singleTopUpArrays(noId, keyIndex, pubkey, 0.5 ether);
 
         ICuratedModule curatedModule = ICuratedModule(address(module));
-        uint256 keyAddedBalanceBefore = module.getKeyAddedBalance(noId, keyIndex);
+        uint256 keyAllocatedBalanceBefore = module.getKeyAllocatedBalance(noId, keyIndex);
         uint256 operatorBalanceBefore = curatedModule.getNodeOperatorBalance(noId);
 
         vm.prank(topUpGateway);
         stakingRouter.topUp(moduleId, keyIndices, operatorIds, pubkeys, topUpLimits);
 
-        assertEq(module.getKeyAddedBalance(noId, keyIndex), keyAddedBalanceBefore);
+        assertEq(module.getKeyAllocatedBalance(noId, keyIndex), keyAllocatedBalanceBefore);
         assertEq(curatedModule.getNodeOperatorBalance(noId), operatorBalanceBefore);
     }
 

--- a/test/fork/vote-upgrade/V3Upgrade.t.sol
+++ b/test/fork/vote-upgrade/V3Upgrade.t.sol
@@ -171,11 +171,10 @@ contract VoteChangesTest is V3UpgradeTestBase {
 
     function test_csmStorageSlotsBeforeUpgrade() public {
         vm.selectFork(forkIdBeforeUpgrade);
-        bytes32 slot3 = vm.load(address(module), bytes32(uint256(3)));
-        bytes32 slot4 = vm.load(address(module), bytes32(uint256(4)));
 
-        assertEq(slot3, bytes32(0), "assert _totalWithdrawnValidators is empty before upgrade");
-        assertEq(slot4, bytes32(0), "assert _keyAddedBalances base slot is empty before upgrade");
+        bytes32 slot2 = vm.load(address(module), bytes32(uint256(2)));
+
+        assertEq(slot2, bytes32(0), "assert ModuleLinearStorage.keyConfirmedBalance slot is empty before upgrade");
     }
 
     function test_csmNodeOperatorsState() public {

--- a/test/helpers/Fixtures.sol
+++ b/test/helpers/Fixtures.sol
@@ -135,6 +135,7 @@ contract DeploymentHelpers is Test {
         GIndex gIFirstBalanceNode;
         uint256 verifierFirstSupportedSlot;
         uint256 capellaSlot;
+        uint256 minWithdrawalRatio;
         uint256[2][] defaultBondCurve;
         uint256 defaultKeyRemovalCharge;
         uint256 defaultGeneralDelayedPenaltyAdditionalFine;
@@ -451,6 +452,7 @@ contract DeploymentHelpers is Test {
         dst.gIFirstBalanceNode = src.gIFirstBalanceNode;
         dst.verifierFirstSupportedSlot = src.verifierFirstSupportedSlot;
         dst.capellaSlot = src.capellaSlot;
+        dst.minWithdrawalRatio = src.minWithdrawalRatio;
 
         // Accounting
         for (uint256 i; i < src.defaultBondCurve.length; ++i) {
@@ -569,6 +571,7 @@ contract DeploymentHelpers is Test {
         params.gIFirstBalanceNode = decoded.gIFirstBalanceNode;
         params.verifierFirstSupportedSlot = decoded.verifierFirstSupportedSlot;
         params.capellaSlot = decoded.capellaSlot;
+        params.minWithdrawalRatio = decoded.minWithdrawalRatio;
         params.defaultBondCurve = decoded.defaultBondCurve;
         params.defaultKeyRemovalCharge = decoded.defaultKeyRemovalCharge;
         params.defaultGeneralDelayedPenaltyAdditionalFine = decoded.defaultGeneralDelayedPenaltyAdditionalFine;
@@ -623,6 +626,7 @@ contract DeploymentHelpers is Test {
         params.gIFirstBalanceNode = decoded.gIFirstBalanceNode;
         params.verifierFirstSupportedSlot = decoded.verifierFirstSupportedSlot;
         params.capellaSlot = decoded.capellaSlot;
+        params.minWithdrawalRatio = decoded.minWithdrawalRatio;
         params.defaultBondCurve = decoded.defaultBondCurve;
         params.defaultKeyRemovalCharge = decoded.defaultKeyRemovalCharge;
         params.defaultGeneralDelayedPenaltyAdditionalFine = decoded.defaultGeneralDelayedPenaltyAdditionalFine;
@@ -677,6 +681,7 @@ contract DeploymentHelpers is Test {
         params.gIFirstBalanceNode = decoded.gIFirstBalanceNode;
         params.verifierFirstSupportedSlot = decoded.verifierFirstSupportedSlot;
         params.capellaSlot = decoded.capellaSlot;
+        params.minWithdrawalRatio = decoded.minWithdrawalRatio;
         params.defaultBondCurve = decoded.defaultBondCurve;
         params.defaultKeyRemovalCharge = decoded.defaultKeyRemovalCharge;
         params.defaultGeneralDelayedPenaltyAdditionalFine = decoded.defaultGeneralDelayedPenaltyAdditionalFine;

--- a/test/unit/CSModule.t.sol
+++ b/test/unit/CSModule.t.sol
@@ -1056,16 +1056,13 @@ contract CSMTopUpQueue is CSMCommon {
         createNodeOperator(1);
         csm.obtainDepositData(1, "");
 
-        setKeyConfirmedBalance(
-            0,
-            0,
-            WithdrawnValidatorLib.MAX_EFFECTIVE_BALANCE - WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE - 2 ether
-        );
+        uint256 cap = WithdrawnValidatorLib.MAX_EFFECTIVE_BALANCE - WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE;
+        setKeyConfirmedBalance(0, 0, cap - 2 ether);
 
         bytes memory key = csm.getSigningKeys(0, 0, 1);
         vm.expectEmit(address(csm));
-        // keyAllocatedBalance was 0 (setKeyConfirmedBalance only writes to keyConfirmedBalance), allocation adds 2 ether
-        emit IBaseModule.KeyAllocatedBalanceChanged(0, 0, 2 ether);
+        // keyAllocatedBalance is already at cap - 2 ether (set by reportValidatorBalance), allocation adds 2 ether to reach cap
+        emit IBaseModule.KeyAllocatedBalanceChanged(0, 0, cap);
 
         uint256[] memory allocations = csm.allocateDeposits({
             maxDepositAmount: 5 ether,
@@ -2043,6 +2040,26 @@ contract CSMReportValidatorBalance is ModuleReportValidatorBalance, CSMCommon {
         topUpQueueLimit = 32;
 
         super.setUp();
+    }
+
+    function test_reportValidatorBalance_doesNotDecreaseKeyAllocatedBalance() public {
+        uint256 noId = createNodeOperator(1);
+        csm.obtainDepositData(1, "");
+
+        // Allocate 20 ether via top-up, setting keyAllocatedBalance to 20 ether.
+        bytes memory key = csm.getSigningKeys(noId, 0, 1);
+        csm.allocateDeposits({
+            maxDepositAmount: 20 ether,
+            pubkeys: BytesArr(key),
+            keyIndices: UintArr(0),
+            operatorIds: UintArr(noId),
+            topUpLimits: UintArr(20 ether)
+        });
+        assertEq(csm.getKeyAllocatedBalance(noId, 0), 20 ether);
+
+        // Confirmed balance below allocated — keyAllocatedBalance must not decrease.
+        csm.reportValidatorBalance(noId, 0, WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE + 10 ether);
+        assertEq(csm.getKeyAllocatedBalance(noId, 0), 20 ether, "keyAllocatedBalance must not decrease");
     }
 }
 

--- a/test/unit/CSModule.t.sol
+++ b/test/unit/CSModule.t.sol
@@ -351,14 +351,11 @@ contract CsmInitialize is CSMCommon {
         _enableInitializers(address(csm));
 
         bytes32 slot1 = bytes32(uint256(1));
-        bytes32 slot2 = bytes32(uint256(2));
         vm.store(address(csm), slot1, bytes32(uint256(1)));
-        vm.store(address(csm), slot2, bytes32(uint256(2)));
 
         csm.finalizeUpgradeV3();
 
         assertEq(vm.load(address(csm), slot1), bytes32(0));
-        assertEq(vm.load(address(csm), slot2), bytes32(0));
 
         (bool active, uint256 limit, uint256 length, uint256 head) = csm.getTopUpQueue();
         assertFalse(active);
@@ -915,7 +912,7 @@ contract CSMTopUpQueue is CSMCommon {
         assertEq(_getTopUpQueueLength(), 0);
     }
 
-    function test_topUp_capsAllocationByKeyAddedBalance() public {
+    function test_topUp_capsAllocationByKeyAllocatedBalance() public {
         createNodeOperator(1);
         csm.obtainDepositData(1, "");
 
@@ -935,13 +932,13 @@ contract CSMTopUpQueue is CSMCommon {
         assertEq(_getTopUpQueueLength(), 0);
     }
 
-    function test_topUp_emitsKeyAddedBalanceChanged() public {
+    function test_topUp_emitsKeyAllocatedBalanceChanged() public {
         createNodeOperator(1);
         csm.obtainDepositData(1, "");
 
         bytes memory key = csm.getSigningKeys(0, 0, 1);
         vm.expectEmit(address(csm));
-        emit IBaseModule.KeyAddedBalanceChanged(0, 0, 4 ether);
+        emit IBaseModule.KeyAllocatedBalanceChanged(0, 0, 4 ether);
 
         csm.allocateDeposits({
             maxDepositAmount: 5 ether,
@@ -1014,7 +1011,7 @@ contract CSMTopUpQueue is CSMCommon {
 
         assertEq(firstAllocations, UintArr(2 ether));
         assertEq(_getTopUpQueueLength(), 1);
-        assertEq(csm.getKeyAddedBalance(0, 0), 2 ether);
+        assertEq(csm.getKeyAllocatedBalance(0, 0), 2 ether);
 
         uint256[] memory secondAllocations = csm.allocateDeposits({
             maxDepositAmount: 2 ether,
@@ -1026,15 +1023,18 @@ contract CSMTopUpQueue is CSMCommon {
 
         assertEq(secondAllocations, UintArr(2 ether));
         assertEq(_getTopUpQueueLength(), 0);
-        assertEq(csm.getKeyAddedBalance(0, 0), 4 ether);
+        assertEq(csm.getKeyAllocatedBalance(0, 0), 4 ether);
     }
 
     function test_topUp_noEmitWhenKeyAtCap() public {
         createNodeOperator(1);
         csm.obtainDepositData(1, "");
 
-        uint256 cap = WithdrawnValidatorLib.MAX_EFFECTIVE_BALANCE - WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE;
-        setKeyAddedBalance(0, 0, cap);
+        setKeyConfirmedBalance(
+            0,
+            0,
+            WithdrawnValidatorLib.MAX_EFFECTIVE_BALANCE - WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE
+        );
 
         bytes memory key = csm.getSigningKeys(0, 0, 1);
         vm.recordLogs();
@@ -1047,9 +1047,8 @@ contract CSMTopUpQueue is CSMCommon {
         });
 
         Vm.Log[] memory entries = vm.getRecordedLogs();
-        bytes32 signature = keccak256("KeyAddedBalanceChanged(uint256,uint256,uint256)");
         for (uint256 i; i < entries.length; ++i) {
-            assertNotEq(entries[i].topics[0], signature);
+            assertNotEq(entries[i].topics[0], IBaseModule.KeyAllocatedBalanceChanged.selector);
         }
     }
 
@@ -1057,12 +1056,16 @@ contract CSMTopUpQueue is CSMCommon {
         createNodeOperator(1);
         csm.obtainDepositData(1, "");
 
-        uint256 cap = WithdrawnValidatorLib.MAX_EFFECTIVE_BALANCE - WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE;
-        setKeyAddedBalance(0, 0, cap - 2 ether);
+        setKeyConfirmedBalance(
+            0,
+            0,
+            WithdrawnValidatorLib.MAX_EFFECTIVE_BALANCE - WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE - 2 ether
+        );
 
         bytes memory key = csm.getSigningKeys(0, 0, 1);
         vm.expectEmit(address(csm));
-        emit IBaseModule.KeyAddedBalanceChanged(0, 0, cap);
+        // keyAllocatedBalance was 0 (setKeyConfirmedBalance only writes to keyConfirmedBalance), allocation adds 2 ether
+        emit IBaseModule.KeyAllocatedBalanceChanged(0, 0, 2 ether);
 
         uint256[] memory allocations = csm.allocateDeposits({
             maxDepositAmount: 5 ether,
@@ -1087,6 +1090,9 @@ contract CSMTopUpQueue is CSMCommon {
             operatorIds: UintArr(0),
             topUpLimits: UintArr(10 ether)
         });
+
+        // Confirm the top-up on-chain via a balance proof so penalty calculation uses the full balance.
+        setKeyConfirmedBalance(0, 0, 10 ether);
 
         vm.deal(address(this), 100 ether);
         accounting.depositETH{ value: 100 ether }(0);
@@ -2024,7 +2030,7 @@ contract CSMReportWithdrawnValidators is ModuleReportWithdrawnValidators, CSMCom
     }
 }
 
-contract CSMKeyAddedBalance is ModuleKeyAddedBalance, CSMCommon {
+contract CSMKeyAllocatedBalance is ModuleKeyAllocatedBalance, CSMCommon {
     function setUp() public override {
         topUpQueueLimit = 32;
 
@@ -2032,7 +2038,7 @@ contract CSMKeyAddedBalance is ModuleKeyAddedBalance, CSMCommon {
     }
 }
 
-contract CSMreportValidatorBalance is ModulereportValidatorBalance, CSMCommon {
+contract CSMReportValidatorBalance is ModuleReportValidatorBalance, CSMCommon {
     function setUp() public override {
         topUpQueueLimit = 32;
 

--- a/test/unit/CuratedModule.t.sol
+++ b/test/unit/CuratedModule.t.sol
@@ -1969,12 +1969,12 @@ contract CuratedCompensateGeneralDelayedPenalty is ModuleCompensateGeneralDelaye
 
 contract CuratedReportWithdrawnValidators is ModuleReportWithdrawnValidators, CuratedCommon {}
 
-contract CuratedKeyAddedBalance is ModuleKeyAddedBalance, CuratedCommon {}
+contract CuratedKeyAllocatedBalance is ModuleKeyAllocatedBalance, CuratedCommon {}
 
-contract CuratedreportValidatorBalance is ModulereportValidatorBalance, CuratedCommon {}
+contract CuratedReportValidatorBalance is ModuleReportValidatorBalance, CuratedCommon {}
 
-contract CuratedTopUpKeyAddedBalance is CuratedCommon {
-    function test_topUp_emitsKeyAddedBalanceChanged() public {
+contract CuratedTopUpKeyAllocatedBalance is CuratedCommon {
+    function test_topUp_emitsKeyAllocatedBalanceChanged() public {
         createNodeOperator(1);
         cm.obtainDepositData(1, "");
 
@@ -1982,7 +1982,7 @@ contract CuratedTopUpKeyAddedBalance is CuratedCommon {
         bytes[] memory pubkeys = BytesArr(key);
 
         vm.expectEmit(address(cm));
-        emit IBaseModule.KeyAddedBalanceChanged(0, 0, 4 ether);
+        emit IBaseModule.KeyAllocatedBalanceChanged(0, 0, 4 ether);
 
         cm.allocateDeposits({
             maxDepositAmount: 5 ether,
@@ -1997,8 +1997,11 @@ contract CuratedTopUpKeyAddedBalance is CuratedCommon {
         createNodeOperator(1);
         cm.obtainDepositData(1, "");
 
-        uint256 cap = WithdrawnValidatorLib.MAX_EFFECTIVE_BALANCE - WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE;
-        setKeyAddedBalance(0, 0, cap);
+        setKeyConfirmedBalance(
+            0,
+            0,
+            WithdrawnValidatorLib.MAX_EFFECTIVE_BALANCE - WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE
+        );
 
         bytes memory key = cm.getSigningKeys(0, 0, 1);
         bytes[] memory pubkeys = BytesArr(key);
@@ -2013,9 +2016,8 @@ contract CuratedTopUpKeyAddedBalance is CuratedCommon {
         });
 
         Vm.Log[] memory entries = vm.getRecordedLogs();
-        bytes32 signature = keccak256("KeyAddedBalanceChanged(uint256,uint256,uint256)");
         for (uint256 i; i < entries.length; ++i) {
-            assertNotEq(entries[i].topics[0], signature);
+            assertNotEq(entries[i].topics[0], IBaseModule.KeyAllocatedBalanceChanged.selector);
         }
     }
 }

--- a/test/unit/CuratedModule.t.sol
+++ b/test/unit/CuratedModule.t.sol
@@ -1971,7 +1971,27 @@ contract CuratedReportWithdrawnValidators is ModuleReportWithdrawnValidators, Cu
 
 contract CuratedKeyAllocatedBalance is ModuleKeyAllocatedBalance, CuratedCommon {}
 
-contract CuratedReportValidatorBalance is ModuleReportValidatorBalance, CuratedCommon {}
+contract CuratedReportValidatorBalance is ModuleReportValidatorBalance, CuratedCommon {
+    function test_reportValidatorBalance_doesNotDecreaseKeyAllocatedBalance() public {
+        uint256 noId = createNodeOperator();
+        cm.obtainDepositData(1, "");
+
+        // Allocate 20 ether via top-up, setting keyAllocatedBalance to 20 ether.
+        bytes memory key = cm.getSigningKeys(noId, 0, 1);
+        cm.allocateDeposits({
+            maxDepositAmount: 20 ether,
+            pubkeys: BytesArr(key),
+            keyIndices: UintArr(0),
+            operatorIds: UintArr(noId),
+            topUpLimits: UintArr(20 ether)
+        });
+        assertEq(cm.getKeyAllocatedBalance(noId, 0), 20 ether);
+
+        // Confirmed balance below allocated — keyAllocatedBalance must not decrease.
+        cm.reportValidatorBalance(noId, 0, WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE + 10 ether);
+        assertEq(cm.getKeyAllocatedBalance(noId, 0), 20 ether, "keyAllocatedBalance must not decrease");
+    }
+}
 
 contract CuratedTopUpKeyAllocatedBalance is CuratedCommon {
     function test_topUp_emitsKeyAllocatedBalanceChanged() public {

--- a/test/unit/ModuleAbstract/KeyBalances.t.sol
+++ b/test/unit/ModuleAbstract/KeyBalances.t.sol
@@ -91,12 +91,14 @@ abstract contract ModuleReportValidatorBalance is ModuleFixtures {
         );
     }
 
-    function test_reportValidatorBalance_doesNotUpdateKeyAllocatedBalance() public {
+    function test_reportValidatorBalance_updatesKeyAllocatedBalance() public {
         uint256 noId = createNodeOperator();
         module.obtainDepositData(1, "");
 
+        vm.expectEmit(address(module));
+        emit IBaseModule.KeyAllocatedBalanceChanged(noId, 0, 10 ether);
         module.reportValidatorBalance(noId, 0, WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE + 10 ether);
-        assertEq(module.getKeyAllocatedBalance(noId, 0), 0, "keyAllocatedBalance must not change on balance report");
+        assertEq(module.getKeyAllocatedBalance(noId, 0), 10 ether);
     }
 
     function test_reportValidatorBalance_revertWhen_confirmedBalanceIsZero() public assertInvariants {

--- a/test/unit/ModuleAbstract/KeyBalances.t.sol
+++ b/test/unit/ModuleAbstract/KeyBalances.t.sol
@@ -8,24 +8,32 @@ import { WithdrawnValidatorLib } from "src/lib/WithdrawnValidatorLib.sol";
 
 import { ModuleFixtures } from "./_Base.t.sol";
 
-abstract contract ModuleKeyAddedBalance is ModuleFixtures {
-    function test_getKeyAddedBalance_defaultZero() public {
+abstract contract ModuleKeyAllocatedBalance is ModuleFixtures {
+    function test_getKeyAllocatedBalance_defaultZero() public {
         uint256 noId = createNodeOperator();
         module.obtainDepositData(1, "");
 
-        assertEq(module.getKeyAddedBalance(noId, 0), 0);
+        assertEq(module.getKeyAllocatedBalance(noId, 0), 0);
     }
 
-    function test_getKeyAddedBalance_afterSet() public {
+    function test_getKeyConfirmedBalance_zeroOnDeposit() public {
         uint256 noId = createNodeOperator();
         module.obtainDepositData(1, "");
 
-        setKeyAddedBalance(noId, 0, 3 ether);
-        assertEq(module.getKeyAddedBalance(noId, 0), 3 ether);
+        assertEq(module.getKeyConfirmedBalance(noId, 0), 0);
+    }
+
+    function test_getKeyConfirmedBalance_afterReport() public {
+        uint256 noId = createNodeOperator();
+        module.obtainDepositData(1, "");
+
+        uint256 balanceWei = WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE + 3 ether;
+        module.reportValidatorBalance(noId, 0, balanceWei);
+        assertEq(module.getKeyConfirmedBalance(noId, 0), 3 ether);
     }
 }
 
-abstract contract ModulereportValidatorBalance is ModuleFixtures {
+abstract contract ModuleReportValidatorBalance is ModuleFixtures {
     function test_reportValidatorBalance_happyPath() public assertInvariants {
         uint256 noId = createNodeOperator();
         module.obtainDepositData(1, "");
@@ -33,31 +41,35 @@ abstract contract ModulereportValidatorBalance is ModuleFixtures {
         uint256 balanceWei = WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE + 10 ether;
 
         vm.expectEmit(address(module));
-        emit IBaseModule.KeyAddedBalanceChanged(noId, 0, 10 ether);
+        emit IBaseModule.KeyConfirmedBalanceChanged(noId, 0, 10 ether);
         module.reportValidatorBalance(noId, 0, balanceWei);
 
-        assertEq(module.getKeyAddedBalance(noId, 0), 10 ether);
+        assertEq(module.getKeyConfirmedBalance(noId, 0), 10 ether);
     }
 
     function test_reportValidatorBalance_increasesWhenHigher() public assertInvariants {
         uint256 noId = createNodeOperator();
         module.obtainDepositData(1, "");
 
-        module.reportValidatorBalance(noId, 0, WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE + 5 ether);
-        assertEq(module.getKeyAddedBalance(noId, 0), 5 ether);
+        uint256 firstBalance = WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE + 5 ether;
+        uint256 secondBalance = WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE + 10 ether;
+
+        module.reportValidatorBalance(noId, 0, firstBalance);
+        assertEq(module.getKeyConfirmedBalance(noId, 0), 5 ether);
 
         vm.expectEmit(address(module));
-        emit IBaseModule.KeyAddedBalanceChanged(noId, 0, 10 ether);
-        module.reportValidatorBalance(noId, 0, WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE + 10 ether);
-        assertEq(module.getKeyAddedBalance(noId, 0), 10 ether);
+        emit IBaseModule.KeyConfirmedBalanceChanged(noId, 0, 10 ether);
+        module.reportValidatorBalance(noId, 0, secondBalance);
+        assertEq(module.getKeyConfirmedBalance(noId, 0), 10 ether);
     }
 
     function test_reportValidatorBalance_doesNotDecrease() public assertInvariants {
         uint256 noId = createNodeOperator();
         module.obtainDepositData(1, "");
 
-        module.reportValidatorBalance(noId, 0, WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE + 10 ether);
-        assertEq(module.getKeyAddedBalance(noId, 0), 10 ether);
+        uint256 balanceWei = WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE + 10 ether;
+        module.reportValidatorBalance(noId, 0, balanceWei);
+        assertEq(module.getKeyConfirmedBalance(noId, 0), 10 ether);
 
         // Lower value — should revert
         vm.expectRevert(IBaseModule.UnreportableBalance.selector);
@@ -65,24 +77,40 @@ abstract contract ModulereportValidatorBalance is ModuleFixtures {
 
         // Equal value — should revert
         vm.expectRevert(IBaseModule.UnreportableBalance.selector);
-        module.reportValidatorBalance(noId, 0, WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE + 10 ether);
+        module.reportValidatorBalance(noId, 0, balanceWei);
     }
 
     function test_reportValidatorBalance_capsAtMax() public assertInvariants {
         uint256 noId = createNodeOperator();
         module.obtainDepositData(1, "");
 
-        uint256 cap = WithdrawnValidatorLib.MAX_EFFECTIVE_BALANCE - WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE;
         module.reportValidatorBalance(noId, 0, WithdrawnValidatorLib.MAX_EFFECTIVE_BALANCE + 100 ether);
-        assertEq(module.getKeyAddedBalance(noId, 0), cap);
+        assertEq(
+            module.getKeyConfirmedBalance(noId, 0),
+            WithdrawnValidatorLib.MAX_EFFECTIVE_BALANCE - WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE
+        );
+    }
+
+    function test_reportValidatorBalance_doesNotUpdateKeyAllocatedBalance() public {
+        uint256 noId = createNodeOperator();
+        module.obtainDepositData(1, "");
+
+        module.reportValidatorBalance(noId, 0, WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE + 10 ether);
+        assertEq(module.getKeyAllocatedBalance(noId, 0), 0, "keyAllocatedBalance must not change on balance report");
+    }
+
+    function test_reportValidatorBalance_revertWhen_confirmedBalanceIsZero() public assertInvariants {
+        uint256 noId = createNodeOperator();
+        module.obtainDepositData(1, "");
+
+        // Reporting MIN_ACTIVATION_BALANCE results in zero added balance, which is <= stored zero.
+        vm.expectRevert(IBaseModule.UnreportableBalance.selector);
+        module.reportValidatorBalance(noId, 0, WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE);
     }
 
     function test_reportValidatorBalance_revertWhen_belowMinActivation() public assertInvariants {
         uint256 noId = createNodeOperator();
         module.obtainDepositData(1, "");
-
-        vm.expectRevert(IBaseModule.UnreportableBalance.selector);
-        module.reportValidatorBalance(noId, 0, WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE);
 
         vm.expectRevert(IBaseModule.UnreportableBalance.selector);
         module.reportValidatorBalance(noId, 0, WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE - 1 ether);

--- a/test/unit/ModuleAbstract/ModuleAbstract.t.sol
+++ b/test/unit/ModuleAbstract/ModuleAbstract.t.sol
@@ -18,6 +18,6 @@ import "./PenaltiesGeneral.t.sol";
 // forge-lint: disable-next-line(unaliased-plain-import)
 import "./PenaltiesWithdrawn.t.sol";
 // forge-lint: disable-next-line(unaliased-plain-import)
-import "./KeyAddedBalance.t.sol";
+import "./KeyBalances.t.sol";
 // forge-lint: disable-next-line(unaliased-plain-import)
 import "./ExitDelay.t.sol";

--- a/test/unit/ModuleAbstract/PenaltiesWithdrawn.t.sol
+++ b/test/unit/ModuleAbstract/PenaltiesWithdrawn.t.sol
@@ -113,7 +113,7 @@ abstract contract ModuleReportWithdrawnValidators is ModuleFixtures {
         assertEq(no.targetLimitMode, 0);
     }
 
-    function test_reportRegularWithdrawnValidators_exitBalanceBelowKeyAddedBalance() public assertInvariants {
+    function test_reportRegularWithdrawnValidators_exitBalanceBelowKeyBalance() public assertInvariants {
         uint256 keyIndex = 0;
         uint256 noId = createNodeOperator();
         module.obtainDepositData(1, "");
@@ -1205,11 +1205,13 @@ abstract contract ModuleReportWithdrawnValidators is ModuleFixtures {
         module.reportValidatorSlashing(noId, 0);
     }
 
-    function test_keyAddedBalance_chargesOnWithdraw() public assertInvariants {
+    function test_keyConfirmedBalance_chargesOnWithdraw() public assertInvariants {
         uint256 noId = createNodeOperator();
         module.obtainDepositData(1, "");
 
-        setKeyAddedBalance(noId, 0, 10 ether);
+        uint256 balanceShortage = 10 ether;
+
+        setKeyConfirmedBalance(noId, 0, balanceShortage);
 
         vm.deal(address(this), 100 ether);
         accounting.depositETH{ value: 100 ether }(noId);
@@ -1225,20 +1227,19 @@ abstract contract ModuleReportWithdrawnValidators is ModuleFixtures {
         });
 
         module.reportRegularWithdrawnValidators(validatorInfos);
-        assertEq(accounting.getBond(noId), bondBefore - 10 ether);
+        assertEq(accounting.getBond(noId), bondBefore - balanceShortage);
     }
 
-    function test_keyAddedBalance_PenalizeWhenSlashed() public assertInvariants {
+    function test_keyConfirmedBalance_PenalizeWhenSlashed() public assertInvariants {
         uint256 noId = createNodeOperator();
 
         module.obtainDepositData(1, "");
         module.reportValidatorSlashing(noId, 0);
 
-        uint256 addedBalance = 10 ether;
-
-        setKeyAddedBalance(noId, 0, addedBalance);
-
+        uint256 topUp = 10 ether;
         uint256 balanceShortage = 1 ether;
+
+        setKeyConfirmedBalance(noId, 0, topUp);
 
         vm.deal(address(this), 100 ether);
         accounting.depositETH{ value: 100 ether }(noId);
@@ -1248,12 +1249,12 @@ abstract contract ModuleReportWithdrawnValidators is ModuleFixtures {
         validatorInfos[0] = WithdrawnValidatorInfo({
             nodeOperatorId: noId,
             keyIndex: 0,
-            exitBalance: WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE + addedBalance - balanceShortage,
+            exitBalance: WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE + topUp - balanceShortage,
             slashingPenalty: 0,
             isSlashed: true
         });
 
         module.reportSlashedWithdrawnValidators(validatorInfos);
-        assertApproxEqAbs(accounting.getBond(noId), bondBefore - balanceShortage, 1 wei);
+        assertEq(accounting.getBond(noId), bondBefore - balanceShortage);
     }
 }

--- a/test/unit/ModuleAbstract/_Base.t.sol
+++ b/test/unit/ModuleAbstract/_Base.t.sol
@@ -188,20 +188,24 @@ abstract contract ModuleFixtures is Test, Fixtures, Utilities, InvariantAsserts 
         module.reportRegularWithdrawnValidators(withdrawalsInfo);
     }
 
-    function setKeyAddedBalance(uint256 noId, uint256 keyIndex, uint256 amount) internal {
-        // NOTE: so far, this is the only available way to change key added balance value.
-        uint256 current = module.getKeyAddedBalance(noId, keyIndex);
-        if (amount == current) return;
+    /// @dev Sets keyConfirmedBalance via reportValidatorBalance.
+    function setKeyConfirmedBalance(uint256 noId, uint256 keyIndex, uint256 confirmedBalance) internal {
+        uint256 current = module.getKeyConfirmedBalance(noId, keyIndex);
+        if (confirmedBalance == current) return;
 
-        assertGt(amount, current, "key added balance cannot be decreased");
+        assertGt(confirmedBalance, current, "key confirmed balance cannot be decreased");
 
         module.reportValidatorBalance({
             nodeOperatorId: noId,
             keyIndex: keyIndex,
-            currentBalanceWei: amount + WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE
+            currentBalanceWei: confirmedBalance + WithdrawnValidatorLib.MIN_ACTIVATION_BALANCE
         });
 
-        assertEq(module.getKeyAddedBalance(noId, keyIndex), amount, "key added balance must match target");
+        assertEq(
+            module.getKeyConfirmedBalance(noId, keyIndex),
+            confirmedBalance,
+            "key confirmed balance must match target"
+        );
     }
 
     function getNodeOperatorSummary(uint256 noId) public view returns (NodeOperatorSummary memory) {

--- a/test/unit/Verifier.t.sol
+++ b/test/unit/Verifier.t.sol
@@ -95,6 +95,7 @@ contract VerifierTestConstructor is VerifierTestBase {
             firstSupportedSlot: firstSupportedSlot,
             pivotSlot: Slot.wrap(100_501),
             capellaSlot: Slot.wrap(42),
+            minWithdrawalRatio: 9000,
             admin: admin
         });
 
@@ -114,6 +115,7 @@ contract VerifierTestConstructor is VerifierTestBase {
         assertEq(Slot.unwrap(verifier.FIRST_SUPPORTED_SLOT()), Slot.unwrap(firstSupportedSlot));
         assertEq(Slot.unwrap(verifier.PIVOT_SLOT()), Slot.unwrap(Slot.wrap(100_501)));
         assertEq(Slot.unwrap(verifier.CAPELLA_SLOT()), Slot.unwrap(Slot.wrap(42)));
+        assertEq(verifier.MIN_WITHDRAWAL_RATIO(), 9000);
     }
 
     function test_constructor_RevertWhen_InvalidChainConfig_SlotsPerEpoch() public {
@@ -138,6 +140,7 @@ contract VerifierTestConstructor is VerifierTestBase {
             firstSupportedSlot: firstSupportedSlot, // Any value less than the slots from the fixtures.
             pivotSlot: firstSupportedSlot,
             capellaSlot: firstSupportedSlot,
+            minWithdrawalRatio: 9000,
             admin: admin
         });
     }
@@ -164,6 +167,7 @@ contract VerifierTestConstructor is VerifierTestBase {
             firstSupportedSlot: firstSupportedSlot, // Any value less than the slots from the fixtures.
             pivotSlot: firstSupportedSlot,
             capellaSlot: firstSupportedSlot,
+            minWithdrawalRatio: 9000,
             admin: admin
         });
     }
@@ -190,6 +194,7 @@ contract VerifierTestConstructor is VerifierTestBase {
             firstSupportedSlot: firstSupportedSlot,
             pivotSlot: firstSupportedSlot.dec(),
             capellaSlot: firstSupportedSlot,
+            minWithdrawalRatio: 9000,
             admin: admin
         });
     }
@@ -216,6 +221,7 @@ contract VerifierTestConstructor is VerifierTestBase {
             firstSupportedSlot: firstSupportedSlot,
             pivotSlot: firstSupportedSlot,
             capellaSlot: firstSupportedSlot.inc(),
+            minWithdrawalRatio: 9000,
             admin: admin
         });
     }
@@ -242,6 +248,7 @@ contract VerifierTestConstructor is VerifierTestBase {
             firstSupportedSlot: firstSupportedSlot, // Any value less than the slots from the fixtures.
             pivotSlot: firstSupportedSlot,
             capellaSlot: firstSupportedSlot,
+            minWithdrawalRatio: 9000,
             admin: admin
         });
     }
@@ -268,6 +275,7 @@ contract VerifierTestConstructor is VerifierTestBase {
             firstSupportedSlot: firstSupportedSlot, // Any value less than the slots from the fixtures.
             pivotSlot: firstSupportedSlot,
             capellaSlot: firstSupportedSlot,
+            minWithdrawalRatio: 9000,
             admin: admin
         });
     }
@@ -294,7 +302,62 @@ contract VerifierTestConstructor is VerifierTestBase {
             firstSupportedSlot: firstSupportedSlot, // Any value less than the slots from the fixtures.
             pivotSlot: firstSupportedSlot,
             capellaSlot: firstSupportedSlot,
+            minWithdrawalRatio: 9000,
             admin: address(0)
+        });
+    }
+
+    function test_constructor_RevertWhen_InvalidMinWithdrawalRatio_Zero() public {
+        vm.expectRevert(IVerifier.InvalidMinWithdrawalRatio.selector);
+        verifier = new Verifier({
+            withdrawalAddress: nextAddress(),
+            module: address(module),
+            slotsPerEpoch: 32,
+            slotsPerHistoricalRoot: 8192,
+            gindices: IVerifier.GIndices({
+                gIFirstWithdrawalPrev: pack(0xe1c0, 4),
+                gIFirstWithdrawalCurr: pack(0xe1c0, 4),
+                gIFirstValidatorPrev: pack(0x560000000000, 40),
+                gIFirstValidatorCurr: pack(0x560000000000, 40),
+                gIFirstHistoricalSummaryPrev: pack(0x3b, 0),
+                gIFirstHistoricalSummaryCurr: pack(0x3b, 0),
+                gIFirstBlockRootInSummaryPrev: pack(0x4000, 13),
+                gIFirstBlockRootInSummaryCurr: pack(0x4000, 13),
+                gIFirstBalanceNodePrev: pack(0x260000000000, 40),
+                gIFirstBalanceNodeCurr: pack(0x260000000000, 40)
+            }),
+            firstSupportedSlot: firstSupportedSlot,
+            pivotSlot: firstSupportedSlot,
+            capellaSlot: firstSupportedSlot,
+            minWithdrawalRatio: 0,
+            admin: admin
+        });
+    }
+
+    function test_constructor_RevertWhen_InvalidMinWithdrawalRatio_AboveMax() public {
+        vm.expectRevert(IVerifier.InvalidMinWithdrawalRatio.selector);
+        verifier = new Verifier({
+            withdrawalAddress: nextAddress(),
+            module: address(module),
+            slotsPerEpoch: 32,
+            slotsPerHistoricalRoot: 8192,
+            gindices: IVerifier.GIndices({
+                gIFirstWithdrawalPrev: pack(0xe1c0, 4),
+                gIFirstWithdrawalCurr: pack(0xe1c0, 4),
+                gIFirstValidatorPrev: pack(0x560000000000, 40),
+                gIFirstValidatorCurr: pack(0x560000000000, 40),
+                gIFirstHistoricalSummaryPrev: pack(0x3b, 0),
+                gIFirstHistoricalSummaryCurr: pack(0x3b, 0),
+                gIFirstBlockRootInSummaryPrev: pack(0x4000, 13),
+                gIFirstBlockRootInSummaryCurr: pack(0x4000, 13),
+                gIFirstBalanceNodePrev: pack(0x260000000000, 40),
+                gIFirstBalanceNodeCurr: pack(0x260000000000, 40)
+            }),
+            firstSupportedSlot: firstSupportedSlot,
+            pivotSlot: firstSupportedSlot,
+            capellaSlot: firstSupportedSlot,
+            minWithdrawalRatio: 10_001,
+            admin: admin
         });
     }
 }
@@ -336,6 +399,7 @@ contract VerifierWithdrawalTest is VerifierTestBase {
             firstSupportedSlot: fixture.data.withdrawalBlock.header.slot.dec(),
             pivotSlot: fixture.data.withdrawalBlock.header.slot.dec(),
             capellaSlot: Slot.wrap(0),
+            minWithdrawalRatio: 9000,
             admin: admin
         });
 
@@ -448,12 +512,12 @@ contract VerifierWithdrawalTest is VerifierTestBase {
     }
 
     function test_processWithdrawalProof_HappyPath_WithAddedBalance() public {
-        // Use a small added balance so the threshold stays below the fixture's 32 ETH withdrawal.
-        // threshold = (32 + 3) * 9000 / 10000 = 31.5 ETH < 32 ETH
+        // Use a small verified added balance so the threshold stays below the fixture's 32 ETH withdrawal.
+        // absolute = 3 ether + 32 ether = 35 ether; threshold = 35 * 9000 / 10000 = 31.5 ETH < 32 ETH
         vm.mockCall(
             address(module),
             abi.encodeWithSelector(
-                IBaseModule.getKeyAddedBalance.selector,
+                IBaseModule.getKeyConfirmedBalance.selector,
                 fixture.data.validator.nodeOperatorId,
                 fixture.data.validator.keyIndex
             ),
@@ -478,16 +542,16 @@ contract VerifierWithdrawalTest is VerifierTestBase {
     }
 
     function test_processWithdrawalProof_HappyPath_MaxEffectiveBalance() public {
-        // threshold = (32 + 2016) * 9000 / 10000 = 1843.2 ETH = 1_843_200_000_000 gwei
+        // threshold = 2048 * 9000 / 10000 = 1843.2 ETH = 1_843_200_000_000 gwei
         // Reload fixture with the minimal expected withdrawal amount.
         _loadFixtureWithAmount({ offset: 11, amountGwei: 1_843_200_000_000 });
         _setMocks();
 
-        // Mock keyAddedBalance for a fully consolidated validator (2048 - 32 = 2016 ETH added).
+        // Mock keyConfirmedBalance for a fully consolidated validator (2048 - 32 = 2016 ETH added).
         vm.mockCall(
             address(module),
             abi.encodeWithSelector(
-                IBaseModule.getKeyAddedBalance.selector,
+                IBaseModule.getKeyConfirmedBalance.selector,
                 fixture.data.validator.nodeOperatorId,
                 fixture.data.validator.keyIndex
             ),
@@ -523,14 +587,14 @@ contract VerifierWithdrawalTest is VerifierTestBase {
         vm.mockCall(
             address(module),
             abi.encodeWithSelector(
-                IBaseModule.getKeyAddedBalance.selector,
+                IBaseModule.getKeyConfirmedBalance.selector,
                 fixture.data.validator.nodeOperatorId,
                 fixture.data.validator.keyIndex
             ),
             abi.encode(100 ether)
         );
 
-        // (32 + 100) ether in gwei * 9000 / 10000 = 118_800_000_000 gwei = 118.8 ether
+        // absolute = 100 + 32 = 132 ether; 132 ether in gwei * 9000 / 10000 = 118_800_000_000 gwei = 118.8 ether
         fixture.data.withdrawal.object.amount = 118_800_000_000 - 1;
 
         vm.expectRevert(IVerifier.PartialWithdrawal.selector);
@@ -538,18 +602,18 @@ contract VerifierWithdrawalTest is VerifierTestBase {
     }
 
     function test_processWithdrawalProof_RevertWhen_PartialWithdrawal_MaxEffectiveBalance() public {
-        // Mock keyAddedBalance for a fully consolidated validator (2048 - 32 = 2016 ETH added).
+        // Mock keyConfirmedBalance for a fully consolidated validator (2048 - 32 = 2016 ETH added).
         vm.mockCall(
             address(module),
             abi.encodeWithSelector(
-                IBaseModule.getKeyAddedBalance.selector,
+                IBaseModule.getKeyConfirmedBalance.selector,
                 fixture.data.validator.nodeOperatorId,
                 fixture.data.validator.keyIndex
             ),
             abi.encode(2016 ether)
         );
 
-        // threshold = (32 + 2016) * 9000 / 10000 = 1843.2 ETH = 1_843_200_000_000 gwei
+        // threshold = 2048 * 9000 / 10000 = 1843.2 ETH = 1_843_200_000_000 gwei
         // Reverts before SSZ proof check, so modifying amount is safe.
         fixture.data.withdrawal.object.amount = 1_843_200_000_000 - 1;
 
@@ -578,6 +642,7 @@ contract VerifierWithdrawalTest is VerifierTestBase {
             firstSupportedSlot: fixture.data.withdrawalBlock.header.slot.dec(),
             pivotSlot: fixture.data.withdrawalBlock.header.slot.inc(),
             capellaSlot: Slot.wrap(0),
+            minWithdrawalRatio: 9000,
             admin: admin
         });
 
@@ -605,6 +670,7 @@ contract VerifierWithdrawalTest is VerifierTestBase {
             firstSupportedSlot: fixture.data.withdrawalBlock.header.slot.dec(),
             pivotSlot: fixture.data.withdrawalBlock.header.slot,
             capellaSlot: Slot.wrap(0),
+            minWithdrawalRatio: 9000,
             admin: admin
         });
 
@@ -632,6 +698,7 @@ contract VerifierWithdrawalTest is VerifierTestBase {
             firstSupportedSlot: fixture.data.withdrawalBlock.header.slot.dec(),
             pivotSlot: fixture.data.withdrawalBlock.header.slot.dec(),
             capellaSlot: Slot.wrap(0),
+            minWithdrawalRatio: 9000,
             admin: admin
         });
 
@@ -654,11 +721,11 @@ contract VerifierWithdrawalTest is VerifierTestBase {
         vm.mockCall(
             address(module),
             abi.encodeWithSelector(
-                IBaseModule.getKeyAddedBalance.selector,
+                IBaseModule.getKeyConfirmedBalance.selector,
                 fixture.data.validator.nodeOperatorId,
                 fixture.data.validator.keyIndex
             ),
-            abi.encode(uint256(0))
+            abi.encode(0)
         );
 
         vm.mockCall(address(module), abi.encodeWithSelector(IBaseModule.reportRegularWithdrawnValidators.selector), "");
@@ -726,6 +793,7 @@ contract VerifierSlashingTest is VerifierTestBase {
             firstSupportedSlot: Slot.wrap(8192),
             pivotSlot: Slot.wrap(8192),
             capellaSlot: Slot.wrap(0),
+            minWithdrawalRatio: 9000,
             admin: admin
         });
 
@@ -855,6 +923,7 @@ contract VerifierPauseTest is VerifierTestBase {
             firstSupportedSlot: Slot.wrap(100_500), // Any value less than the slots from the fixtures.
             pivotSlot: Slot.wrap(100_500),
             capellaSlot: Slot.wrap(0),
+            minWithdrawalRatio: 9000,
             admin: admin
         });
 
@@ -947,6 +1016,7 @@ contract VerifierTestable is Verifier {
         Slot firstSupportedSlot,
         Slot pivotSlot,
         Slot capellaSlot,
+        uint256 minWithdrawalRatio,
         address admin
     )
         Verifier(
@@ -958,6 +1028,7 @@ contract VerifierTestable is Verifier {
             firstSupportedSlot,
             pivotSlot,
             capellaSlot,
+            minWithdrawalRatio,
             admin
         )
     {}
@@ -1030,6 +1101,7 @@ contract VerifierGIndexTest is Test, Utilities {
             firstSupportedSlot: Slot.wrap(8192),
             pivotSlot: Slot.wrap(8192 * 13),
             capellaSlot: Slot.wrap(8192),
+            minWithdrawalRatio: 9000,
             admin: admin
         });
 
@@ -1324,6 +1396,7 @@ contract VerifierGIndexCapellaZeroTest is Test, Utilities {
             firstSupportedSlot: Slot.wrap(0),
             pivotSlot: Slot.wrap(8192 * 13),
             capellaSlot: Slot.wrap(0),
+            minWithdrawalRatio: 9000,
             admin: admin
         });
     }
@@ -1450,6 +1523,7 @@ contract VerifierValidatorBalanceTest is Test, Utilities {
             firstSupportedSlot: Slot.wrap(8192),
             pivotSlot: Slot.wrap(8192 * 13),
             capellaSlot: Slot.wrap(8192),
+            minWithdrawalRatio: 9000,
             admin: admin
         });
     }
@@ -1642,6 +1716,7 @@ contract VerifierBalanceProofTest is VerifierTestBase {
             firstSupportedSlot: fixture.data.recentBlock.header.slot.dec(),
             pivotSlot: fixture.data.recentBlock.header.slot.dec(),
             capellaSlot: Slot.wrap(0),
+            minWithdrawalRatio: 9000,
             admin: admin
         });
 
@@ -1779,6 +1854,7 @@ contract VerifierParentBlockRootTest is Test, Utilities {
             firstSupportedSlot: Slot.wrap(8192),
             pivotSlot: Slot.wrap(8192 * 13),
             capellaSlot: Slot.wrap(8192),
+            minWithdrawalRatio: 9000,
             admin: admin
         });
     }

--- a/test/unit/Verifier.t.sol
+++ b/test/unit/Verifier.t.sol
@@ -1779,6 +1779,13 @@ contract VerifierBalanceProofTest is VerifierTestBase {
         verifier.processBalanceProof(fixture.data);
     }
 
+    function test_processBalanceProof_RevertWhen_ValidatorIsWithdrawable() public {
+        fixture.data.validator.object.withdrawableEpoch = uint64(fixture.data.recentBlock.header.slot.unwrap() / 32);
+
+        vm.expectRevert(IVerifier.ValidatorIsWithdrawable.selector);
+        verifier.processBalanceProof(fixture.data);
+    }
+
     function test_processBalanceProof_RevertWhen_Paused() public {
         vm.prank(admin);
         verifier.pauseFor(1 days);

--- a/test/unit/VerifierHistorical.t.sol
+++ b/test/unit/VerifierHistorical.t.sol
@@ -74,11 +74,11 @@ contract VerifierHistoricalBase is Test, Utilities {
         vm.mockCall(
             address(module),
             abi.encodeWithSelector(
-                IBaseModule.getKeyAddedBalance.selector,
+                IBaseModule.getKeyConfirmedBalance.selector,
                 fixture.data.validator.nodeOperatorId,
                 fixture.data.validator.keyIndex
             ),
-            abi.encode(uint256(0))
+            abi.encode(0)
         );
 
         vm.mockCall(address(module), abi.encodeWithSelector(IBaseModule.reportRegularWithdrawnValidators.selector), "");
@@ -122,6 +122,7 @@ contract VerifierHistoricalTest is VerifierHistoricalBase {
             firstSupportedSlot: fixture.data.withdrawalBlock.header.slot,
             pivotSlot: fixture.data.withdrawalBlock.header.slot,
             capellaSlot: Slot.wrap(0),
+            minWithdrawalRatio: 9000,
             admin: nextAddress("ADMIN")
         });
 
@@ -282,6 +283,7 @@ contract VerifierCrossForkHistoricalBalanceTest is Test, Utilities {
             firstSupportedSlot: fixture.data.historicalBlock.header.slot,
             pivotSlot: fixture.data.recentBlock.header.slot.dec(),
             capellaSlot: Slot.wrap(0),
+            minWithdrawalRatio: 9000,
             admin: admin
         });
 
@@ -366,6 +368,7 @@ contract VerifierCrossForkHistoricalBalanceAtPivotSlotTest is Test, Utilities {
             firstSupportedSlot: fixture.data.historicalBlock.header.slot,
             pivotSlot: fixture.data.recentBlock.header.slot,
             capellaSlot: Slot.wrap(0),
+            minWithdrawalRatio: 9000,
             admin: admin
         });
 
@@ -450,6 +453,7 @@ contract VerifierHistoricalBalanceTest is Test, Utilities {
             firstSupportedSlot: fixture.data.historicalBlock.header.slot,
             pivotSlot: fixture.data.historicalBlock.header.slot,
             capellaSlot: Slot.wrap(0),
+            minWithdrawalRatio: 9000,
             admin: admin
         });
 
@@ -585,6 +589,7 @@ contract VerifierCrossForkHistoricalTest is VerifierHistoricalBase {
             firstSupportedSlot: fixture.data.withdrawalBlock.header.slot,
             pivotSlot: fixture.data.recentBlock.header.slot.dec(),
             capellaSlot: Slot.wrap(0),
+            minWithdrawalRatio: 9000,
             admin: nextAddress("ADMIN")
         });
         _setMocks();
@@ -634,6 +639,7 @@ contract VerifierCrossForkHistoricalAtPivotSlotTest is VerifierHistoricalBase {
             firstSupportedSlot: fixture.data.withdrawalBlock.header.slot,
             pivotSlot: fixture.data.recentBlock.header.slot,
             capellaSlot: Slot.wrap(0),
+            minWithdrawalRatio: 9000,
             admin: nextAddress("ADMIN")
         });
         _setMocks();

--- a/test/unit/VerifierHistorical.t.sol
+++ b/test/unit/VerifierHistorical.t.sol
@@ -502,6 +502,15 @@ contract VerifierHistoricalBalanceTest is Test, Utilities {
         verifier.processHistoricalBalanceProof(fixture.data);
     }
 
+    function test_processHistoricalBalanceProof_RevertWhen_ValidatorIsWithdrawable() public {
+        fixture.data.validator.object.withdrawableEpoch = uint64(
+            fixture.data.historicalBlock.header.slot.unwrap() / 32
+        );
+
+        vm.expectRevert(IVerifier.ValidatorIsWithdrawable.selector);
+        verifier.processHistoricalBalanceProof(fixture.data);
+    }
+
     function test_processHistoricalBalanceProof_RevertWhen_InvalidHistoricalBlock() public {
         fixture.data.historicalBlock.header.parentRoot = someBytes32();
 


### PR DESCRIPTION
## Description

The PR primarily addresses an issue that can occur under the following circumstances:

  - the protocol sent a top-up to a validator,
  - the deposit queue is long enough, and
  - the validator exited and was withdrawn before the top-up was applied.

In that case, the system assumes the top-up should be included in the validator's withdrawal amount, even though it was never actually applied on the beacon chain. As a result, the observed withdrawal amount may fail the `MIN_WITHDRAWAL_RATIO` check. This can block processing of an otherwise valid withdrawal and prevent the node operator's bond from being unlocked.

The mitigation is as follows: we now maintain two separate balance trackers. One tracks top-ups that the protocol sends to the CL, and the other tracks the actual balance observed on the beacon chain. The former is used for allocation correction, while  the latter is used for withdrawal processing.

## Checklist

- [x] Appropriate PR labels applied
- [x] Test coverage maintained (`just coverage`)
  - [ ] No need to add/update tests
  - [x] Tests are added/updated
- [x] Documentation maintained
  - [x] No need to update
  - [ ] Updated
