### PR TITLE
Add names to Merkle gates

### DIFF
--- a/script/csm/DeployBase.s.sol
+++ b/script/csm/DeployBase.s.sol
@@ -92,6 +92,7 @@ struct DeployParams {
     // TODO: Legacy-only field. Kept only for SimulateVote.upgrade() END_REFERRAL_SEASON_ROLE revoke.
     address identifiedCommunityStakersGateManager;
     uint256 identifiedCommunityStakersGateCurveId;
+    string identifiedCommunityStakersGateName;
     bytes32 identifiedCommunityStakersGateTreeRoot;
     string identifiedCommunityStakersGateTreeCid;
     uint256[2][] identifiedCommunityStakersGateBondCurve;
@@ -113,6 +114,7 @@ struct DeployParams {
     uint256 identifiedCommunityStakersGateExitDelayFee;
     uint256 identifiedCommunityStakersGateMaxElWithdrawalRequestFee;
     // IDVTC VettedGate
+    string identifiedDVTClusterGateName;
     bytes32 identifiedDVTClusterGateTreeRoot;
     string identifiedDVTClusterGateTreeCid;
     uint256 identifiedDVTClusterBondCurveId;
@@ -365,6 +367,7 @@ abstract contract DeployBase is Script {
                     identifiedCommunityStakersGateBondCurveId,
                     config.identifiedCommunityStakersGateTreeRoot,
                     config.identifiedCommunityStakersGateTreeCid,
+                    config.identifiedCommunityStakersGateName,
                     deployer
                 )
             );
@@ -373,6 +376,7 @@ abstract contract DeployBase is Script {
                     identifiedDVTClusterBondCurveId,
                     config.identifiedDVTClusterGateTreeRoot,
                     config.identifiedDVTClusterGateTreeCid,
+                    config.identifiedDVTClusterGateName,
                     deployer
                 )
             );

--- a/script/csm/DeployCSMImplementationsBase.s.sol
+++ b/script/csm/DeployCSMImplementationsBase.s.sol
@@ -66,6 +66,7 @@ abstract contract DeployCSMImplementationsBase is DeployBase {
                     expectedIdentifiedDVTClusterCurveId,
                     config.identifiedDVTClusterGateTreeRoot,
                     config.identifiedDVTClusterGateTreeCid,
+                    config.identifiedDVTClusterGateName,
                     deployer
                 )
             );

--- a/script/csm/DeployHoodi.s.sol
+++ b/script/csm/DeployHoodi.s.sol
@@ -85,9 +85,11 @@ contract DeployHoodi is DeployBase {
         // VettedGate
         config.identifiedCommunityStakersGateManager = 0x4AF43Ee34a6fcD1fEcA1e1F832124C763561dA53; // Dev team EOA
         config.identifiedCommunityStakersGateCurveId = 2;
+        config.identifiedCommunityStakersGateName = "Identified Community Stakers Gate";
         config
             .identifiedCommunityStakersGateTreeRoot = 0x6ddbc639b18ef7eee4e4262baf6e2bec58724b40b9e557df4bc78a0d9c2e0607; // See the first value in artifacts/hoodi/ics/merkle-tree.json
         config.identifiedCommunityStakersGateTreeCid = "bafkreicr363zly5gj3gkpmamu2qzcpevw6tylwc767fxi3vfc2skcxanfi";
+        config.identifiedDVTClusterGateName = "Identified DVT Cluster Gate";
         config.identifiedDVTClusterGateTreeRoot = bytes32(uint256(0xdeadbeef)); // TODO: Set real IDVTC tree root
         config.identifiedDVTClusterGateTreeCid = "someCid"; // TODO: Set real IDVTC tree CID
         // 1.5 -> 1.3

--- a/script/csm/DeployHoodi.s.sol
+++ b/script/csm/DeployHoodi.s.sol
@@ -89,7 +89,7 @@ contract DeployHoodi is DeployBase {
         config
             .identifiedCommunityStakersGateTreeRoot = 0x6ddbc639b18ef7eee4e4262baf6e2bec58724b40b9e557df4bc78a0d9c2e0607; // See the first value in artifacts/hoodi/ics/merkle-tree.json
         config.identifiedCommunityStakersGateTreeCid = "bafkreicr363zly5gj3gkpmamu2qzcpevw6tylwc767fxi3vfc2skcxanfi";
-        config.identifiedDVTClusterGateName = "Identified DVT Cluster Gate";
+        config.identifiedDVTClusterGateName = "Identified DVT Clusters Gate";
         config.identifiedDVTClusterGateTreeRoot = bytes32(uint256(0xdeadbeef)); // TODO: Set real IDVTC tree root
         config.identifiedDVTClusterGateTreeCid = "someCid"; // TODO: Set real IDVTC tree CID
         // 1.5 -> 1.3

--- a/script/csm/DeployLocalDevNet.s.sol
+++ b/script/csm/DeployLocalDevNet.s.sol
@@ -81,7 +81,7 @@ contract DeployLocalDevNet is DeployBase {
             bytes32(uint256(0xdeadbeef))
         );
         config.identifiedCommunityStakersGateTreeCid = vm.envOr("CSM_VETTED_GATE_TREE_CID", string("someCid"));
-        config.identifiedDVTClusterGateName = "Identified DVT Cluster Gate";
+        config.identifiedDVTClusterGateName = "Identified DVT Clusters Gate";
         config.identifiedDVTClusterGateTreeRoot = bytes32(uint256(0xdeadbeef)); // TODO: Set real IDVTC tree root
         config.identifiedDVTClusterGateTreeCid = "someCid"; // TODO: Set real IDVTC tree CID
         // 1.5 -> 1.3

--- a/script/csm/DeployLocalDevNet.s.sol
+++ b/script/csm/DeployLocalDevNet.s.sol
@@ -75,11 +75,13 @@ contract DeployLocalDevNet is DeployBase {
         // VettedGate
         config.identifiedCommunityStakersGateManager = 0x4AF43Ee34a6fcD1fEcA1e1F832124C763561dA53; // Dev team EOA
         config.identifiedCommunityStakersGateCurveId = 2;
+        config.identifiedCommunityStakersGateName = "Identified Community Stakers Gate";
         config.identifiedCommunityStakersGateTreeRoot = vm.envOr(
             "CSM_VETTED_GATE_TREE_ROOT",
             bytes32(uint256(0xdeadbeef))
         );
         config.identifiedCommunityStakersGateTreeCid = vm.envOr("CSM_VETTED_GATE_TREE_CID", string("someCid"));
+        config.identifiedDVTClusterGateName = "Identified DVT Cluster Gate";
         config.identifiedDVTClusterGateTreeRoot = bytes32(uint256(0xdeadbeef)); // TODO: Set real IDVTC tree root
         config.identifiedDVTClusterGateTreeCid = "someCid"; // TODO: Set real IDVTC tree CID
         // 1.5 -> 1.3

--- a/script/csm/DeployMainnet.s.sol
+++ b/script/csm/DeployMainnet.s.sol
@@ -84,9 +84,11 @@ contract DeployMainnet is DeployBase {
         // VettedGate
         config.identifiedCommunityStakersGateManager = 0xC52fC3081123073078698F1EAc2f1Dc7Bd71880f; // CSM Committee MS
         config.identifiedCommunityStakersGateCurveId = 2;
+        config.identifiedCommunityStakersGateName = "Identified Community Stakers Gate";
         config
             .identifiedCommunityStakersGateTreeRoot = 0x91545c42adde0f5d82e4c228f81449eab20349c1d31a8538e0468466f93495c5;
         config.identifiedCommunityStakersGateTreeCid = "bafkreido7ieacbe6nlhdivxfp2gd5kxovofngf6qdmahih4laihm675e2a";
+        config.identifiedDVTClusterGateName = "Identified DVT Cluster Gate";
         config.identifiedDVTClusterGateTreeRoot = bytes32(uint256(0xdeadbeef)); // TODO: Set real IDVTC tree root
         config.identifiedDVTClusterGateTreeCid = "someCid"; // TODO: Set real IDVTC tree CID
         // 1.5 -> 1.3

--- a/script/csm/DeployMainnet.s.sol
+++ b/script/csm/DeployMainnet.s.sol
@@ -88,7 +88,7 @@ contract DeployMainnet is DeployBase {
         config
             .identifiedCommunityStakersGateTreeRoot = 0x91545c42adde0f5d82e4c228f81449eab20349c1d31a8538e0468466f93495c5;
         config.identifiedCommunityStakersGateTreeCid = "bafkreido7ieacbe6nlhdivxfp2gd5kxovofngf6qdmahih4laihm675e2a";
-        config.identifiedDVTClusterGateName = "Identified DVT Cluster Gate";
+        config.identifiedDVTClusterGateName = "Identified DVT Clusters Gate";
         config.identifiedDVTClusterGateTreeRoot = bytes32(uint256(0xdeadbeef)); // TODO: Set real IDVTC tree root
         config.identifiedDVTClusterGateTreeCid = "someCid"; // TODO: Set real IDVTC tree CID
         // 1.5 -> 1.3

--- a/script/curated/DeployBase.s.sol
+++ b/script/curated/DeployBase.s.sol
@@ -51,6 +51,7 @@ struct GateCurveParams {
 }
 
 struct CuratedGateConfig {
+    string name;
     uint256[2][] bondCurve;
     bytes32 treeRoot;
     string treeCid;
@@ -590,7 +591,7 @@ abstract contract DeployBase is Script {
             uint256 gateCurveId = curveIds[i];
             CuratedGateConfig storage gateConfig = config.curatedGates[i];
             CuratedGate gate = CuratedGate(
-                gateFactory.create(gateCurveId, gateConfig.treeRoot, gateConfig.treeCid, deployer)
+                gateFactory.create(gateCurveId, gateConfig.treeRoot, gateConfig.treeCid, gateConfig.name, deployer)
             );
 
             {

--- a/script/curated/DeployHoodi.s.sol
+++ b/script/curated/DeployHoodi.s.sol
@@ -83,6 +83,7 @@ contract DeployHoodi is DeployBase {
         // Professional Operator Gate
         {
             CuratedGateConfig storage gate = config.curatedGates.push();
+            gate.name = "Professional Operator Gate";
             gate.treeRoot = bytes32(type(uint256).max);
             gate.treeCid = "QmU4cnyaKWgMVCZVLiuQaqu6yGXahjzi4F1Vcnq2SXBBmT";
             gate.params.metaRegistryBondCurveWeight = _m(50000);
@@ -91,6 +92,7 @@ contract DeployHoodi is DeployBase {
         // Professional Trusted Operator Gate
         {
             CuratedGateConfig storage gate = config.curatedGates.push();
+            gate.name = "Professional Trusted Operator Gate";
             gate.bondCurve.push([1, 11 ether]);
             gate.bondCurve.push([2, 0.1 ether]);
             gate.bondCurve.push([19, 0.7 ether]);
@@ -106,6 +108,7 @@ contract DeployHoodi is DeployBase {
         // Public Good Operator Gate
         {
             CuratedGateConfig storage gate = config.curatedGates.push();
+            gate.name = "Public Good Operator Gate";
             gate.bondCurve.push([1, 11 ether]);
             gate.bondCurve.push([2, 0.1 ether]);
             gate.bondCurve.push([19, 0.7 ether]);
@@ -121,6 +124,7 @@ contract DeployHoodi is DeployBase {
         // Decentralization Operator Gate
         {
             CuratedGateConfig storage gate = config.curatedGates.push();
+            gate.name = "Decentralization Operator Gate";
             gate.bondCurve.push([1, 11 ether]);
             gate.bondCurve.push([2, 0.1 ether]);
             gate.bondCurve.push([19, 0.7 ether]);
@@ -136,6 +140,7 @@ contract DeployHoodi is DeployBase {
         // Extra Effort Operator Gate
         {
             CuratedGateConfig storage gate = config.curatedGates.push();
+            gate.name = "Extra Effort Operator Gate";
             gate.bondCurve.push([1, 11 ether]);
             gate.bondCurve.push([2, 0.1 ether]);
             gate.bondCurve.push([19, 0.7 ether]);
@@ -151,6 +156,7 @@ contract DeployHoodi is DeployBase {
         // Intra-Operator DVT Cluster Gate
         {
             CuratedGateConfig storage gate = config.curatedGates.push();
+            gate.name = "Intra-Operator DVT Cluster Gate";
             gate.bondCurve.push([1, 11 ether]);
             gate.bondCurve.push([2, 0.1 ether]);
             gate.bondCurve.push([19, 0.7 ether]);
@@ -166,6 +172,7 @@ contract DeployHoodi is DeployBase {
         // Intra-Operator DVT Cluster Plus Gate (identical to the one above but with 4% fee)
         {
             CuratedGateConfig storage gate = config.curatedGates.push();
+            gate.name = "Intra-Operator DVT Cluster Plus Gate";
             gate.bondCurve.push([1, 11 ether]);
             gate.bondCurve.push([2, 0.1 ether]);
             gate.bondCurve.push([19, 0.7 ether]);

--- a/script/curated/DeployLocalDevNet.s.sol
+++ b/script/curated/DeployLocalDevNet.s.sol
@@ -73,6 +73,7 @@ contract DeployLocalDevNet is DeployBase {
         // Professional Operator Gate
         {
             CuratedGateConfig storage gate = config.curatedGates.push();
+            gate.name = "Professional Operator Gate";
             gate.treeRoot = bytes32(uint256(0xaaaabbbb)); // TODO: derive from final tree
             gate.treeCid = "TODO: ipfs-cid-cohort-a";
             gate.params.metaRegistryBondCurveWeight = _m(70000);
@@ -81,6 +82,7 @@ contract DeployLocalDevNet is DeployBase {
         // Professional Trusted Operator Gate
         {
             CuratedGateConfig storage gate = config.curatedGates.push();
+            gate.name = "Professional Trusted Operator Gate";
             gate.bondCurve.push([1, 11 ether]);
             gate.bondCurve.push([2, 0.1 ether]);
             gate.bondCurve.push([19, 0.7 ether]);
@@ -96,6 +98,7 @@ contract DeployLocalDevNet is DeployBase {
         // Public Good Operator Gate
         {
             CuratedGateConfig storage gate = config.curatedGates.push();
+            gate.name = "Public Good Operator Gate";
             gate.bondCurve.push([1, 11 ether]);
             gate.bondCurve.push([2, 0.1 ether]);
             gate.bondCurve.push([19, 0.7 ether]);
@@ -111,6 +114,7 @@ contract DeployLocalDevNet is DeployBase {
         // Decentralization Operator Gate
         {
             CuratedGateConfig storage gate = config.curatedGates.push();
+            gate.name = "Decentralization Operator Gate";
             gate.bondCurve.push([1, 11 ether]);
             gate.bondCurve.push([2, 0.1 ether]);
             gate.bondCurve.push([19, 0.7 ether]);
@@ -126,6 +130,7 @@ contract DeployLocalDevNet is DeployBase {
         // Extra Effort Operator Gate
         {
             CuratedGateConfig storage gate = config.curatedGates.push();
+            gate.name = "Extra Effort Operator Gate";
             gate.bondCurve.push([1, 11 ether]);
             gate.bondCurve.push([2, 0.1 ether]);
             gate.bondCurve.push([19, 0.7 ether]);
@@ -141,6 +146,7 @@ contract DeployLocalDevNet is DeployBase {
         // Intra-Operator DVT Cluster Gate
         {
             CuratedGateConfig storage gate = config.curatedGates.push();
+            gate.name = "Intra-Operator DVT Cluster Gate";
             gate.bondCurve.push([1, 11 ether]);
             gate.bondCurve.push([2, 0.1 ether]);
             gate.bondCurve.push([19, 0.7 ether]);
@@ -156,6 +162,7 @@ contract DeployLocalDevNet is DeployBase {
         // Intra-Operator DVT Cluster Plus Gate (identical to the one above but with 4% fee)
         {
             CuratedGateConfig storage gate = config.curatedGates.push();
+            gate.name = "Intra-Operator DVT Cluster Plus Gate";
             gate.bondCurve.push([1, 11 ether]);
             gate.bondCurve.push([2, 0.1 ether]);
             gate.bondCurve.push([19, 0.7 ether]);

--- a/script/curated/DeployMainnet.s.sol
+++ b/script/curated/DeployMainnet.s.sol
@@ -80,6 +80,7 @@ contract DeployMainnet is DeployBase {
         // Professional Operator Gate
         {
             CuratedGateConfig storage gate = config.curatedGates.push();
+            gate.name = "Professional Operator Gate";
             gate.treeRoot = bytes32(uint256(0xaaaabbbb)); // TODO: derive from final tree
             gate.treeCid = "TODO: ipfs-cid-cohort-a";
             gate.params.metaRegistryBondCurveWeight = _m(50000);
@@ -88,6 +89,7 @@ contract DeployMainnet is DeployBase {
         // Professional Trusted Operator Gate
         {
             CuratedGateConfig storage gate = config.curatedGates.push();
+            gate.name = "Professional Trusted Operator Gate";
             gate.bondCurve.push([1, 11 ether]);
             gate.bondCurve.push([2, 0.1 ether]);
             gate.bondCurve.push([19, 0.7 ether]);
@@ -103,6 +105,7 @@ contract DeployMainnet is DeployBase {
         // Public Good Operator Gate
         {
             CuratedGateConfig storage gate = config.curatedGates.push();
+            gate.name = "Public Good Operator Gate";
             gate.bondCurve.push([1, 11 ether]);
             gate.bondCurve.push([2, 0.1 ether]);
             gate.bondCurve.push([19, 0.7 ether]);
@@ -118,6 +121,7 @@ contract DeployMainnet is DeployBase {
         // Decentralization Operator Gate
         {
             CuratedGateConfig storage gate = config.curatedGates.push();
+            gate.name = "Decentralization Operator Gate";
             gate.bondCurve.push([1, 11 ether]);
             gate.bondCurve.push([2, 0.1 ether]);
             gate.bondCurve.push([19, 0.7 ether]);
@@ -133,6 +137,7 @@ contract DeployMainnet is DeployBase {
         // Extra Effort Operator Gate
         {
             CuratedGateConfig storage gate = config.curatedGates.push();
+            gate.name = "Extra Effort Operator Gate";
             gate.bondCurve.push([1, 11 ether]);
             gate.bondCurve.push([2, 0.1 ether]);
             gate.bondCurve.push([19, 0.7 ether]);
@@ -148,6 +153,7 @@ contract DeployMainnet is DeployBase {
         // Intra-Operator DVT Cluster Gate
         {
             CuratedGateConfig storage gate = config.curatedGates.push();
+            gate.name = "Intra-Operator DVT Cluster Gate";
             gate.bondCurve.push([1, 11 ether]);
             gate.bondCurve.push([2, 0.1 ether]);
             gate.bondCurve.push([19, 0.7 ether]);
@@ -163,6 +169,7 @@ contract DeployMainnet is DeployBase {
         // Intra-Operator DVT Cluster Plus Gate (identical to the one above but with 4% fee)
         {
             CuratedGateConfig storage gate = config.curatedGates.push();
+            gate.name = "Intra-Operator DVT Cluster Plus Gate";
             gate.bondCurve.push([1, 11 ether]);
             gate.bondCurve.push([2, 0.1 ether]);
             gate.bondCurve.push([19, 0.7 ether]);

--- a/script/fork-helpers/SimulateVote.s.sol
+++ b/script/fork-helpers/SimulateVote.s.sol
@@ -345,8 +345,10 @@ contract SimulateVote is Script, ForkHelpersCommon {
             // 31-32. Revoke legacy referral program roles
             existingVettedGate.revokeRole(START_REFERRAL_SEASON_ROLE, deployParams.aragonAgent);
             existingVettedGate.revokeRole(END_REFERRAL_SEASON_ROLE, deployParams.identifiedCommunityStakersGateManager);
+            // 33. Set human-readable name for migrated Identified Community Stakers gate
+            existingVettedGate.setName(deployParams.identifiedCommunityStakersGateName);
 
-            // 33-42. Setup CircuitBreaker: grant PAUSE_ROLE and register pausers
+            // 34-43. Setup CircuitBreaker: grant PAUSE_ROLE and register pausers
             if (deploymentConfig.circuitBreaker != address(0)) {
                 module.grantRole(module.PAUSE_ROLE(), deploymentConfig.circuitBreaker);
                 accounting.grantRole(accounting.PAUSE_ROLE(), deploymentConfig.circuitBreaker);
@@ -369,11 +371,11 @@ contract SimulateVote is Script, ForkHelpersCommon {
                 console.log("CircuitBreaker is not configured");
             }
 
-            // 43-44. Grant Identified DVT Cluster gate permissions
+            // 44-45. Grant Identified DVT Cluster gate permissions
             module.grantRole(module.CREATE_NODE_OPERATOR_ROLE(), deploymentConfig.identifiedDVTClusterGate);
             accounting.grantRole(accounting.SET_BOND_CURVE_ROLE(), deploymentConfig.identifiedDVTClusterGate);
 
-            // 45-47. Deploy Identified DVT Cluster bond curve and parameter overrides
+            // 46-48. Deploy Identified DVT Cluster bond curve and parameter overrides
             accounting.grantRole(accounting.MANAGE_BOND_CURVES_ROLE(), deploymentConfig.identifiedDVTClusterCurveSetup);
             parametersRegistry.grantRole(
                 parametersRegistry.MANAGE_CURVE_PARAMETERS_ROLE(),
@@ -381,7 +383,7 @@ contract SimulateVote is Script, ForkHelpersCommon {
             );
             OneShotCurveSetup(deploymentConfig.identifiedDVTClusterCurveSetup).execute();
 
-            // 48. Grant MANAGE_GENERAL_PENALTIES_AND_CHARGES_ROLE to penaltiesManager
+            // 49. Grant MANAGE_GENERAL_PENALTIES_AND_CHARGES_ROLE to penaltiesManager
             parametersRegistry.grantRole(
                 parametersRegistry.MANAGE_GENERAL_PENALTIES_AND_CHARGES_ROLE(),
                 deployParams.penaltiesManager
@@ -392,9 +394,9 @@ contract SimulateVote is Script, ForkHelpersCommon {
 
         {
             vm.startBroadcast(burnerAdmin);
-            // 49. Revoke REQUEST_BURN_SHARES_ROLE from Accounting
+            // 50. Revoke REQUEST_BURN_SHARES_ROLE from Accounting
             burner.revokeRole(burner.REQUEST_BURN_SHARES_ROLE(), address(accounting));
-            // 50. Grant REQUEST_BURN_MY_STETH_ROLE to Accounting
+            // 51. Grant REQUEST_BURN_MY_STETH_ROLE to Accounting
             burner.grantRole(burner.REQUEST_BURN_MY_STETH_ROLE(), address(accounting));
             vm.stopBroadcast();
         }
@@ -406,9 +408,9 @@ contract SimulateVote is Script, ForkHelpersCommon {
             address twgAdmin = _prepareAdmin(address(twg));
 
             vm.startBroadcast(twgAdmin);
-            // 51. Revoke TWG full-withdrawal role from old Ejector
+            // 52. Revoke TWG full-withdrawal role from old Ejector
             twg.revokeRole(twg.ADD_FULL_WITHDRAWAL_REQUEST_ROLE(), oldEjector);
-            // 52. Grant TWG full-withdrawal role to new Ejector
+            // 53. Grant TWG full-withdrawal role to new Ejector
             twg.grantRole(twg.ADD_FULL_WITHDRAWAL_REQUEST_ROLE(), deploymentConfig.ejector);
             vm.stopBroadcast();
         }

--- a/src/CuratedGate.sol
+++ b/src/CuratedGate.sol
@@ -41,9 +41,10 @@ contract CuratedGate is ICuratedGate, MerkleGate {
         uint256 curveId,
         bytes32 treeRoot,
         string calldata treeCid,
+        string calldata name,
         address admin
     ) public override(IMerkleGate, MerkleGate) initializer {
-        super.initialize(curveId, treeRoot, treeCid, admin);
+        super.initialize({ curveId_: curveId, treeRoot_: treeRoot, treeCid_: treeCid, name_: name, admin: admin });
     }
 
     /// @inheritdoc ICuratedGate

--- a/src/MerkleGateFactory.sol
+++ b/src/MerkleGateFactory.sol
@@ -20,10 +20,17 @@ contract MerkleGateFactory is IMerkleGateFactory {
         uint256 curveId,
         bytes32 treeRoot,
         string calldata treeCid,
+        string calldata name,
         address admin
     ) external returns (address instance) {
         instance = address(new OssifiableProxy({ implementation_: GATE_IMPL, data_: "", admin_: admin }));
-        IMerkleGate(instance).initialize(curveId, treeRoot, treeCid, admin);
+        IMerkleGate(instance).initialize({
+            curveId: curveId,
+            treeRoot: treeRoot,
+            treeCid: treeCid,
+            name: name,
+            admin: admin
+        });
 
         emit MerkleGateCreated(instance, admin, curveId);
     }

--- a/src/VettedGate.sol
+++ b/src/VettedGate.sol
@@ -31,10 +31,11 @@ contract VettedGate is IVettedGate, MerkleGate {
         uint256 curveId,
         bytes32 treeRoot,
         string calldata treeCid,
+        string calldata name,
         address admin
     ) public override(IMerkleGate, MerkleGate) initializer {
         if (curveId == ACCOUNTING.DEFAULT_BOND_CURVE_ID()) revert InvalidCurveId();
-        super.initialize(curveId, treeRoot, treeCid, admin);
+        super.initialize({ curveId_: curveId, treeRoot_: treeRoot, treeCid_: treeCid, name_: name, admin: admin });
     }
 
     /// @inheritdoc IVettedGate

--- a/src/abstract/MerkleGate.sol
+++ b/src/abstract/MerkleGate.sol
@@ -8,12 +8,19 @@ import { MerkleProof } from "@openzeppelin/contracts/utils/cryptography/MerklePr
 import { Strings } from "@openzeppelin/contracts/utils/Strings.sol";
 
 import { AssetRecoverer } from "./AssetRecoverer.sol";
+import { NamedUpgradeable } from "./NamedUpgradeable.sol";
 import { PausableWithRoles } from "./PausableWithRoles.sol";
 
 import { IMerkleGate } from "../interfaces/IMerkleGate.sol";
 
 /// @notice Shared Merkle-based gate logic for gated node-operator flows.
-abstract contract MerkleGate is IMerkleGate, AccessControlEnumerableUpgradeable, PausableWithRoles, AssetRecoverer {
+abstract contract MerkleGate is
+    IMerkleGate,
+    NamedUpgradeable,
+    AccessControlEnumerableUpgradeable,
+    PausableWithRoles,
+    AssetRecoverer
+{
     bytes32 public constant SET_TREE_ROLE = keccak256("SET_TREE_ROLE");
 
     /// @notice Id of the bond curve to be assigned for eligible members.
@@ -29,14 +36,10 @@ abstract contract MerkleGate is IMerkleGate, AccessControlEnumerableUpgradeable,
     mapping(address => bool) internal _consumedAddresses;
 
     /// @inheritdoc IMerkleGate
-    string public name;
-
-    /// @inheritdoc IMerkleGate
     function setTreeParams(bytes32 treeRoot_, string calldata treeCid_) external onlyRole(SET_TREE_ROLE) {
         _setTreeParams(treeRoot_, treeCid_);
     }
 
-    /// @inheritdoc IMerkleGate
     function setName(string calldata name_) external onlyRole(DEFAULT_ADMIN_ROLE) {
         _setName(name_);
     }
@@ -94,15 +97,6 @@ abstract contract MerkleGate is IMerkleGate, AccessControlEnumerableUpgradeable,
         treeCid = treeCid_;
 
         emit TreeSet(treeRoot_, treeCid_);
-    }
-
-    function _setName(string calldata name_) internal {
-        if (bytes(name_).length == 0) revert InvalidName();
-        if (Strings.equal(name_, name)) revert InvalidName();
-
-        name = name_;
-
-        emit NameSet(name_);
     }
 
     function _onlyRecoverer() internal view override {

--- a/src/abstract/MerkleGate.sol
+++ b/src/abstract/MerkleGate.sol
@@ -29,8 +29,16 @@ abstract contract MerkleGate is IMerkleGate, AccessControlEnumerableUpgradeable,
     mapping(address => bool) internal _consumedAddresses;
 
     /// @inheritdoc IMerkleGate
+    string public name;
+
+    /// @inheritdoc IMerkleGate
     function setTreeParams(bytes32 treeRoot_, string calldata treeCid_) external onlyRole(SET_TREE_ROLE) {
         _setTreeParams(treeRoot_, treeCid_);
+    }
+
+    /// @inheritdoc IMerkleGate
+    function setName(string calldata name_) external onlyRole(DEFAULT_ADMIN_ROLE) {
+        _setName(name_);
     }
 
     /// @inheritdoc IMerkleGate
@@ -43,11 +51,13 @@ abstract contract MerkleGate is IMerkleGate, AccessControlEnumerableUpgradeable,
         uint256 curveId_,
         bytes32 treeRoot_,
         string calldata treeCid_,
+        string calldata name_,
         address admin
     ) public virtual onlyInitializing {
         if (admin == address(0)) revert ZeroAdminAddress();
         curveId = curveId_;
         _setTreeParams(treeRoot_, treeCid_);
+        _setName(name_);
         _grantRole(DEFAULT_ADMIN_ROLE, admin);
     }
 
@@ -84,6 +94,15 @@ abstract contract MerkleGate is IMerkleGate, AccessControlEnumerableUpgradeable,
         treeCid = treeCid_;
 
         emit TreeSet(treeRoot_, treeCid_);
+    }
+
+    function _setName(string calldata name_) internal {
+        if (bytes(name_).length == 0) revert InvalidName();
+        if (Strings.equal(name_, name)) revert InvalidName();
+
+        name = name_;
+
+        emit NameSet(name_);
     }
 
     function _onlyRecoverer() internal view override {

--- a/src/abstract/NamedUpgradeable.sol
+++ b/src/abstract/NamedUpgradeable.sol
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: 2026 Lido <info@lido.fi>
+// SPDX-License-Identifier: GPL-3.0
+
+pragma solidity 0.8.33;
+
+import { Strings } from "@openzeppelin/contracts/utils/Strings.sol";
+
+import { INamedUpgradeable } from "../interfaces/INamedUpgradeable.sol";
+
+abstract contract NamedUpgradeable is INamedUpgradeable {
+    uint256 internal constant MAX_NAME_LENGTH = 256;
+
+    /// @custom:storage-location erc7201:NamedUpgradeable
+    struct NamedUpgradeableStorage {
+        string name;
+    }
+
+    // keccak256(abi.encode(uint256(keccak256("NamedUpgradeable")) - 1)) & ~bytes32(uint256(0xff))
+    bytes32 private constant NAMED_UPGRADEABLE_STORAGE_LOCATION =
+        0xf31ae013a5af13f77f257862ecd68bd4c15a1f200f6be2d419997a40372cfa00;
+
+    /// @inheritdoc INamedUpgradeable
+    function name() public view returns (string memory) {
+        return _getNamedUpgradeableStorage().name;
+    }
+
+    function _setName(string calldata name_) internal {
+        if (bytes(name_).length == 0) revert InvalidName();
+        if (bytes(name_).length > MAX_NAME_LENGTH) revert InvalidName();
+
+        NamedUpgradeableStorage storage $ = _getNamedUpgradeableStorage();
+        if (Strings.equal(name_, $.name)) revert InvalidName();
+
+        $.name = name_;
+
+        emit NameSet(name_);
+    }
+
+    function _getNamedUpgradeableStorage() private pure returns (NamedUpgradeableStorage storage $) {
+        assembly {
+            $.slot := NAMED_UPGRADEABLE_STORAGE_LOCATION
+        }
+    }
+}

--- a/src/interfaces/IMerkleGate.sol
+++ b/src/interfaces/IMerkleGate.sol
@@ -3,9 +3,11 @@
 
 pragma solidity 0.8.33;
 
+import { INamedUpgradeable } from "./INamedUpgradeable.sol";
+
 /// @title Merkle Gate Interface
 /// @notice Common surface for gates that guard node operator creation via Merkle proofs.
-interface IMerkleGate {
+interface IMerkleGate is INamedUpgradeable {
     /// @notice Emitted when a new Merkle tree is set
     /// @param treeRoot Root of the Merkle tree
     /// @param treeCid CID of the Merkle tree
@@ -15,16 +17,11 @@ interface IMerkleGate {
     /// @param member Address that consumed eligibility
     event Consumed(address indexed member);
 
-    /// @notice Emitted when the gate display name is set
-    /// @param name Human-readable gate name
-    event NameSet(string name);
-
     /// Errors
     error InvalidProof();
     error AlreadyConsumed();
     error InvalidTreeRoot();
     error InvalidTreeCid();
-    error InvalidName();
     error ZeroAdminAddress();
 
     /// @return SET_TREE_ROLE role required to update tree parameters
@@ -36,9 +33,6 @@ interface IMerkleGate {
     /// @return treeCid Current Merkle tree CID
     function treeCid() external view returns (string memory);
 
-    /// @return name Human-readable gate name
-    function name() external view returns (string memory);
-
     /// @return curveId Instance-specific bond curve id
     function curveId() external view returns (uint256);
 
@@ -46,10 +40,6 @@ interface IMerkleGate {
     /// @param _treeRoot New root
     /// @param _treeCid New CID
     function setTreeParams(bytes32 _treeRoot, string calldata _treeCid) external;
-
-    /// @notice Update the human-readable gate name
-    /// @param name New gate name
-    function setName(string calldata name) external;
 
     /// @notice Returns whether a member already consumed eligibility
     function isConsumed(address member) external view returns (bool);

--- a/src/interfaces/IMerkleGate.sol
+++ b/src/interfaces/IMerkleGate.sol
@@ -15,11 +15,16 @@ interface IMerkleGate {
     /// @param member Address that consumed eligibility
     event Consumed(address indexed member);
 
+    /// @notice Emitted when the gate display name is set
+    /// @param name Human-readable gate name
+    event NameSet(string name);
+
     /// Errors
     error InvalidProof();
     error AlreadyConsumed();
     error InvalidTreeRoot();
     error InvalidTreeCid();
+    error InvalidName();
     error ZeroAdminAddress();
 
     /// @return SET_TREE_ROLE role required to update tree parameters
@@ -31,6 +36,9 @@ interface IMerkleGate {
     /// @return treeCid Current Merkle tree CID
     function treeCid() external view returns (string memory);
 
+    /// @return name Human-readable gate name
+    function name() external view returns (string memory);
+
     /// @return curveId Instance-specific bond curve id
     function curveId() external view returns (uint256);
 
@@ -38,6 +46,10 @@ interface IMerkleGate {
     /// @param _treeRoot New root
     /// @param _treeCid New CID
     function setTreeParams(bytes32 _treeRoot, string calldata _treeCid) external;
+
+    /// @notice Update the human-readable gate name
+    /// @param name New gate name
+    function setName(string calldata name) external;
 
     /// @notice Returns whether a member already consumed eligibility
     function isConsumed(address member) external view returns (bool);
@@ -52,8 +64,15 @@ interface IMerkleGate {
     /// @param curveId Bond curve id used by the gate.
     /// @param treeRoot Initial Merkle tree root.
     /// @param treeCid Initial Merkle tree CID.
+    /// @param name Human-readable gate name.
     /// @param admin Address to be granted DEFAULT_ADMIN_ROLE.
-    function initialize(uint256 curveId, bytes32 treeRoot, string calldata treeCid, address admin) external;
+    function initialize(
+        uint256 curveId,
+        bytes32 treeRoot,
+        string calldata treeCid,
+        string calldata name,
+        address admin
+    ) external;
 
     /// @notice Initialized version for upgradeable tooling
     function getInitializedVersion() external view returns (uint64);

--- a/src/interfaces/IMerkleGateFactory.sol
+++ b/src/interfaces/IMerkleGateFactory.sol
@@ -15,12 +15,14 @@ interface IMerkleGateFactory {
     /// @param curveId Bond curve id to assign to eligible members.
     /// @param treeRoot Initial Merkle tree root.
     /// @param treeCid Initial Merkle tree CID.
+    /// @param name Human-readable gate name.
     /// @param admin Address of the proxy admin and DEFAULT_ADMIN_ROLE holder.
     /// @return instance Address of the created proxy instance.
     function create(
         uint256 curveId,
         bytes32 treeRoot,
         string calldata treeCid,
+        string calldata name,
         address admin
     ) external returns (address instance);
 }

--- a/src/interfaces/INamedUpgradeable.sol
+++ b/src/interfaces/INamedUpgradeable.sol
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: 2026 Lido <info@lido.fi>
+// SPDX-License-Identifier: GPL-3.0
+
+pragma solidity 0.8.33;
+
+/// @title Named Upgradeable Interface
+/// @notice Common surface for contracts with an upgrade-safe human-readable name.
+interface INamedUpgradeable {
+    /// @notice Emitted when the display name is set
+    /// @param name Human-readable name
+    event NameSet(string name);
+
+    error InvalidName();
+
+    /// @return name Human-readable name
+    function name() external view returns (string memory);
+
+    /// @notice Update the human-readable name
+    /// @param name New name
+    function setName(string calldata name) external;
+}

--- a/test/fork/deployment/PostDeploymentCSM.t.sol
+++ b/test/fork/deployment/PostDeploymentCSM.t.sol
@@ -344,6 +344,8 @@ abstract contract VettedGateDeploymentBaseTest is DeploymentBaseTest {
 
     function _expectedTreeCid() internal view virtual returns (string memory);
 
+    function _expectedName() internal view virtual returns (string memory);
+
     function _expectedPauseRoleMembersWithoutCb() internal view virtual returns (uint256) {
         return 1;
     }
@@ -396,6 +398,7 @@ abstract contract VettedGateDeploymentBaseTest is DeploymentBaseTest {
             curveId: 1,
             treeRoot: _expectedTreeRoot(),
             treeCid: _expectedTreeCid(),
+            name: _expectedName(),
             admin: deployParams.aragonAgent
         });
 
@@ -404,6 +407,7 @@ abstract contract VettedGateDeploymentBaseTest is DeploymentBaseTest {
             curveId: 1,
             treeRoot: _expectedTreeRoot(),
             treeCid: _expectedTreeCid(),
+            name: _expectedName(),
             admin: deployParams.aragonAgent
         });
     }
@@ -444,6 +448,14 @@ contract IdentifiedCommunityStakersGateDeploymentTest is VettedGateDeploymentBas
         return deployParams.identifiedCommunityStakersGateTreeCid;
     }
 
+    function _expectedName() internal view override returns (string memory) {
+        return deployParams.identifiedCommunityStakersGateName;
+    }
+
+    function test_name_afterVote() public view {
+        assertEq(_gate().name(), _expectedName());
+    }
+
     function _expectedPauseRoleMembersWithoutCb() internal view override returns (uint256) {
         return _expectedPauseRoleMembersWithoutCb(isUpgradeFlow);
     }
@@ -464,6 +476,14 @@ contract IdentifiedDVTClusterGateDeploymentTest is VettedGateDeploymentBaseTest 
 
     function _expectedTreeCid() internal view override returns (string memory) {
         return deployParams.identifiedDVTClusterGateTreeCid;
+    }
+
+    function _expectedName() internal view override returns (string memory) {
+        return deployParams.identifiedDVTClusterGateName;
+    }
+
+    function test_name() public view {
+        assertEq(_gate().name(), _expectedName());
     }
 }
 

--- a/test/fork/deployment/PostDeploymentCurated.t.sol
+++ b/test/fork/deployment/PostDeploymentCurated.t.sol
@@ -152,6 +152,7 @@ contract CuratedGatesDeploymentTest is DeploymentBaseTest {
             CuratedGateConfig storage cfg = deployParams.curatedGates[i];
             assertEq(gate.treeRoot(), cfg.treeRoot, "unexpected gate root");
             assertEq(gate.treeCid(), cfg.treeCid, "unexpected gate cid");
+            assertEq(gate.name(), cfg.name, "unexpected gate name");
             assertEq(gate.curveId(), _expectedCurveId(i), "unexpected gate curve");
         }
     }
@@ -178,6 +179,7 @@ contract CuratedGatesDeploymentTest is DeploymentBaseTest {
 
             assertEq(gate.treeRoot(), deployParams.curatedGates[i].treeRoot);
             assertEq(gate.treeCid(), deployParams.curatedGates[i].treeCid);
+            assertEq(gate.name(), deployParams.curatedGates[i].name);
             assertEq(gate.curveId(), _expectedCurveId(i));
         }
     }

--- a/test/fork/integration/csm/Misc.t.sol
+++ b/test/fork/integration/csm/Misc.t.sol
@@ -21,9 +21,10 @@ contract VettedGateFactoryTest is MiscTest {
         uint256 curveId = 1;
         bytes32 root = merkleTree.root();
         string memory cid = "someOtherCid";
+        string memory name = "Other Vetted Gate";
 
         vm.startSnapshotGas("VettedGateFactory.createVetted");
-        address instance = vettedGateFactory.create(curveId, root, cid, address(this));
+        address instance = vettedGateFactory.create(curveId, root, cid, name, address(this));
         vm.stopSnapshotGas();
 
         VettedGate gate = VettedGate(instance);
@@ -31,6 +32,7 @@ contract VettedGateFactoryTest is MiscTest {
         assertEq(address(gate.MODULE()), address(module));
         assertEq(gate.treeRoot(), root);
         assertEq(gate.treeCid(), cid);
+        assertEq(gate.name(), name);
         assertEq(gate.getRoleMemberCount(gate.DEFAULT_ADMIN_ROLE()), 1);
         assertTrue(gate.hasRole(gate.DEFAULT_ADMIN_ROLE(), address(this)));
     }

--- a/test/fork/integration/curated/CuratedGateFactory.t.sol
+++ b/test/fork/integration/curated/CuratedGateFactory.t.sol
@@ -17,11 +17,12 @@ contract CuratedGateFactoryTest is CuratedIntegrationBase {
         tree.pushLeaf(abi.encode(nextAddress()));
         bytes32 root = tree.root();
         string memory cid = "curatedCid";
+        string memory name = "Other Curated Gate";
         uint256 curveId = 1;
         address admin = nextAddress("GateAdmin");
 
         vm.startSnapshotGas("CuratedGateFactory.createCurated");
-        address instance = curatedGateFactory.create(curveId, root, cid, admin);
+        address instance = curatedGateFactory.create(curveId, root, cid, name, admin);
         vm.stopSnapshotGas();
 
         CuratedGate gate = CuratedGate(instance);
@@ -31,6 +32,7 @@ contract CuratedGateFactoryTest is CuratedIntegrationBase {
         assertEq(address(gate.META_REGISTRY()), address(metaRegistry));
         assertEq(gate.treeRoot(), root);
         assertEq(gate.treeCid(), cid);
+        assertEq(gate.name(), name);
         assertEq(gate.getRoleMemberCount(gate.DEFAULT_ADMIN_ROLE()), 1);
         assertTrue(gate.hasRole(gate.DEFAULT_ADMIN_ROLE(), admin));
     }

--- a/test/fork/vote-upgrade/V3Upgrade.t.sol
+++ b/test/fork/vote-upgrade/V3Upgrade.t.sol
@@ -618,6 +618,11 @@ contract VoteChangesTest is V3UpgradeTestBase {
             keccak256(bytes(deployParams.identifiedDVTClusterGateTreeCid)),
             "gate tree cid"
         );
+        assertEq(
+            keccak256(bytes(gate.name())),
+            keccak256(bytes(deployParams.identifiedDVTClusterGateName)),
+            "gate name"
+        );
 
         assertTrue(gate.hasRole(gate.DEFAULT_ADMIN_ROLE(), deployParams.aragonAgent), "gate aragon admin");
         if (deployParams.secondAdminAddress != address(0)) {
@@ -800,6 +805,10 @@ contract VoteChangesTest is V3UpgradeTestBase {
         assertEq(vettedGate.getInitializedVersion(), versionBefore);
         assertEq(vettedGate.treeRoot(), treeRootBefore);
         assertEq(keccak256(bytes(vettedGate.treeCid())), keccak256(bytes(treeCidBefore)));
+        assertEq(
+            keccak256(bytes(vettedGate.name())),
+            keccak256(bytes(deployParams.identifiedCommunityStakersGateName))
+        );
 
         // TODO: Tighten to the final exact count once CircuitBreaker is live and migration is done.
         _assertCircuitBreakerPauseRoleState(

--- a/test/unit/CuratedGate.t.sol
+++ b/test/unit/CuratedGate.t.sol
@@ -9,6 +9,7 @@ import { PausableUntil } from "src/lib/utils/PausableUntil.sol";
 import { CuratedGate } from "src/CuratedGate.sol";
 import { ICuratedGate } from "src/interfaces/ICuratedGate.sol";
 import { IMerkleGate } from "src/interfaces/IMerkleGate.sol";
+import { INamedUpgradeable } from "src/interfaces/INamedUpgradeable.sol";
 import { IMetaRegistry, OperatorMetadata } from "src/interfaces/IMetaRegistry.sol";
 import { IBaseModule, NodeOperatorManagementProperties } from "src/interfaces/IBaseModule.sol";
 import { IAccounting } from "src/interfaces/IAccounting.sol";
@@ -73,6 +74,10 @@ contract CuratedGateTestBase is Test, Utilities, Fixtures {
     function curveId() internal view virtual returns (uint256) {
         return 1;
     }
+
+    function _tooLongName() internal pure returns (string memory) {
+        return string(new bytes(257));
+    }
 }
 
 contract CuratedGateTestBaseDefaultCurve is CuratedGateTestBase {
@@ -130,8 +135,15 @@ contract CuratedGateTest_initialize is CuratedGateTestBase {
     function test_initialize_RevertWhen_InvalidName() public {
         CuratedGate g = new CuratedGate(address(module));
         _enableInitializers(address(g));
-        vm.expectRevert(IMerkleGate.InvalidName.selector);
+        vm.expectRevert(INamedUpgradeable.InvalidName.selector);
         g.initialize(1, root, cid, "", admin);
+    }
+
+    function test_initialize_RevertWhen_NameTooLong() public {
+        CuratedGate g = new CuratedGate(address(module));
+        _enableInitializers(address(g));
+        vm.expectRevert(INamedUpgradeable.InvalidName.selector);
+        g.initialize(1, root, cid, _tooLongName(), admin);
     }
 
     function test_initialize_AllowsDefaultCurveId() public {
@@ -148,11 +160,17 @@ contract CuratedGateTest_setName is CuratedGateTestBase {
         string memory newName = "Renamed Gate";
 
         vm.expectEmit(address(gate));
-        emit IMerkleGate.NameSet(newName);
+        emit INamedUpgradeable.NameSet(newName);
         vm.prank(admin);
         gate.setName(newName);
 
         assertEq(keccak256(bytes(gate.name())), keccak256(bytes(newName)));
+    }
+
+    function test_setName_RevertWhen_NameTooLong() public {
+        vm.expectRevert(INamedUpgradeable.InvalidName.selector);
+        vm.prank(admin);
+        gate.setName(_tooLongName());
     }
 }
 

--- a/test/unit/CuratedGate.t.sol
+++ b/test/unit/CuratedGate.t.sol
@@ -33,6 +33,7 @@ contract CuratedGateTestBase is Test, Utilities, Fixtures {
     MerkleTree internal tree;
     bytes32 internal root;
     string internal cid;
+    string internal gateName;
 
     function setUp() public virtual {
         admin = nextAddress("ADMIN");
@@ -58,10 +59,11 @@ contract CuratedGateTestBase is Test, Utilities, Fixtures {
         tree.pushLeaf(abi.encode(member2));
         root = tree.root();
         cid = someCIDv0();
+        gateName = "Professional Operator Gate";
 
         gate = new CuratedGate(address(module));
         _enableInitializers(address(gate));
-        gate.initialize(curveId(), root, cid, admin);
+        gate.initialize(curveId(), root, cid, gateName, admin);
 
         vm.startPrank(admin);
         gate.grantRole(gate.SET_TREE_ROLE(), admin);
@@ -96,9 +98,10 @@ contract CuratedGateTest_initialize is CuratedGateTestBase {
     function test_initialize() public {
         CuratedGate g = new CuratedGate(address(module));
         _enableInitializers(address(g));
-        g.initialize(1, root, cid, admin);
+        g.initialize(1, root, cid, gateName, admin);
         assertEq(g.treeRoot(), root);
         assertEq(keccak256(bytes(g.treeCid())), keccak256(bytes(cid)));
+        assertEq(keccak256(bytes(g.name())), keccak256(bytes(gateName)));
         assertTrue(g.hasRole(g.DEFAULT_ADMIN_ROLE(), admin));
         assertEq(g.curveId(), 1);
     }
@@ -107,29 +110,49 @@ contract CuratedGateTest_initialize is CuratedGateTestBase {
         CuratedGate g = new CuratedGate(address(module));
         _enableInitializers(address(g));
         vm.expectRevert(IMerkleGate.ZeroAdminAddress.selector);
-        g.initialize(1, root, cid, address(0));
+        g.initialize(1, root, cid, gateName, address(0));
     }
 
     function test_initialize_RevertWhen_InvalidTreeRoot() public {
         CuratedGate g = new CuratedGate(address(module));
         _enableInitializers(address(g));
         vm.expectRevert(IMerkleGate.InvalidTreeRoot.selector);
-        g.initialize(1, bytes32(0), cid, admin);
+        g.initialize(1, bytes32(0), cid, gateName, admin);
     }
 
     function test_initialize_RevertWhen_InvalidTreeCid() public {
         CuratedGate g = new CuratedGate(address(module));
         _enableInitializers(address(g));
         vm.expectRevert(IMerkleGate.InvalidTreeCid.selector);
-        g.initialize(1, root, "", admin);
+        g.initialize(1, root, "", gateName, admin);
+    }
+
+    function test_initialize_RevertWhen_InvalidName() public {
+        CuratedGate g = new CuratedGate(address(module));
+        _enableInitializers(address(g));
+        vm.expectRevert(IMerkleGate.InvalidName.selector);
+        g.initialize(1, root, cid, "", admin);
     }
 
     function test_initialize_AllowsDefaultCurveId() public {
         CuratedGate g = new CuratedGate(address(module));
         _enableInitializers(address(g));
         uint256 defaultCurveId = module.ACCOUNTING().DEFAULT_BOND_CURVE_ID();
-        g.initialize(defaultCurveId, root, cid, admin);
+        g.initialize(defaultCurveId, root, cid, gateName, admin);
         assertEq(g.curveId(), defaultCurveId);
+    }
+}
+
+contract CuratedGateTest_setName is CuratedGateTestBase {
+    function test_setName() public {
+        string memory newName = "Renamed Gate";
+
+        vm.expectEmit(address(gate));
+        emit IMerkleGate.NameSet(newName);
+        vm.prank(admin);
+        gate.setName(newName);
+
+        assertEq(keccak256(bytes(gate.name())), keccak256(bytes(newName)));
     }
 }
 

--- a/test/unit/MerkleGateFactory.t.sol
+++ b/test/unit/MerkleGateFactory.t.sol
@@ -20,12 +20,14 @@ import { MetaRegistryMock } from "../helpers/mocks/MetaRegistryMock.sol";
 contract MerkleGateFactoryTest is Test, Utilities {
     bytes32 internal root;
     string internal cid;
+    string internal name;
     uint256 internal curveId;
     address internal admin;
 
     function setUp() public {
         root = bytes32(randomBytes(32));
         cid = "someCid";
+        name = "Identified Community Stakers Gate";
         curveId = 1;
         admin = nextAddress("admin");
     }
@@ -39,13 +41,14 @@ contract MerkleGateFactoryTest is Test, Utilities {
         vm.expectEmit(address(factory));
         emit IMerkleGateFactory.MerkleGateCreated(expectedInstance, admin, curveId);
 
-        address instance = factory.create(curveId, root, cid, admin);
+        address instance = factory.create(curveId, root, cid, name, admin);
         IVettedGate gate = IVettedGate(instance);
 
         assertEq(gate.curveId(), curveId);
         assertEq(address(gate.MODULE()), address(csm));
         assertEq(gate.treeRoot(), root);
         assertEq(gate.treeCid(), cid);
+        assertEq(gate.name(), name);
 
         AccessControlEnumerableUpgradeable access = AccessControlEnumerableUpgradeable(instance);
         assertEq(access.getRoleMemberCount(access.DEFAULT_ADMIN_ROLE()), 1);
@@ -67,7 +70,7 @@ contract MerkleGateFactoryTest is Test, Utilities {
         vm.expectEmit(address(factory));
         emit IMerkleGateFactory.MerkleGateCreated(expectedInstance, admin, curveId);
 
-        address instance = factory.create(curveId, root, cid, admin);
+        address instance = factory.create(curveId, root, cid, name, admin);
         ICuratedGate gate = ICuratedGate(instance);
 
         assertEq(gate.curveId(), curveId);
@@ -75,6 +78,7 @@ contract MerkleGateFactoryTest is Test, Utilities {
         assertEq(address(gate.META_REGISTRY()), address(metaRegistry));
         assertEq(gate.treeRoot(), root);
         assertEq(gate.treeCid(), cid);
+        assertEq(gate.name(), name);
 
         AccessControlEnumerableUpgradeable access = AccessControlEnumerableUpgradeable(instance);
         assertEq(access.getRoleMemberCount(access.DEFAULT_ADMIN_ROLE()), 1);
@@ -102,7 +106,7 @@ contract MerkleGateFactoryTest is Test, Utilities {
         vm.expectEmit(address(factory));
         emit IMerkleGateFactory.MerkleGateCreated(expectedInstance, admin, curveId);
 
-        address instance = factory.create(curveId, root, cid, admin);
+        address instance = factory.create(curveId, root, cid, name, admin);
         OssifiableProxy proxy = OssifiableProxy(payable(instance));
         assertEq(proxy.proxy__getImplementation(), impl);
         assertNotEq(proxy.proxy__getImplementation(), secondImpl);

--- a/test/unit/VettedGate.t.sol
+++ b/test/unit/VettedGate.t.sol
@@ -8,6 +8,7 @@ import { VettedGate } from "src/VettedGate.sol";
 import { PausableUntil } from "src/lib/utils/PausableUntil.sol";
 import { IVettedGate } from "src/interfaces/IVettedGate.sol";
 import { IMerkleGate } from "src/interfaces/IMerkleGate.sol";
+import { INamedUpgradeable } from "src/interfaces/INamedUpgradeable.sol";
 import { IBaseModule, NodeOperatorManagementProperties } from "src/interfaces/IBaseModule.sol";
 import { IAccounting } from "src/interfaces/IAccounting.sol";
 
@@ -83,6 +84,10 @@ contract VettedGateTestBase is Test, Utilities, Fixtures {
             })
         );
     }
+
+    function _tooLongName() internal pure returns (string memory) {
+        return string(new bytes(257));
+    }
 }
 
 contract VettedGateTest_constructor is VettedGateTestBase {
@@ -105,7 +110,7 @@ contract VettedGateTest_initialize is VettedGateTestBase {
         vm.expectEmit();
         emit IMerkleGate.TreeSet(root, cid);
         vm.expectEmit();
-        emit IMerkleGate.NameSet(gateName);
+        emit INamedUpgradeable.NameSet(gateName);
         gate.initialize(curveId, root, cid, gateName, admin);
 
         assertEq(gate.curveId(), curveId);
@@ -146,8 +151,16 @@ contract VettedGateTest_initialize is VettedGateTestBase {
         VettedGate gate = new VettedGate(address(csm));
         _enableInitializers(address(gate));
 
-        vm.expectRevert(IMerkleGate.InvalidName.selector);
+        vm.expectRevert(INamedUpgradeable.InvalidName.selector);
         gate.initialize(curveId, root, cid, "", admin);
+    }
+
+    function test_initialize_RevertWhen_NameTooLong() public {
+        VettedGate gate = new VettedGate(address(csm));
+        _enableInitializers(address(gate));
+
+        vm.expectRevert(INamedUpgradeable.InvalidName.selector);
+        gate.initialize(curveId, root, cid, _tooLongName(), admin);
     }
 
     function test_initialize_RevertWhen_ZeroAdminAddress() public {
@@ -164,7 +177,7 @@ contract VettedGateTest_setName is VettedGateTestBase {
         string memory newName = "Renamed Gate";
 
         vm.expectEmit(address(vettedGate));
-        emit IMerkleGate.NameSet(newName);
+        emit INamedUpgradeable.NameSet(newName);
         vm.prank(admin);
         vettedGate.setName(newName);
 
@@ -178,13 +191,19 @@ contract VettedGateTest_setName is VettedGateTestBase {
     }
 
     function test_setName_RevertWhen_InvalidName() public {
-        vm.expectRevert(IMerkleGate.InvalidName.selector);
+        vm.expectRevert(INamedUpgradeable.InvalidName.selector);
         vm.prank(admin);
         vettedGate.setName("");
     }
 
+    function test_setName_RevertWhen_NameTooLong() public {
+        vm.expectRevert(INamedUpgradeable.InvalidName.selector);
+        vm.prank(admin);
+        vettedGate.setName(_tooLongName());
+    }
+
     function test_setName_RevertWhen_SameName() public {
-        vm.expectRevert(IMerkleGate.InvalidName.selector);
+        vm.expectRevert(INamedUpgradeable.InvalidName.selector);
         vm.prank(admin);
         vettedGate.setName(gateName);
     }

--- a/test/unit/VettedGate.t.sol
+++ b/test/unit/VettedGate.t.sol
@@ -28,6 +28,7 @@ contract VettedGateTestBase is Test, Utilities, Fixtures {
     MerkleTree internal merkleTree;
     bytes32 internal root;
     string internal cid;
+    string internal gateName;
 
     function setUp() public virtual {
         csm = new CSMMock();
@@ -42,11 +43,12 @@ contract VettedGateTestBase is Test, Utilities, Fixtures {
         merkleTree.pushLeaf(abi.encode(anotherNodeOperator));
         root = merkleTree.root();
         cid = "someCid";
+        gateName = "Identified Community Stakers Gate";
 
         curveId = 1;
         vettedGate = new VettedGate(address(csm));
         _enableInitializers(address(vettedGate));
-        vettedGate.initialize(curveId, root, cid, admin);
+        vettedGate.initialize(curveId, root, cid, gateName, admin);
     }
 
     function _addNodeOperator(
@@ -102,11 +104,14 @@ contract VettedGateTest_initialize is VettedGateTestBase {
 
         vm.expectEmit();
         emit IMerkleGate.TreeSet(root, cid);
-        gate.initialize(curveId, root, cid, admin);
+        vm.expectEmit();
+        emit IMerkleGate.NameSet(gateName);
+        gate.initialize(curveId, root, cid, gateName, admin);
 
         assertEq(gate.curveId(), curveId);
         assertEq(gate.treeRoot(), root);
         assertEq(keccak256(bytes(gate.treeCid())), keccak256(bytes(cid)));
+        assertEq(keccak256(bytes(gate.name())), keccak256(bytes(gateName)));
         assertEq(gate.getRoleMemberCount(gate.DEFAULT_ADMIN_ROLE()), 1);
         assertEq(gate.getRoleMember(gate.DEFAULT_ADMIN_ROLE(), 0), admin);
         assertEq(gate.getInitializedVersion(), 1);
@@ -118,7 +123,7 @@ contract VettedGateTest_initialize is VettedGateTestBase {
         uint256 defaultCurveId = csm.accounting().DEFAULT_BOND_CURVE_ID();
 
         vm.expectRevert(IVettedGate.InvalidCurveId.selector);
-        gate.initialize(defaultCurveId, root, cid, admin);
+        gate.initialize(defaultCurveId, root, cid, gateName, admin);
     }
 
     function test_initialize_RevertWhen_InvalidTreeRoot() public {
@@ -126,7 +131,7 @@ contract VettedGateTest_initialize is VettedGateTestBase {
         _enableInitializers(address(gate));
 
         vm.expectRevert(IMerkleGate.InvalidTreeRoot.selector);
-        gate.initialize(curveId, bytes32(0), cid, admin);
+        gate.initialize(curveId, bytes32(0), cid, gateName, admin);
     }
 
     function test_initialize_RevertWhen_InvalidTreeCid() public {
@@ -134,7 +139,15 @@ contract VettedGateTest_initialize is VettedGateTestBase {
         _enableInitializers(address(gate));
 
         vm.expectRevert(IMerkleGate.InvalidTreeCid.selector);
-        gate.initialize(curveId, root, "", admin);
+        gate.initialize(curveId, root, "", gateName, admin);
+    }
+
+    function test_initialize_RevertWhen_InvalidName() public {
+        VettedGate gate = new VettedGate(address(csm));
+        _enableInitializers(address(gate));
+
+        vm.expectRevert(IMerkleGate.InvalidName.selector);
+        gate.initialize(curveId, root, cid, "", admin);
     }
 
     function test_initialize_RevertWhen_ZeroAdminAddress() public {
@@ -142,7 +155,38 @@ contract VettedGateTest_initialize is VettedGateTestBase {
         _enableInitializers(address(gate));
 
         vm.expectRevert(bytes4(keccak256("ZeroAdminAddress()")));
-        gate.initialize(curveId, root, cid, address(0));
+        gate.initialize(curveId, root, cid, gateName, address(0));
+    }
+}
+
+contract VettedGateTest_setName is VettedGateTestBase {
+    function test_setName() public {
+        string memory newName = "Renamed Gate";
+
+        vm.expectEmit(address(vettedGate));
+        emit IMerkleGate.NameSet(newName);
+        vm.prank(admin);
+        vettedGate.setName(newName);
+
+        assertEq(keccak256(bytes(vettedGate.name())), keccak256(bytes(newName)));
+    }
+
+    function test_setName_RevertWhen_NotRoleHolder() public {
+        vm.expectRevert();
+        vm.prank(stranger);
+        vettedGate.setName("Renamed Gate");
+    }
+
+    function test_setName_RevertWhen_InvalidName() public {
+        vm.expectRevert(IMerkleGate.InvalidName.selector);
+        vm.prank(admin);
+        vettedGate.setName("");
+    }
+
+    function test_setName_RevertWhen_SameName() public {
+        vm.expectRevert(IMerkleGate.InvalidName.selector);
+        vm.prank(admin);
+        vettedGate.setName(gateName);
     }
 }
 


### PR DESCRIPTION
## Description

Adds human-readable names to Merkle gates, including initialization-time assignment for new gates and default-admin updates for existing gates. The deployment configs now provide names for curated, identified community staker, and identified DVT cluster gates, and the Hoodi vote simulation migrates the existing VettedGate name through the admin agent flow.

Updates unit, integration, deployment, and vote-upgrade tests to assert gate names and admin-only name changes.

## Checklist

- [ ] Appropriate PR labels applied
- [x] Test coverage maintained (`just coverage`)
  - [ ] No need to add/update tests
  - [x] Tests are added/updated
- [x] Documentation maintained
  - [x] No need to update
  - [ ] Updated
