### PR TITLE
fix: scope zero-first interval check to reward share

### DIFF
--- a/src/ParametersRegistry.sol
+++ b/src/ParametersRegistry.sol
@@ -264,10 +264,10 @@ contract ParametersRegistry is IParametersRegistry, Initializable, AccessControl
         uint256 curveId,
         KeyNumberValueInterval[] calldata data
     ) external onlyRoleMemberOrCurveParametersRoleOrAdmin(MANAGE_REWARD_SHARE_ROLE) {
-        // NOTE: The shared interval validator enforces `data[0].value > 0`.
+        _validateKeyNumberValueIntervals(data);
         // Zero reward share for the first interval would allow rebate-only oracle reports (`distributed == 0 && rebate > 0`),
         // and those are rejected by FeeDistributor.
-        _validateKeyNumberValueIntervals(data);
+        if (data[0].value == 0) revert InvalidKeyNumberValueIntervals();
         KeyNumberValueInterval[] storage intervals = _rewardShareData[curveId];
         if (intervals.length > 0) delete _rewardShareData[curveId];
         for (uint256 i = 0; i < data.length; ++i) {
@@ -736,7 +736,7 @@ contract ParametersRegistry is IParametersRegistry, Initializable, AccessControl
     function _validateKeyNumberValueIntervals(KeyNumberValueInterval[] calldata intervals) private pure {
         if (intervals.length == 0) revert InvalidKeyNumberValueIntervals();
         if (intervals[0].minKeyNumber != 1) revert InvalidKeyNumberValueIntervals();
-        if (intervals[0].value == 0 || intervals[0].value > MAX_BP) revert InvalidKeyNumberValueIntervals();
+        if (intervals[0].value > MAX_BP) revert InvalidKeyNumberValueIntervals();
 
         for (uint256 i = 1; i < intervals.length; ++i) {
             unchecked {

--- a/test/unit/ParametersRegistry.t.sol
+++ b/test/unit/ParametersRegistry.t.sol
@@ -658,6 +658,26 @@ contract ParametersRegistryPerformanceLeewayDataTest is ParametersRegistryBaseTe
         parametersRegistry.setPerformanceLeewayData(curveId, data);
     }
 
+    function test_set_zeroFirstIntervalValue() public {
+        uint256 curveId = 1;
+        IParametersRegistry.KeyNumberValueInterval[] memory data = new IParametersRegistry.KeyNumberValueInterval[](2);
+        data[0] = IParametersRegistry.KeyNumberValueInterval(1, 0);
+        data[1] = IParametersRegistry.KeyNumberValueInterval(10, 8000);
+
+        vm.prank(admin);
+        parametersRegistry.setPerformanceLeewayData(curveId, data);
+
+        IParametersRegistry.KeyNumberValueInterval[] memory dataOut = parametersRegistry.getPerformanceLeewayData(
+            curveId
+        );
+
+        assertEq(dataOut.length, data.length);
+        for (uint256 i = 0; i < dataOut.length; ++i) {
+            assertEq(dataOut[i].minKeyNumber, data[i].minKeyNumber);
+            assertEq(dataOut[i].value, data[i].value);
+        }
+    }
+
     function test_set_RevertWhen_emptyIntervals() public {
         uint256 curveId = 1;
         IParametersRegistry.KeyNumberValueInterval[] memory data = new IParametersRegistry.KeyNumberValueInterval[](0);


### PR DESCRIPTION
## Description

- Limit the zero first-interval value check to `setRewardShareData`.
- Allow `setPerformanceLeewayData` to accept a zero first interval again.
- Add a regression test covering zero first-interval performance leeway data.

## Checklist

- [x] Appropriate PR labels applied
- [x] Test coverage maintained (`just coverage`)
  - [ ] No need to add/update tests
  - [x] Tests are added/updated
- [x] Documentation maintained
  - [x] No need to update
  - [ ] Updated
