### PR TITLE
fix: harden top-up stake accounting and meta weights

### DIFF
--- a/script/curated/DeployHoodi.s.sol
+++ b/script/curated/DeployHoodi.s.sol
@@ -87,7 +87,7 @@ contract DeployHoodi is DeployBase {
             CuratedGateConfig storage gate = config.curatedGates.push();
             gate.treeRoot = bytes32(uint256(0xaaaabbbb)); // TODO: derive from final tree
             gate.treeCid = "TODO: ipfs-cid-cohort-a";
-            gate.params.metaRegistryBondCurveWeight = _m(70000);
+            gate.params.metaRegistryBondCurveWeight = _m(50000);
         }
 
         // Professional Trusted Operator Gate

--- a/script/curated/DeployHoodi.s.sol
+++ b/script/curated/DeployHoodi.s.sol
@@ -87,7 +87,7 @@ contract DeployHoodi is DeployBase {
             CuratedGateConfig storage gate = config.curatedGates.push();
             gate.treeRoot = bytes32(uint256(0xaaaabbbb)); // TODO: derive from final tree
             gate.treeCid = "TODO: ipfs-cid-cohort-a";
-            gate.params.metaRegistryBondCurveWeight = _m(7000);
+            gate.params.metaRegistryBondCurveWeight = _m(70000);
         }
 
         // Professional Trusted Operator Gate
@@ -101,7 +101,7 @@ contract DeployHoodi is DeployBase {
             gate.params.generalDelayedPenaltyAdditionalFine = _m(0.05 ether);
             gate.params.keysLimit = _m(500);
             gate.params.rewardShareData.push([1, 8750]); // 87.5% of 4% = 3.5% of the total
-            gate.params.metaRegistryBondCurveWeight = _m(10000);
+            gate.params.metaRegistryBondCurveWeight = _m(100000);
             gate.params.exitDelayFee = _m(0.005 ether);
         }
 
@@ -116,7 +116,7 @@ contract DeployHoodi is DeployBase {
             gate.params.generalDelayedPenaltyAdditionalFine = _m(0.05 ether);
             gate.params.keysLimit = _m(500);
             gate.params.rewardShareData.push([1, 10000]); // 100% of 4% = 4% of the total
-            gate.params.metaRegistryBondCurveWeight = _m(10000);
+            gate.params.metaRegistryBondCurveWeight = _m(100000);
             gate.params.exitDelayFee = _m(0.005 ether);
         }
 
@@ -131,7 +131,7 @@ contract DeployHoodi is DeployBase {
             gate.params.generalDelayedPenaltyAdditionalFine = _m(0.05 ether);
             gate.params.keysLimit = _m(500);
             gate.params.rewardShareData.push([1, 10000]); // 100% of 4% = 4% of the total
-            gate.params.metaRegistryBondCurveWeight = _m(10000);
+            gate.params.metaRegistryBondCurveWeight = _m(100000);
             gate.params.exitDelayFee = _m(0.005 ether);
         }
 
@@ -146,7 +146,7 @@ contract DeployHoodi is DeployBase {
             gate.params.generalDelayedPenaltyAdditionalFine = _m(0.05 ether);
             gate.params.keysLimit = _m(500);
             gate.params.rewardShareData.push([1, 10000]); // 100% of 4% = 4% of the total
-            gate.params.metaRegistryBondCurveWeight = _m(10000);
+            gate.params.metaRegistryBondCurveWeight = _m(100000);
             gate.params.exitDelayFee = _m(0.005 ether);
         }
 
@@ -161,7 +161,7 @@ contract DeployHoodi is DeployBase {
             gate.params.generalDelayedPenaltyAdditionalFine = _m(0.05 ether);
             gate.params.keysLimit = _m(500);
             gate.params.rewardShareData.push([1, 8750]); // 87.5% of 4% = 3.5% of the total
-            gate.params.metaRegistryBondCurveWeight = _m(10000);
+            gate.params.metaRegistryBondCurveWeight = _m(100000);
             gate.params.exitDelayFee = _m(0.005 ether);
         }
 

--- a/script/curated/DeployLocalDevNet.s.sol
+++ b/script/curated/DeployLocalDevNet.s.sol
@@ -77,7 +77,7 @@ contract DeployLocalDevNet is DeployBase {
             CuratedGateConfig storage gate = config.curatedGates.push();
             gate.treeRoot = bytes32(uint256(0xaaaabbbb)); // TODO: derive from final tree
             gate.treeCid = "TODO: ipfs-cid-cohort-a";
-            gate.params.metaRegistryBondCurveWeight = _m(7000);
+            gate.params.metaRegistryBondCurveWeight = _m(70000);
         }
 
         // Professional Trusted Operator Gate
@@ -91,7 +91,7 @@ contract DeployLocalDevNet is DeployBase {
             gate.params.generalDelayedPenaltyAdditionalFine = _m(0.05 ether);
             gate.params.keysLimit = _m(500);
             gate.params.rewardShareData.push([1, 8750]); // 87.5% of 4% = 3.5% of the total
-            gate.params.metaRegistryBondCurveWeight = _m(10000);
+            gate.params.metaRegistryBondCurveWeight = _m(100000);
             gate.params.exitDelayFee = _m(0.005 ether);
         }
 
@@ -106,7 +106,7 @@ contract DeployLocalDevNet is DeployBase {
             gate.params.generalDelayedPenaltyAdditionalFine = _m(0.05 ether);
             gate.params.keysLimit = _m(500);
             gate.params.rewardShareData.push([1, 10000]); // 100% of 4% = 4% of the total
-            gate.params.metaRegistryBondCurveWeight = _m(10000);
+            gate.params.metaRegistryBondCurveWeight = _m(100000);
             gate.params.exitDelayFee = _m(0.005 ether);
         }
 
@@ -121,7 +121,7 @@ contract DeployLocalDevNet is DeployBase {
             gate.params.generalDelayedPenaltyAdditionalFine = _m(0.05 ether);
             gate.params.keysLimit = _m(500);
             gate.params.rewardShareData.push([1, 10000]); // 100% of 4% = 4% of the total
-            gate.params.metaRegistryBondCurveWeight = _m(10000);
+            gate.params.metaRegistryBondCurveWeight = _m(100000);
             gate.params.exitDelayFee = _m(0.005 ether);
         }
 
@@ -136,7 +136,7 @@ contract DeployLocalDevNet is DeployBase {
             gate.params.generalDelayedPenaltyAdditionalFine = _m(0.05 ether);
             gate.params.keysLimit = _m(500);
             gate.params.rewardShareData.push([1, 10000]); // 100% of 4% = 4% of the total
-            gate.params.metaRegistryBondCurveWeight = _m(10000);
+            gate.params.metaRegistryBondCurveWeight = _m(100000);
             gate.params.exitDelayFee = _m(0.005 ether);
         }
 
@@ -151,7 +151,7 @@ contract DeployLocalDevNet is DeployBase {
             gate.params.generalDelayedPenaltyAdditionalFine = _m(0.05 ether);
             gate.params.keysLimit = _m(500);
             gate.params.rewardShareData.push([1, 8750]); // 87.5% of 4% = 3.5% of the total
-            gate.params.metaRegistryBondCurveWeight = _m(10000);
+            gate.params.metaRegistryBondCurveWeight = _m(100000);
             gate.params.exitDelayFee = _m(0.005 ether);
         }
 

--- a/script/curated/DeployMainnet.s.sol
+++ b/script/curated/DeployMainnet.s.sol
@@ -84,7 +84,7 @@ contract DeployMainnet is DeployBase {
             CuratedGateConfig storage gate = config.curatedGates.push();
             gate.treeRoot = bytes32(uint256(0xaaaabbbb)); // TODO: derive from final tree
             gate.treeCid = "TODO: ipfs-cid-cohort-a";
-            gate.params.metaRegistryBondCurveWeight = _m(7000);
+            gate.params.metaRegistryBondCurveWeight = _m(70000);
         }
 
         // Professional Trusted Operator Gate
@@ -98,7 +98,7 @@ contract DeployMainnet is DeployBase {
             gate.params.generalDelayedPenaltyAdditionalFine = _m(0.05 ether);
             gate.params.keysLimit = _m(500);
             gate.params.rewardShareData.push([1, 8750]); // 87.5% of 4% = 3.5% of the total
-            gate.params.metaRegistryBondCurveWeight = _m(10000);
+            gate.params.metaRegistryBondCurveWeight = _m(100000);
             gate.params.exitDelayFee = _m(0.005 ether);
         }
 
@@ -113,7 +113,7 @@ contract DeployMainnet is DeployBase {
             gate.params.generalDelayedPenaltyAdditionalFine = _m(0.05 ether);
             gate.params.keysLimit = _m(500);
             gate.params.rewardShareData.push([1, 10000]); // 100% of 4% = 4% of the total
-            gate.params.metaRegistryBondCurveWeight = _m(10000);
+            gate.params.metaRegistryBondCurveWeight = _m(100000);
             gate.params.exitDelayFee = _m(0.005 ether);
         }
 
@@ -128,7 +128,7 @@ contract DeployMainnet is DeployBase {
             gate.params.generalDelayedPenaltyAdditionalFine = _m(0.05 ether);
             gate.params.keysLimit = _m(500);
             gate.params.rewardShareData.push([1, 10000]); // 100% of 4% = 4% of the total
-            gate.params.metaRegistryBondCurveWeight = _m(10000);
+            gate.params.metaRegistryBondCurveWeight = _m(100000);
             gate.params.exitDelayFee = _m(0.005 ether);
         }
 
@@ -143,7 +143,7 @@ contract DeployMainnet is DeployBase {
             gate.params.generalDelayedPenaltyAdditionalFine = _m(0.05 ether);
             gate.params.keysLimit = _m(500);
             gate.params.rewardShareData.push([1, 10000]); // 100% of 4% = 4% of the total
-            gate.params.metaRegistryBondCurveWeight = _m(10000);
+            gate.params.metaRegistryBondCurveWeight = _m(100000);
             gate.params.exitDelayFee = _m(0.005 ether);
         }
 
@@ -158,7 +158,7 @@ contract DeployMainnet is DeployBase {
             gate.params.generalDelayedPenaltyAdditionalFine = _m(0.05 ether);
             gate.params.keysLimit = _m(500);
             gate.params.rewardShareData.push([1, 8750]); // 87.5% of 4% = 3.5% of the total
-            gate.params.metaRegistryBondCurveWeight = _m(10000);
+            gate.params.metaRegistryBondCurveWeight = _m(100000);
             gate.params.exitDelayFee = _m(0.005 ether);
         }
 

--- a/script/curated/DeployMainnet.s.sol
+++ b/script/curated/DeployMainnet.s.sol
@@ -84,7 +84,7 @@ contract DeployMainnet is DeployBase {
             CuratedGateConfig storage gate = config.curatedGates.push();
             gate.treeRoot = bytes32(uint256(0xaaaabbbb)); // TODO: derive from final tree
             gate.treeCid = "TODO: ipfs-cid-cohort-a";
-            gate.params.metaRegistryBondCurveWeight = _m(70000);
+            gate.params.metaRegistryBondCurveWeight = _m(50000);
         }
 
         // Professional Trusted Operator Gate

--- a/src/MetaRegistry.sol
+++ b/src/MetaRegistry.sol
@@ -132,6 +132,7 @@ contract MetaRegistry is IMetaRegistry, Initializable, AccessControlEnumerableUp
     /// @inheritdoc IMetaRegistry
     function setBondCurveWeight(uint256 curveId, uint256 weight) external onlyRole(SET_BOND_CURVE_WEIGHT_ROLE) {
         MetaRegistryStorage storage $ = _storage();
+        if (weight != 0 && weight < MAX_BP) revert InvalidBondCurveWeight();
         if ($.bondCurveWeight[curveId] == weight) revert SameBondCurveWeight();
 
         $.bondCurveWeight[curveId] = weight;

--- a/src/interfaces/IMetaRegistry.sol
+++ b/src/interfaces/IMetaRegistry.sol
@@ -52,6 +52,7 @@ interface IMetaRegistry {
     error OwnerEditsRestricted();
     error UnsupportedExternalOperatorType();
     error SameBondCurveWeight();
+    error InvalidBondCurveWeight();
     error ModuleAddressNotCached();
     error OperatorNameTooLong();
     error OperatorDescriptionTooLong();

--- a/src/lib/StakeTracker.sol
+++ b/src/lib/StakeTracker.sol
@@ -54,13 +54,21 @@ library StakeTracker {
         for (uint256 i; i < allocations.length; ++i) {
             uint256 allocationWei = allocations[i];
             if (allocationWei == 0) continue;
-            _increaseKeyAllocatedBalance($.keyAllocatedBalance, operatorIds[i], keyIndices[i], allocationWei);
+            // Current allocators cap per-key top-ups before they reach StakeTracker, so a partial
+            // application here is a defensive safeguard for unreachable-by-design inputs.
+            uint256 appliedIncrementWei = _increaseKeyAllocatedBalance(
+                $.keyAllocatedBalance,
+                operatorIds[i],
+                keyIndices[i],
+                allocationWei
+            );
+            if (appliedIncrementWei == 0) continue;
 
             uint256 operatorIndex = operatorIndexes.get(operatorIds[i]);
             if (operatorIndex == 0) {
                 operatorIndex = touchedOperatorsCount;
                 allocatedOperatorIds[operatorIndex] = operatorIds[i];
-                increments[operatorIndex] = allocationWei;
+                increments[operatorIndex] = appliedIncrementWei;
                 unchecked {
                     ++touchedOperatorsCount;
                 }
@@ -68,7 +76,7 @@ library StakeTracker {
                 operatorIndexes.set(operatorIds[i], touchedOperatorsCount);
             } else {
                 unchecked {
-                    increments[operatorIndex - 1] += allocationWei;
+                    increments[operatorIndex - 1] += appliedIncrementWei;
                 }
             }
         }
@@ -141,14 +149,18 @@ library StakeTracker {
         uint256 nodeOperatorId,
         uint256 keyIndex,
         uint256 incrementWei
-    ) private {
+    ) private returns (uint256 appliedIncrementWei) {
         uint256 pointer = KeyPointerLib.keyPointer(nodeOperatorId, keyIndex);
+        uint256 oldAllocated = keyAllocatedBalance[pointer];
         uint256 updated = Math.min(
             ValidatorBalanceLimits.MAX_EFFECTIVE_BALANCE - ValidatorBalanceLimits.MIN_ACTIVATION_BALANCE,
-            keyAllocatedBalance[pointer] + incrementWei
+            oldAllocated + incrementWei
         );
         keyAllocatedBalance[pointer] = updated;
         emit IBaseModule.KeyAllocatedBalanceChanged(nodeOperatorId, keyIndex, updated);
+        unchecked {
+            appliedIncrementWei = updated - oldAllocated;
+        }
     }
 
     function _activeValidatorsCount(NodeOperator storage no) private view returns (uint256) {

--- a/test/fork/integration/curated/DepositInfoRefresh.t.sol
+++ b/test/fork/integration/curated/DepositInfoRefresh.t.sol
@@ -41,7 +41,7 @@ contract DepositInfoRefreshTestCurated is CuratedIntegrationBase {
         assertEq(pubkeys.length, 0, "should not deposit with zero weight");
 
         // Restore weight
-        metaRegistry.setBondCurveWeight(curveId, 1);
+        metaRegistry.setBondCurveWeight(curveId, 10000);
         metaRegistry.refreshOperatorWeight(noId);
 
         // Run batch update to refresh deposit info

--- a/test/fork/integration/curated/MetaRegistry.t.sol
+++ b/test/fork/integration/curated/MetaRegistry.t.sol
@@ -131,7 +131,7 @@ contract MetaRegistryIntegrationTestCurated is CuratedIntegrationBase {
         uint256 curveId = accounting.getBondCurveId(noId);
 
         uint256 currentWeight = metaRegistry.getBondCurveWeight(curveId);
-        uint256 newWeight = currentWeight + 1;
+        uint256 newWeight = currentWeight == 0 ? 10000 : currentWeight + 10000;
         uint256 nonceBefore = module.getNonce();
 
         metaRegistry.setBondCurveWeight(curveId, newWeight);
@@ -148,7 +148,7 @@ contract MetaRegistryIntegrationTestCurated is CuratedIntegrationBase {
         uint256 curveId = accounting.getBondCurveId(noId);
 
         uint256 currentWeight = metaRegistry.getBondCurveWeight(curveId);
-        uint256 newWeight = currentWeight * 2 + 1;
+        uint256 newWeight = currentWeight == 0 ? 20000 : currentWeight * 2;
 
         // Change curve weight (does NOT auto-update operator weights)
         metaRegistry.setBondCurveWeight(curveId, newWeight);

--- a/test/helpers/Fixtures.sol
+++ b/test/helpers/Fixtures.sol
@@ -1369,7 +1369,7 @@ contract CuratedIntegrationHelpers is ForkIntegrationHelpersBase {
             );
         }
         if (r.getBondCurveWeight(curveId) == 0) {
-            r.setBondCurveWeight(curveId, 100);
+            r.setBondCurveWeight(curveId, 10000);
             CuratedModule cm = CuratedModule(address(module));
             cm.batchDepositInfoUpdate(cm.getNodeOperatorsCount());
         }

--- a/test/unit/CuratedModule.t.sol
+++ b/test/unit/CuratedModule.t.sol
@@ -7,6 +7,7 @@ import { Initializable } from "@openzeppelin/contracts-upgradeable/proxy/utils/I
 
 import { CuratedDepositAllocator } from "src/lib/allocator/CuratedDepositAllocator.sol";
 import { SigningKeys } from "src/lib/SigningKeys.sol";
+import { StakeTracker } from "src/lib/StakeTracker.sol";
 import { ValidatorBalanceLimits } from "src/lib/ValidatorBalanceLimits.sol";
 import { CuratedModule } from "src/CuratedModule.sol";
 import { IBaseModule, NodeOperator, NodeOperatorManagementProperties } from "src/interfaces/IBaseModule.sol";
@@ -22,8 +23,28 @@ import { AccountingMock } from "../helpers/mocks/AccountingMock.sol";
 // forge-lint: disable-next-line(unaliased-plain-import)
 import "./ModuleAbstract/ModuleAbstract.t.sol";
 
+contract CuratedModuleHarness is CuratedModule {
+    constructor(
+        bytes32 moduleType,
+        address lidoLocator,
+        address parametersRegistry,
+        address accounting,
+        address exitPenalties,
+        address metaRegistry
+    ) CuratedModule(moduleType, lidoLocator, parametersRegistry, accounting, exitPenalties, metaRegistry) {}
+
+    function exposedIncreaseKeyBalances(
+        uint256[] calldata operatorIds,
+        uint256[] calldata keyIndices,
+        uint256[] calldata allocations
+    ) external {
+        StakeTracker.increaseKeyBalances(_baseStorage(), operatorIds, keyIndices, allocations);
+    }
+}
+
 contract CuratedCommon is ModuleFixtures {
     ICuratedModule cm;
+    CuratedModuleHarness internal curatedHarness;
     Stub internal metaRegistry;
     uint256 internal constant DEFAULT_OPERATOR_WEIGHT = 1;
     uint256 internal constant MAX_MOCKED_OPERATORS = 256;
@@ -53,7 +74,7 @@ contract CuratedCommon is ModuleFixtures {
 
         metaRegistry = new Stub();
         _mockMetaOperatorDefaults();
-        module = new CuratedModule({
+        curatedHarness = new CuratedModuleHarness({
             moduleType: "curated-module",
             lidoLocator: address(locator),
             parametersRegistry: address(parametersRegistry),
@@ -61,7 +82,8 @@ contract CuratedCommon is ModuleFixtures {
             exitPenalties: address(exitPenalties),
             metaRegistry: address(metaRegistry)
         });
-        cm = CuratedModule(address(module));
+        module = curatedHarness;
+        cm = curatedHarness;
 
         accounting.setModule(module);
 
@@ -1886,6 +1908,22 @@ contract CuratedTopUpKeyAllocatedBalance is CuratedCommon {
         });
 
         assertEq(allocations, UintArr(10 ether, 0));
+        assertEq(cm.getKeyAllocatedBalances(0, 0, 1), UintArr(cap));
+        assertEq(module.getTotalModuleStake(), ValidatorBalanceLimits.MAX_EFFECTIVE_BALANCE);
+        assertEq(cm.getNodeOperatorBalance(0), ValidatorBalanceLimits.MAX_EFFECTIVE_BALANCE);
+    }
+
+    function test_topUp_capsOperatorBalanceIncrementToAppliedHeadroom() public {
+        createNodeOperator(1);
+        cm.obtainDepositData(1, "");
+
+        uint256 cap = ValidatorBalanceLimits.MAX_EFFECTIVE_BALANCE - ValidatorBalanceLimits.MIN_ACTIVATION_BALANCE;
+        setKeyConfirmedBalance(0, 0, cap - 2 ether);
+
+        // Current allocators cap per-key top-ups before they reach StakeTracker, so an over-cap allocation is
+        // practically unreachable in production right now. Use the harness to exercise the defensive accounting path.
+        curatedHarness.exposedIncreaseKeyBalances(UintArr(0), UintArr(0), UintArr(10 ether));
+
         assertEq(cm.getKeyAllocatedBalances(0, 0, 1), UintArr(cap));
         assertEq(module.getTotalModuleStake(), ValidatorBalanceLimits.MAX_EFFECTIVE_BALANCE);
         assertEq(cm.getNodeOperatorBalance(0), ValidatorBalanceLimits.MAX_EFFECTIVE_BALANCE);

--- a/test/unit/MetaRegistry.t.sol
+++ b/test/unit/MetaRegistry.t.sol
@@ -1011,33 +1011,41 @@ contract MetaRegistryTestWeights is MetaRegistryTestGroupsBase {
 }
 
 contract MetaRegistryTestBondCurve is MetaRegistryTestGroupsBase {
+    uint256 internal constant VALID_BOND_CURVE_WEIGHT = CURVE_WEIGHT + 123;
+
     function test_getBondCurveWeight_ReturnsValue() public {
         assertEq(registry.getBondCurveWeight(0), 0);
 
         vm.expectCall(address(module), abi.encodeWithSelector(IBaseModule.requestFullDepositInfoUpdate.selector));
         vm.expectEmit(address(registry));
-        emit IMetaRegistry.BondCurveWeightSet(0, 123);
+        emit IMetaRegistry.BondCurveWeightSet(0, VALID_BOND_CURVE_WEIGHT);
         vm.prank(bondCurveWeightManager);
-        registry.setBondCurveWeight(0, 123);
+        registry.setBondCurveWeight(0, VALID_BOND_CURVE_WEIGHT);
 
-        assertEq(registry.getBondCurveWeight(0), 123);
+        assertEq(registry.getBondCurveWeight(0), VALID_BOND_CURVE_WEIGHT);
     }
 
     function test_setBondCurveWeight_RevertWhen_NoRole() public {
         expectRoleRevert(stranger, registry.SET_BOND_CURVE_WEIGHT_ROLE());
         vm.prank(stranger);
-        registry.setBondCurveWeight(0, 123);
+        registry.setBondCurveWeight(0, VALID_BOND_CURVE_WEIGHT);
+    }
+
+    function test_setBondCurveWeight_RevertWhen_BelowMinNonZeroWeight() public {
+        vm.prank(bondCurveWeightManager);
+        vm.expectRevert(IMetaRegistry.InvalidBondCurveWeight.selector);
+        registry.setBondCurveWeight(0, MAX_BP - 1);
     }
 
     function test_setBondCurveWeight_RevertWhen_SameWeight() public {
         {
             vm.prank(bondCurveWeightManager);
-            registry.setBondCurveWeight(0, 123);
+            registry.setBondCurveWeight(0, VALID_BOND_CURVE_WEIGHT);
         }
 
         vm.prank(bondCurveWeightManager);
         vm.expectRevert(IMetaRegistry.SameBondCurveWeight.selector);
-        registry.setBondCurveWeight(0, 123);
+        registry.setBondCurveWeight(0, VALID_BOND_CURVE_WEIGHT);
     }
 
     function test_refreshOperatorWeight_NoOpWhen_NotInGroup() public {


### PR DESCRIPTION
## Description

- Clamp `StakeTracker` operator and module extra-stake accounting to the per-key delta actually applied after the local cap.
- Add a harness-backed regression test for the unreachable-by-design over-cap allocation path.
- Reject non-zero `MetaRegistry` bond curve weights below `MAX_BP` so positive bp shares cannot truncate to zero effective weight.

## Checklist

- [x] Appropriate PR labels applied
- [ ] Test coverage maintained (`just coverage`)
  - [ ] No need to add/update tests
  - [x] Tests are added/updated
- [ ] Documentation maintained
  - [x] No need to update
  - [ ] Updated
