### PR TITLE
fix: cap withdrawn and duplicate-key top-up limits per key

### DIFF
--- a/src/lib/NodeOperatorOps.sol
+++ b/src/lib/NodeOperatorOps.sol
@@ -15,10 +15,13 @@ import { ValidatorCountsReport } from "./ValidatorCountsReport.sol";
 import { ValidatorBalanceLimits } from "./ValidatorBalanceLimits.sol";
 import { KeyPointerLib } from "./KeyPointerLib.sol";
 import { StakeTracker } from "./StakeTracker.sol";
+import { TransientUintUintMap, TransientUintUintMapLib } from "./TransientUintUintMapLib.sol";
 import { SigningKeys } from "./SigningKeys.sol";
 
 /// @dev The library is used to reduce BaseModule bytecode size.
 library NodeOperatorOps {
+    using TransientUintUintMapLib for TransientUintUintMap;
+
     function createNodeOperator(
         mapping(uint256 => NodeOperator) storage nodeOperators,
         uint256 nodeOperatorId,
@@ -333,14 +336,24 @@ library NodeOperatorOps {
         uint256[] calldata operatorIds,
         uint256[] calldata keyIndices,
         uint256[] calldata topUpLimits
-    ) external view returns (uint256[] memory cappedTopUpLimits) {
+    ) external returns (uint256[] memory cappedTopUpLimits) {
         uint256 len = topUpLimits.length;
         cappedTopUpLimits = new uint256[](len);
         uint256 cap = _keyBalanceCap();
+        TransientUintUintMap reservedByKey = TransientUintUintMapLib.create();
         for (uint256 i; i < len; ++i) {
-            uint256 balance = $.keyAllocatedBalance[KeyPointerLib.keyPointer(operatorIds[i], keyIndices[i])];
+            uint256 pointer = KeyPointerLib.keyPointer(operatorIds[i], keyIndices[i]);
+            // Withdrawn keys must not receive new top-ups, but returning zero keeps CSM queue cleanup
+            // working for stale or rewound head items.
+            if ($.isValidatorWithdrawn[pointer]) continue;
+
+            // Share the remaining headroom across duplicate keys in the same batch so later entries
+            // cannot reserve the same per-key capacity twice.
+            uint256 balance = $.keyAllocatedBalance[pointer] + reservedByKey.get(pointer);
             uint256 remaining = balance > cap ? 0 : cap - balance;
-            cappedTopUpLimits[i] = Math.min(topUpLimits[i], remaining);
+            uint256 capped = Math.min(topUpLimits[i], remaining);
+            cappedTopUpLimits[i] = capped;
+            reservedByKey.add(pointer, capped);
         }
     }
 

--- a/test/unit/CSModule.t.sol
+++ b/test/unit/CSModule.t.sol
@@ -950,6 +950,50 @@ contract CSMTopUpQueue is CSMCommon {
         assertEq(_getTopUpQueueLength(), 0);
     }
 
+    function test_topUp_rewindedWithdrawnHeadKeyIsDequeuedWithoutAllocation() public {
+        createNodeOperator(2);
+        csm.obtainDepositData(2, "");
+
+        bytes memory packedPubkeys = csm.getSigningKeys(0, 0, 2);
+        bytes memory key0 = slice(packedPubkeys, 0, 48);
+        bytes memory key1 = slice(packedPubkeys, 48, 48);
+
+        csm.allocateDeposits({
+            maxDepositAmount: 2 ether,
+            pubkeys: BytesArr(key0),
+            keyIndices: UintArr(0),
+            operatorIds: UintArr(0),
+            topUpLimits: UintArr(2 ether)
+        });
+
+        WithdrawnValidatorInfo[] memory infos = new WithdrawnValidatorInfo[](1);
+        infos[0] = WithdrawnValidatorInfo({
+            nodeOperatorId: 0,
+            keyIndex: 0,
+            exitBalance: ValidatorBalanceLimits.MIN_ACTIVATION_BALANCE + 2 ether,
+            slashingPenalty: 0,
+            isSlashed: false
+        });
+        csm.reportRegularWithdrawnValidators(infos);
+
+        csm.rewindTopUpQueue(0);
+
+        uint256[] memory allocations = csm.allocateDeposits({
+            maxDepositAmount: 4 ether,
+            pubkeys: BytesArr(key0, key1),
+            keyIndices: UintArr(0, 1),
+            operatorIds: UintArr(0, 0),
+            topUpLimits: UintArr(4 ether, 4 ether)
+        });
+
+        assertEq(allocations, UintArr(0, 4 ether));
+        assertEq(csm.getKeyAllocatedBalance(0, 0), 2 ether);
+        assertEq(csm.getKeyAllocatedBalance(0, 1), 4 ether);
+        assertEq(module.getTotalModuleStake(), ValidatorBalanceLimits.MIN_ACTIVATION_BALANCE + 4 ether);
+        assertEq(module.getNodeOperatorBalance(0), ValidatorBalanceLimits.MIN_ACTIVATION_BALANCE + 4 ether);
+        assertEq(_getTopUpQueueLength(), 0);
+    }
+
     function test_topUp_emitsKeyAllocatedBalanceChanged() public {
         createNodeOperator(1);
         csm.obtainDepositData(1, "");

--- a/test/unit/CuratedModule.t.sol
+++ b/test/unit/CuratedModule.t.sol
@@ -1839,6 +1839,57 @@ contract CuratedTopUpKeyAllocatedBalance is CuratedCommon {
             assertNotEq(entries[i].topics[0], IBaseModule.KeyAllocatedBalanceChanged.selector);
         }
     }
+
+    function test_topUp_withdrawnKeyGetsZeroAllocation() public {
+        uint256 noId = createNodeOperator(1);
+        cm.obtainDepositData(1, "");
+
+        WithdrawnValidatorInfo[] memory validatorInfos = new WithdrawnValidatorInfo[](1);
+        validatorInfos[0] = WithdrawnValidatorInfo({
+            nodeOperatorId: noId,
+            keyIndex: 0,
+            exitBalance: ValidatorBalanceLimits.MIN_ACTIVATION_BALANCE,
+            slashingPenalty: 0,
+            isSlashed: false
+        });
+        cm.reportRegularWithdrawnValidators(validatorInfos);
+
+        bytes memory key = cm.getSigningKeys(noId, 0, 1);
+        uint256[] memory allocations = cm.allocateDeposits({
+            maxDepositAmount: 5 ether,
+            pubkeys: BytesArr(key),
+            keyIndices: UintArr(0),
+            operatorIds: UintArr(noId),
+            topUpLimits: UintArr(5 ether)
+        });
+
+        assertEq(allocations, UintArr(0));
+        assertEq(cm.getKeyAllocatedBalance(noId, 0), 0);
+        assertEq(module.getTotalModuleStake(), 0);
+        assertEq(cm.getNodeOperatorBalance(noId), 0);
+    }
+
+    function test_topUp_duplicateKeySharesRemainingHeadroom() public {
+        createNodeOperator(1);
+        cm.obtainDepositData(1, "");
+
+        uint256 cap = ValidatorBalanceLimits.MAX_EFFECTIVE_BALANCE - ValidatorBalanceLimits.MIN_ACTIVATION_BALANCE;
+        setKeyConfirmedBalance(0, 0, cap - 10 ether);
+
+        bytes memory key = cm.getSigningKeys(0, 0, 1);
+        uint256[] memory allocations = cm.allocateDeposits({
+            maxDepositAmount: 20 ether,
+            pubkeys: BytesArr(key, key),
+            keyIndices: UintArr(0, 0),
+            operatorIds: UintArr(0, 0),
+            topUpLimits: UintArr(20 ether, 20 ether)
+        });
+
+        assertEq(allocations, UintArr(10 ether, 0));
+        assertEq(cm.getKeyAllocatedBalance(0, 0), cap);
+        assertEq(module.getTotalModuleStake(), ValidatorBalanceLimits.MAX_EFFECTIVE_BALANCE);
+        assertEq(cm.getNodeOperatorBalance(0), ValidatorBalanceLimits.MAX_EFFECTIVE_BALANCE);
+    }
 }
 
 contract CuratedTotalModuleStake is CuratedCommon {


### PR DESCRIPTION
## Description

- Zero withdrawn-key top-up limits so stale or rewound CSM queue items are cleaned up without receiving new stake.
- Share per-key top-up headroom across duplicate entries in the same batch so duplicate keys cannot reserve the same capacity twice.
- Add CSM and Curated unit coverage for withdrawn-key cleanup and duplicate-key headroom sharing.

## Checklist

- [x] Appropriate PR labels applied
- [x] Test coverage maintained (`just coverage`)
  - [ ] No need to add/update tests
  - [x] Tests are added/updated
- [x] Documentation maintained
  - [x] No need to update
  - [ ] Updated
