### PR TITLE
fix: valid key index/range

### DIFF
--- a/src/abstract/BaseModule.sol
+++ b/src/abstract/BaseModule.sol
@@ -451,13 +451,13 @@ abstract contract BaseModule is
 
     /// @inheritdoc IBaseModule
     function isValidatorSlashed(uint256 nodeOperatorId, uint256 keyIndex) external view returns (bool) {
-        _onlyExistingNodeOperator(nodeOperatorId);
+        _onlyValidKeyIndex(nodeOperatorId, keyIndex);
         return _baseStorage().isValidatorSlashed[KeyPointerLib.keyPointer(nodeOperatorId, keyIndex)];
     }
 
     /// @inheritdoc IBaseModule
     function isValidatorWithdrawn(uint256 nodeOperatorId, uint256 keyIndex) external view returns (bool) {
-        _onlyExistingNodeOperator(nodeOperatorId);
+        _onlyValidKeyIndex(nodeOperatorId, keyIndex);
         return _baseStorage().isValidatorWithdrawn[KeyPointerLib.keyPointer(nodeOperatorId, keyIndex)];
     }
 
@@ -780,9 +780,16 @@ abstract contract BaseModule is
         revert NodeOperatorDoesNotExist();
     }
 
+    /// NOTE: The function does not revert when `startIndex` is equal to `totalAddedKeys` and `keysCount` is zero. The
+    /// method might be fixed later once we're sure all off-chain tooling will handle the updated behaviour.
     function _onlyValidIndexRange(uint256 nodeOperatorId, uint256 startIndex, uint256 keysCount) internal view {
         if (startIndex + keysCount > _baseStorage().nodeOperators[nodeOperatorId].totalAddedKeys)
             revert SigningKeysInvalidOffset();
+    }
+
+    function _onlyValidKeyIndex(uint256 nodeOperatorId, uint256 keyIndex) internal view {
+        if (keyIndex < _baseStorage().nodeOperators[nodeOperatorId].totalAddedKeys) return;
+        revert SigningKeysInvalidOffset();
     }
 
     function _getBondCurveId(uint256 nodeOperatorId) internal view returns (uint256) {

--- a/test/helpers/InvariantAsserts.sol
+++ b/test/helpers/InvariantAsserts.sol
@@ -103,10 +103,9 @@ contract InvariantAsserts is Test {
             assertNotEq(no.rewardAddress, address(0), "assert reward != 0");
 
             if (assertZeroConfirmedBalances) {
-                uint256[] memory balances = csm.getKeyConfirmedBalances(noId, 0, no.totalDepositedKeys);
-
                 for (uint256 i; i < no.totalDepositedKeys; ++i) {
-                    assertEq(balances[i], 0, "assert key confirmed balance == 0");
+                    uint256[] memory balances = csm.getKeyConfirmedBalances(noId, i, 1);
+                    assertEq(balances[0], 0, "assert key confirmed balance == 0");
                 }
             }
 
@@ -134,12 +133,11 @@ contract InvariantAsserts is Test {
         for (uint256 noId = 0; noId < noCount; ++noId) {
             uint256 operatorTrackedStake;
             uint256 totalDepositedKeys = module.getNodeOperator(noId).totalDepositedKeys;
-            uint256[] memory keyAllocatedBalances = module.getKeyAllocatedBalances(noId, 0, totalDepositedKeys);
 
             for (uint256 keyIndex = 0; keyIndex < totalDepositedKeys; ++keyIndex) {
                 if (module.isValidatorWithdrawn(noId, keyIndex)) continue;
-
-                operatorTrackedStake += ValidatorBalanceLimits.MIN_ACTIVATION_BALANCE + keyAllocatedBalances[keyIndex];
+                uint256[] memory keyAllocatedBalance = module.getKeyAllocatedBalances(noId, keyIndex, 1);
+                operatorTrackedStake += ValidatorBalanceLimits.MIN_ACTIVATION_BALANCE + keyAllocatedBalance[0];
             }
 
             totalTrackedStake += operatorTrackedStake;

--- a/test/unit/ModuleAbstract/KeysManage.t.sol
+++ b/test/unit/ModuleAbstract/KeysManage.t.sol
@@ -202,7 +202,12 @@ abstract contract ModuleGetSigningKeys is ModuleFixtures {
         assertEq(obtainedKeys, keys, "unexpected keys");
     }
 
-    function test_getSigningKeys_getNonExistingKeys() public assertInvariants brutalizeMemory {
+    function test_getSigningKeys_RevertWhen_InvalidRange() public assertInvariants brutalizeMemory {
+        uint256 emptyNoId = createNodeOperator(0);
+
+        vm.expectRevert(IBaseModule.SigningKeysInvalidOffset.selector);
+        module.getSigningKeys({ nodeOperatorId: emptyNoId, startIndex: 0, keysCount: 1 });
+
         bytes memory keys = randomBytes(48);
 
         uint256 noId = createNodeOperator({
@@ -214,6 +219,10 @@ abstract contract ModuleGetSigningKeys is ModuleFixtures {
 
         vm.expectRevert(IBaseModule.SigningKeysInvalidOffset.selector);
         module.getSigningKeys({ nodeOperatorId: noId, startIndex: 0, keysCount: 3 });
+
+        uint256 twoKeysNoId = createNodeOperator(2);
+        vm.expectRevert(IBaseModule.SigningKeysInvalidOffset.selector);
+        module.getSigningKeys({ nodeOperatorId: twoKeysNoId, startIndex: 1, keysCount: 2 });
     }
 
     function test_getSigningKeys_getKeysFromOffset() public assertInvariants brutalizeMemory {
@@ -267,7 +276,12 @@ abstract contract ModuleGetSigningKeysWithSignatures is ModuleFixtures {
         assertEq(obtainedSignatures, signatures, "unexpected signatures");
     }
 
-    function test_getSigningKeysWithSignatures_getNonExistingKeys() public assertInvariants brutalizeMemory {
+    function test_getSigningKeysWithSignatures_RevertWhen_InvalidRange() public assertInvariants brutalizeMemory {
+        uint256 emptyNoId = createNodeOperator(0);
+
+        vm.expectRevert(IBaseModule.SigningKeysInvalidOffset.selector);
+        module.getSigningKeysWithSignatures({ nodeOperatorId: emptyNoId, startIndex: 0, keysCount: 1 });
+
         bytes memory keys = randomBytes(48);
         bytes memory signatures = randomBytes(96);
 
@@ -280,6 +294,10 @@ abstract contract ModuleGetSigningKeysWithSignatures is ModuleFixtures {
 
         vm.expectRevert(IBaseModule.SigningKeysInvalidOffset.selector);
         module.getSigningKeysWithSignatures({ nodeOperatorId: noId, startIndex: 0, keysCount: 3 });
+
+        uint256 twoKeysNoId = createNodeOperator(2);
+        vm.expectRevert(IBaseModule.SigningKeysInvalidOffset.selector);
+        module.getSigningKeysWithSignatures({ nodeOperatorId: twoKeysNoId, startIndex: 1, keysCount: 2 });
     }
 
     function test_getSigningKeysWithSignatures_getKeysFromOffset() public assertInvariants brutalizeMemory {

--- a/test/unit/ModuleAbstract/PenaltiesWithdrawn.t.sol
+++ b/test/unit/ModuleAbstract/PenaltiesWithdrawn.t.sol
@@ -17,9 +17,17 @@ abstract contract ModuleReportWithdrawnValidators is ModuleFixtures {
         assertFalse(module.isValidatorWithdrawn(noId, 0));
     }
 
-    function test_isValidatorWithdrawn_RevertWhen_OperatorDoesNotExist() public {
-        vm.expectRevert(IBaseModule.NodeOperatorDoesNotExist.selector);
+    function test_isValidatorWithdrawn_RevertWhen_InvalidKeyIndex() public {
+        vm.expectRevert(IBaseModule.SigningKeysInvalidOffset.selector);
         module.isValidatorWithdrawn(0, 0);
+
+        uint256 emptyNoId = createNodeOperator(0);
+        vm.expectRevert(IBaseModule.SigningKeysInvalidOffset.selector);
+        module.isValidatorWithdrawn(emptyNoId, 0);
+
+        uint256 noId = createNodeOperator(1);
+        vm.expectRevert(IBaseModule.SigningKeysInvalidOffset.selector);
+        module.isValidatorWithdrawn(noId, 1);
     }
 
     function test_reportRegularWithdrawnValidators_NoPenalties() public assertInvariants {
@@ -1286,9 +1294,17 @@ abstract contract ModuleReportWithdrawnValidators is ModuleFixtures {
         assertFalse(module.isValidatorSlashed(noId, 0));
     }
 
-    function test_isValidatorSlashed_RevertWhen_OperatorDoesNotExist() public {
-        vm.expectRevert(IBaseModule.NodeOperatorDoesNotExist.selector);
+    function test_isValidatorSlashed_RevertWhen_InvalidKeyIndex() public {
+        vm.expectRevert(IBaseModule.SigningKeysInvalidOffset.selector);
         module.isValidatorSlashed(0, 0);
+
+        uint256 emptyNoId = createNodeOperator(0);
+        vm.expectRevert(IBaseModule.SigningKeysInvalidOffset.selector);
+        module.isValidatorSlashed(emptyNoId, 0);
+
+        uint256 noId = createNodeOperator(1);
+        vm.expectRevert(IBaseModule.SigningKeysInvalidOffset.selector);
+        module.isValidatorSlashed(noId, 1);
     }
 
     function test_reportValidatorSlashing_RevertWhen_CalledTwice() public {


### PR DESCRIPTION
## Description

Fix insufficient input validation for `isValidator*` methods.

## Checklist

- [x] Appropriate PR labels applied
- [x] Test coverage maintained (`just coverage`)
  - [ ] No need to add/update tests
  - [x] Tests are added/updated
- [x] Documentation maintained
  - [x] No need to update
  - [ ] Updated
