### PR TITLE
[codex] Exclude sub-step top-up capacity from baseline

### DIFF
--- a/src/interfaces/ICuratedModule.sol
+++ b/src/interfaces/ICuratedModule.sol
@@ -51,7 +51,7 @@ interface ICuratedModule is IBaseModule, IStakingModuleV2 {
     /// @notice Returns current deposit allocation targets for all operators.
     /// @dev Target = totalCurrent * operatorWeight / totalWeight (in validator count).
     ///      Includes operators regardless of depositable capacity for informational purposes.
-    ///      Actual allocation recalculates shares only across operators with available capacity,
+    ///      Actual allocation recalculates shares only across operators with usable capacity,
     ///      so real per-operator amounts may differ from the targets shown here.
     ///      Arrays are indexed by operator id; zero-weight operators have zero values.
     /// @return currentValidators Current active validator count per operator.
@@ -64,7 +64,7 @@ interface ICuratedModule is IBaseModule, IStakingModuleV2 {
     /// @notice Returns current top-up allocation targets for all operators.
     /// @dev Target = totalCurrent * operatorWeight / totalWeight (in wei).
     ///      Includes operators regardless of top-up capacity for informational purposes.
-    ///      Actual allocation recalculates shares only across operators with available capacity,
+    ///      Actual allocation recalculates shares only across operators with usable capacity,
     ///      so real per-operator amounts may differ from the targets shown here.
     ///      Arrays are indexed by operator id; zero-weight operators have zero values.
     /// @return currentAllocations Current operator stake in wei.

--- a/src/lib/allocator/CuratedDepositAllocator.sol
+++ b/src/lib/allocator/CuratedDepositAllocator.sol
@@ -65,9 +65,9 @@ library CuratedDepositAllocator {
 
     /// @dev Returns operator-level top-up allocations for the provided operators.
     ///      - Duplicated operator ids are not expected (caller guarantees uniqueness).
-    ///      - Only operators with non-zero allocation weight are included.
+    ///      - Only operators with non-zero allocation weight and usable top-up capacity are included.
     ///      - Shares are computed across all eligible operators in the module
-    ///        (non-zero weight, non-zero top-up capacity),
+    ///        (non-zero weight, non-zero quantized top-up capacity),
     ///        so a subset cannot bias its share by omitting other eligible operators.
     ///      - Per-operator capacity is computed as:
     ///        `(active_validators * 2048 ETH) - current_operator_balance`, floored at zero.
@@ -92,7 +92,7 @@ library CuratedDepositAllocator {
     ///      - Raw operator ids may contain duplicates; they are deduplicated before operator-level allocation
     ///        to avoid overweighting operators that appear on multiple requested keys.
     ///      - Shares are computed across all eligible operators in the module
-    ///        (non-zero weight, non-zero top-up capacity),
+    ///        (non-zero weight, non-zero quantized top-up capacity),
     ///        so a subset cannot bias its share by omitting other eligible operators.
     ///      - Per-operator capacity is computed as:
     ///        `(active_validators * 2048 ETH) - current_operator_balance`, floored at zero.
@@ -270,10 +270,10 @@ library CuratedDepositAllocator {
 
         IMetaRegistry metaRegistry = ICuratedModule(address(this)).META_REGISTRY();
 
-        // Build global share baseline across all eligible operators (non-zero weight + capacity).
+        // Build global share baseline across all eligible operators (non-zero weight + usable capacity).
         for (uint256 i; i < operatorsCount; ++i) {
             uint256 balance = StakeTracker.getOperatorBalance($, i);
-            uint256 capacity = _topUpCapacity($.nodeOperators[i], balance);
+            uint256 capacity = quantizeForTopUp(_topUpCapacity($.nodeOperators[i], balance));
             if (capacity == 0) continue;
             capacitiesByOperatorId[i] = capacity;
 
@@ -301,7 +301,7 @@ library CuratedDepositAllocator {
     /// @notice Returns current deposit allocation targets for all operators.
     /// @dev Target = totalCurrent * operatorWeight / totalWeight (in validator count).
     ///      Includes operators regardless of depositable capacity for informational purposes.
-    ///      Actual allocation recalculates shares only across operators with available capacity,
+    ///      Actual allocation recalculates shares only across operators with usable capacity,
     ///      so real per-operator amounts may differ from the targets shown here.
     ///      Arrays are indexed by operator id; zero-weight operators have zero values.
     /// @param nodeOperators Node operator storage mapping from the module.
@@ -349,7 +349,7 @@ library CuratedDepositAllocator {
     /// @notice Returns current top-up allocation targets for all operators.
     /// @dev Target = totalCurrent * operatorWeight / totalWeight (in wei).
     ///      Includes operators regardless of top-up capacity for informational purposes.
-    ///      Actual allocation recalculates shares only across operators with available capacity,
+    ///      Actual allocation recalculates shares only across operators with usable capacity,
     ///      so real per-operator amounts may differ from the targets shown here.
     ///      Arrays are indexed by operator id; zero-weight operators have zero values.
     /// @param $ Base module storage pointer.

--- a/test/unit/CuratedModule.t.sol
+++ b/test/unit/CuratedModule.t.sol
@@ -719,6 +719,31 @@ contract CuratedTopUpObtainDepositData is CuratedCommon {
         assertEq(allocations[0], 4 ether);
     }
 
+    function test_topUpObtainDepositData_subStepCapacityExcludedFromShare() public assertInvariants {
+        uint256 firstId = createNodeOperator(1);
+        uint256 secondId = createNodeOperator(1);
+        module.obtainDepositData(2, "");
+
+        uint256 almostFullTopUp = ValidatorBalanceLimits.MAX_EFFECTIVE_BALANCE -
+            ValidatorBalanceLimits.MIN_ACTIVATION_BALANCE -
+            1 wei;
+        curatedHarness.exposedIncreaseKeyBalances(UintArr(firstId), UintArr(0), UintArr(almostFullTopUp));
+        _mockOperatorWeight(firstId, 1000);
+        _mockOperatorWeight(secondId, 1);
+
+        bytes memory key = module.getSigningKeys(secondId, 0, 1);
+
+        uint256[] memory allocations = cm.allocateDeposits(
+            2 ether,
+            BytesArr(key),
+            UintArr(0),
+            UintArr(secondId),
+            UintArr(10 ether)
+        );
+
+        assertEq(allocations[0], 2 ether);
+    }
+
     function test_topUpObtainDepositData_capacityCapsAllocation() public assertInvariants {
         uint256 noId = createNodeOperator(1);
         module.obtainDepositData(1, "");
@@ -1074,6 +1099,25 @@ contract CuratedTopUpObtainDepositData is CuratedCommon {
         assertEq(ids.length, 1);
         assertEq(ids[0], secondId);
         assertEq(allocs[0], 4 ether);
+    }
+
+    function test_getDepositsAllocation_subStepCapacityExcludedFromShare() public assertInvariants {
+        uint256 firstId = createNodeOperator(1);
+        uint256 secondId = createNodeOperator(1);
+        module.obtainDepositData(2, "");
+
+        uint256 almostFullTopUp = ValidatorBalanceLimits.MAX_EFFECTIVE_BALANCE -
+            ValidatorBalanceLimits.MIN_ACTIVATION_BALANCE -
+            1 wei;
+        curatedHarness.exposedIncreaseKeyBalances(UintArr(firstId), UintArr(0), UintArr(almostFullTopUp));
+        _mockOperatorWeight(firstId, 1000);
+        _mockOperatorWeight(secondId, 1);
+
+        (, uint256[] memory ids, uint256[] memory allocs) = cm.getDepositsAllocation(2 ether);
+
+        assertEq(ids.length, 1);
+        assertEq(ids[0], secondId);
+        assertEq(allocs[0], 2 ether);
     }
 
     function test_getDepositsAllocation_capacityCapsAllocation() public assertInvariants {


### PR DESCRIPTION
## Summary

- Exclude operators whose raw top-up capacity rounds down to zero at the 2 ETH step from the global top-up allocation baseline.
- Store quantized top-up capacity in the baseline so eligibility matches the greedy allocator's usable capacity.
- Add regression coverage for both `allocateDeposits()` and `getDepositsAllocation()` when a high-weight operator has only sub-step capacity left.

## Why

Operators with positive raw capacity below `TOP_UP_STEP` were previously included in `weightSum` and `totalCurrent`, but the greedy allocator later quantized their usable capacity to zero. That could dilute other operators' shares and leave an otherwise deployable top-up round unallocated.

## Validation

- `forge build src/lib/allocator/CuratedDepositAllocator.sol src/interfaces/ICuratedModule.sol src/CuratedModule.sol`
- `forge test --match-contract CuratedTopUpObtainDepositData --match-test subStepCapacityExcludedFromShare`
- `forge test --match-path test/unit/CuratedModule.t.sol`