### PR TITLE
fix: account for surplus stETH shares in fork tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -136,13 +136,6 @@ jobs:
           CHAIN: mainnet
           RPC_URL: ${{ secrets.RPC_URL_MAINNET }}
 
-      - name: Run post-vote tests after upgrade
-        run: just test-upgrade --no-match-contract=VoteChangesTest
-        env:
-          CHAIN: mainnet
-          DEPLOY_CONFIG: ./artifacts/mainnet/deploy-mainnet.json
-          RPC_URL: ${{ secrets.RPC_URL_MAINNET }}
-
       # TODO: Enable later
       # - name: Check gas report
       #   run: just gas-report && git diff --exit-code GAS.md

--- a/script/DeployMainnet.s.sol
+++ b/script/DeployMainnet.s.sol
@@ -25,14 +25,14 @@ contract DeployMainnet is DeployBase {
         config.consensusVersion = 3;
         config.oracleMembers = new address[](9);
         config.oracleMembers[0] = 0x73181107c8D9ED4ce0bbeF7A0b4ccf3320C41d12; // Instadapp
-        config.oracleMembers[1] = 0x285f8537e1dAeEdaf617e96C742F2Cf36d63CcfB; // Chorus One
+        config.oracleMembers[1] = 0x4118DAD7f348A4063bD15786c299De2f3B1333F3; // Caliber
         config.oracleMembers[2] = 0x404335BcE530400a5814375E7Ec1FB55fAff3eA2; // Staking Facilities
-        config.oracleMembers[3] = 0x946D3b081ed19173dC83Cd974fC69e1e760B7d78; // Stakefish
+        config.oracleMembers[3] = 0x8dB977C13CAA938BC58464bFD622DF0570564b78;
         config.oracleMembers[4] = 0x007DE4a5F7bc37E2F26c0cb2E8A95006EE9B89b5; // P2P
         config.oracleMembers[5] = 0xc79F702202E3A6B0B6310B537E786B9ACAA19BAf; // Chainlayer
         config.oracleMembers[6] = 0x61c91ECd902EB56e314bB2D5c5C07785444Ea1c8; // bloXroute
         config.oracleMembers[7] = 0xe57B3792aDCc5da47EF4fF588883F0ee0c9835C9; // MatrixedLink
-        config.oracleMembers[8] = 0x4118DAD7f348A4063bD15786c299De2f3B1333F3; // Caliber
+        config.oracleMembers[8] = 0x042a9e5acCfa17e28300F1b5967f20891E973922;
         config.hashConsensusQuorum = 5;
 
         // Verifier

--- a/script/DeployMainnet.s.sol
+++ b/script/DeployMainnet.s.sol
@@ -21,7 +21,7 @@ contract DeployMainnet is DeployBase {
         config.slotsPerEpoch = 32; // https://github.com/ethereum/consensus-specs/blob/7df1ce30384b13d01617f8ddf930f4035da0f689/specs/phase0/beacon-chain.md?plain=1#L246
         config.clGenesisTime = 1606824023; // https://github.com/eth-clients/mainnet/blob/f6b7882618a5ad2c1d2731ae35e5d16a660d5bb7/README.md?plain=1#L10
         config.oracleReportEpochsPerFrame = 225 * 28; // 28 days
-        config.fastLaneLengthSlots = 1800;
+        config.fastLaneLengthSlots = 300;
         config.consensusVersion = 3;
         config.oracleMembers = new address[](9);
         config.oracleMembers[0] = 0x73181107c8D9ED4ce0bbeF7A0b4ccf3320C41d12; // Instadapp

--- a/test/fork/integration/ClaimInTokens.t.sol
+++ b/test/fork/integration/ClaimInTokens.t.sol
@@ -30,6 +30,7 @@ contract ClaimRewardsTest is
     address internal stranger;
     address internal nodeOperator;
     uint256 internal defaultNoId;
+    uint256 internal accountingSharesSurplus;
 
     modifier assertInvariants() {
         _;
@@ -55,6 +56,9 @@ contract ClaimRewardsTest is
         Env memory env = envVars();
         vm.createSelectFork(env.RPC_URL);
         initializeFromDeployment();
+        accountingSharesSurplus =
+            lido.sharesOf(address(accounting)) -
+            accounting.totalBondShares();
 
         vm.startPrank(csm.getRoleMember(csm.DEFAULT_ADMIN_ROLE(), 0));
         csm.grantRole(csm.DEFAULT_ADMIN_ROLE(), address(this));
@@ -143,8 +147,8 @@ contract ClaimRewardsTest is
             "NO bond shares should be decreased by real transferred shares"
         );
         assertEq(
-            accountingTotalBondSharesAfter,
             accountingSharesAfter,
+            accountingTotalBondSharesAfter + accountingSharesSurplus,
             "Total bond shares should be equal to real shares"
         );
     }
@@ -208,8 +212,8 @@ contract ClaimRewardsTest is
             "NO bond shares should be decreased by real transferred shares"
         );
         assertEq(
-            accountingTotalBondSharesAfter,
             accountingSharesAfter,
+            accountingTotalBondSharesAfter + accountingSharesSurplus,
             "Total bond shares should be equal to real shares"
         );
     }
@@ -289,8 +293,8 @@ contract ClaimRewardsTest is
             "NO bond shares should be decreased by real transferred shares"
         );
         assertEq(
-            accountingTotalBondSharesAfter,
             accountingSharesAfter,
+            accountingTotalBondSharesAfter + accountingSharesSurplus,
             "Total bond shares should be equal to real shares"
         );
     }
@@ -354,8 +358,8 @@ contract ClaimRewardsTest is
         );
         assertEq(current, required, "NO bond shares should be equal required");
         assertEq(
-            accounting.totalBondShares(),
             accountingSharesAfter,
+            accounting.totalBondShares() + accountingSharesSurplus,
             "Total bond shares should be equal to real shares"
         );
     }
@@ -424,8 +428,8 @@ contract ClaimRewardsTest is
             "NO bond shares should be equal required"
         );
         assertEq(
-            accounting.totalBondShares(),
             accountingSharesAfter,
+            accounting.totalBondShares() + accountingSharesSurplus,
             "Total bond shares should be equal to real shares"
         );
     }
@@ -517,8 +521,8 @@ contract ClaimRewardsTest is
             "NO bond shares should be equal required"
         );
         assertEq(
-            accounting.totalBondShares(),
             accountingSharesAfter,
+            accounting.totalBondShares() + accountingSharesSurplus,
             "Total bond shares should be equal to real shares"
         );
     }

--- a/test/fork/integration/RecoverTokens.t.sol
+++ b/test/fork/integration/RecoverTokens.t.sol
@@ -132,6 +132,9 @@ contract RecoverIntegrationTest is
     function test_recoverStETH_fromAccounting() public assertInvariants {
         assertEq(lido.sharesOf(recoverer), 0);
 
+        uint256 surplusBefore = lido.sharesOf(address(accounting)) -
+            accounting.totalBondShares();
+
         uint256 amount = 1 ether;
         vm.startPrank(user);
         vm.deal(user, amount);
@@ -142,7 +145,7 @@ contract RecoverIntegrationTest is
         vm.prank(recoverer);
         accounting.recoverStETHShares();
 
-        assertEq(lido.sharesOf(recoverer), shares);
+        assertEq(lido.sharesOf(recoverer), shares + surplusBefore);
     }
 
     function test_recoverETH_fromAccounting() public assertInvariants {


### PR DESCRIPTION
## Description

backport test changes from develop to mainnet to support integration tests for current deployed state of the contracts

## Checklist

- [ ] Appropriate PR labels applied
- [ ] Test coverage maintained (`just coverage`)
  - [ ] No need to add/update tests
  - [ ] Tests are added/updated
- [ ] Documentation maintained
  - [ ] No need to update
  - [ ] Updated
