### PR TITLE
feat: add bond curve setter to the event

### DIFF
--- a/src/abstract/BondCurve.sol
+++ b/src/abstract/BondCurve.sol
@@ -100,7 +100,7 @@ abstract contract BondCurve is IBondCurve, Initializable {
         }
         if ($.operatorBondCurveId[nodeOperatorId] == curveId) revert SameBondCurveId();
         $.operatorBondCurveId[nodeOperatorId] = curveId;
-        emit BondCurveSet(nodeOperatorId, curveId);
+        emit BondCurveSet(nodeOperatorId, curveId, msg.sender);
     }
 
     function _getCurveInfo(uint256 curveId) private view returns (BondCurveData storage) {

--- a/src/interfaces/IBondCurve.sol
+++ b/src/interfaces/IBondCurve.sol
@@ -60,7 +60,7 @@ interface IBondCurve {
 
     event BondCurveAdded(uint256 indexed curveId, BondCurveIntervalInput[] bondCurveIntervals);
     event BondCurveUpdated(uint256 indexed curveId, BondCurveIntervalInput[] bondCurveIntervals);
-    event BondCurveSet(uint256 indexed nodeOperatorId, uint256 curveId);
+    event BondCurveSet(uint256 indexed nodeOperatorId, uint256 curveId, address indexed setter);
 
     error InvalidBondCurveLength();
     error InvalidBondCurveValues();

--- a/test/unit/abstract/BondCurve.t.sol
+++ b/test/unit/abstract/BondCurve.t.sol
@@ -29,6 +29,12 @@ contract BondCurveTestable is BondCurve {
     }
 }
 
+contract BondCurveGateMock {
+    function setBondCurve(BondCurveTestable bondCurve, uint256 nodeOperatorId, uint256 curveId) external {
+        bondCurve.setBondCurve(nodeOperatorId, curveId);
+    }
+}
+
 contract BondCurveInitTest is Test {
     BondCurveTestable public bondCurve;
 
@@ -280,8 +286,23 @@ contract BondCurveTest is Test {
         uint256 addedId = bondCurve.addBondCurve(_bondCurve);
 
         vm.expectEmit(address(bondCurve));
-        emit IBondCurve.BondCurveSet(noId, addedId);
+        emit IBondCurve.BondCurveSet(noId, addedId, address(this));
         bondCurve.setBondCurve(noId, addedId);
+
+        assertEq(bondCurve.getBondCurveId(noId), addedId);
+    }
+
+    function test_setBondCurve_EmitsGateAsSetter() public {
+        uint256 noId = 0;
+        IBondCurve.BondCurveIntervalInput[] memory _bondCurve = new IBondCurve.BondCurveIntervalInput[](1);
+        _bondCurve[0] = IBondCurve.BondCurveIntervalInput(1, 16 ether);
+        uint256 addedId = bondCurve.addBondCurve(_bondCurve);
+
+        BondCurveGateMock gate = new BondCurveGateMock();
+
+        vm.expectEmit(address(bondCurve));
+        emit IBondCurve.BondCurveSet(noId, addedId, address(gate));
+        gate.setBondCurve(bondCurve, noId, addedId);
 
         assertEq(bondCurve.getBondCurveId(noId), addedId);
     }


### PR DESCRIPTION
## Description

Adds bond curve setter address to the corresponding event.

## Checklist

- [x] Appropriate PR labels applied
- [x] Test coverage maintained (`just coverage`)
  - [ ] No need to add/update tests
  - [x] Tests are added/updated
- [x] Documentation maintained
  - [x] No need to update
  - [ ] Updated
