### PR TITLE
Add SSV checks to ICS assessment

### DIFF
--- a/ics_assessment/README.md
+++ b/ics_assessment/README.md
@@ -80,7 +80,9 @@ python main.py 0xabc... 0xdef...
 
 The assessment reads local synced artifacts plus the remaining live lookups for:
 
-- High Signal
+- High Signal:
+  - Lido High Signal lookup by address
+  - SSV High Signal lookup by the resolved High Signal username
 - Human Passport
 
 ```bash
@@ -280,7 +282,7 @@ Static curated snapshots:
 - Experience community lists:
   - [EthStaker](https://github.com/ethstaker/solo-stakers/blob/main/solos_list/solo_stakers_v2.csv)
   - [StakeCat](https://github.com/Stake-Cat/Solo-Stakers/tree/main) ([Solo-Stakers-B.csv](https://github.com/Stake-Cat/Solo-Stakers/blob/main/Solo-Stakers/Solo-Stakers-B.csv), [Rocketpool-Solo-Stakers.csv](https://github.com/Stake-Cat/Solo-Stakers/blob/main/Solo-Stakers/Rocketpool-Solo-Stakers.csv), [Gnosischain-Solo-Stakers.csv](https://github.com/Stake-Cat/Solo-Stakers/blob/main/Gnosischain/Gnosischain-Solo-Stakers.csv))
-- SSV verified operators
+- SSV verified operators (Experience and Humanity)
 - SDVTM participants
 - Holesky eligible addresses
 
@@ -297,7 +299,9 @@ On-chain synced artifacts:
 
 Live at runtime:
 
-- High Signal, if `HIGH_SIGNAL_API_KEY` is set
+- High Signal, if `HIGH_SIGNAL_API_KEY` is set. Lido High Signal is fetched by
+  address, then SSV High Signal is fetched by the resolved High Signal username.
+  The Engagement score uses the higher of the two scores.
 - Human Passport, if `HUMAN_PASSPORT_API_KEY` is set
 
 ## Environment Variables

--- a/ics_assessment/config.py
+++ b/ics_assessment/config.py
@@ -67,6 +67,7 @@ HUMANITY_SCORES = {
     "human-passport-min": 3,
     "human-passport-max": 8,
     "circles-verified": 4,
+    "ssv-verified": 3,
     "discord-account": 2,
     "x-account": 1,
 }

--- a/ics_assessment/engagement/assess.py
+++ b/ics_assessment/engagement/assess.py
@@ -84,6 +84,10 @@ class EngagementEvaluator:
         else:
             return CheckOutcome(score=0)
         detail = f"score={high_signal_score}"
+        if self.runtime_inputs.high_signal_project:
+            detail += f"; project={self.runtime_inputs.high_signal_project}"
+        if self.runtime_inputs.high_signal_username:
+            detail += f"; username={self.runtime_inputs.high_signal_username}"
         if self.runtime_inputs.high_signal_address:
             detail += f"; address={self.runtime_inputs.high_signal_address}"
         return CheckOutcome(score=hs_points, detail=detail)

--- a/ics_assessment/engagement/sources.py
+++ b/ics_assessment/engagement/sources.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
 import requests
 from web3 import Web3
@@ -71,12 +72,35 @@ def protocol_guild_matches(addresses: set[str], sources: EngagementSources) -> l
     return matched_addresses
 
 
-def fetch_high_signal_max(addresses: set[str], api_key: str | None) -> tuple[float | None, str | None]:
-    if not api_key:
-        return None, None
+def _fetch_high_signal_user(params: dict[str, str]) -> dict[str, Any] | None:
+    response = requests.get(
+        "https://app.highsignal.xyz/api/data/v1/user",
+        params=params,
+        timeout=20,
+    )
+    if response.status_code == 404:
+        return None
+    response.raise_for_status()
+    return response.json()
 
-    high_signal_url = "https://app.highsignal.xyz/api/data/v1/user"
-    params = {
+
+def _latest_total_score(payload: dict[str, Any] | None) -> float:
+    if not payload:
+        return 0.0
+    total_scores = payload.get("totalScores", [])
+    if not total_scores:
+        return 0.0
+    return float(total_scores[0].get("totalScore", 0) or 0)
+
+
+def fetch_high_signal_max(
+    addresses: set[str],
+    api_key: str | None,
+) -> tuple[float | None, str | None, str | None, str | None]:
+    if not api_key:
+        return None, None, None, None
+
+    base_params = {
         "apiKey": api_key,
         "project": "lido",
         "searchType": "ethereumAddress",
@@ -85,18 +109,32 @@ def fetch_high_signal_max(addresses: set[str], api_key: str | None) -> tuple[flo
     }
     best_score = 0.0
     best_address = None
+    best_username = None
+    best_project = None
     for address in addresses:
-        params["searchValue"] = Web3.to_checksum_address(address)
-        response = requests.get(high_signal_url, params=params)
-        if response.status_code == 404:
-            continue
-        response.raise_for_status()
-        payload = response.json()
-        total_scores = payload.get("totalScores", 0)
-        address_score = 0.0
-        if total_scores:
-            address_score = float(total_scores[0]["totalScore"])
-        if address_score >= best_score:
-            best_score = address_score
-            best_address = address
-    return best_score, best_address
+        lido_params = base_params | {"searchValue": Web3.to_checksum_address(address)}
+        lido_payload = _fetch_high_signal_user(lido_params)
+        username = (lido_payload or {}).get("username")
+        for project, score in (
+            ("lido", _latest_total_score(lido_payload)),
+            ("ssv", _fetch_ssv_high_signal_score(username)),
+        ):
+            if score > best_score:
+                best_score = score
+                best_address = address
+                best_username = username
+                best_project = project
+    return best_score, best_address, best_username, best_project
+
+
+def _fetch_ssv_high_signal_score(username: str | None) -> float:
+    if not username:
+        return 0.0
+    params = {
+        "project": "ssv",
+        "searchType": "highSignalUsername",
+        "searchValue": username,
+        "startDate": HIGH_SIGNAL_START_DATE.strftime("%Y-%m-%d"),
+        "endDate": HIGH_SIGNAL_END_DATE.strftime("%Y-%m-%d"),
+    }
+    return _latest_total_score(_fetch_high_signal_user(params))

--- a/ics_assessment/humanity/assess.py
+++ b/ics_assessment/humanity/assess.py
@@ -7,7 +7,7 @@ from ics_assessment.config import (
 )
 from ics_assessment.result_models import CategoryResult, CheckOutcome
 from ics_assessment.data_utils import truncate
-from ics_assessment.humanity.sources import HumanitySources, circles_matches
+from ics_assessment.humanity.sources import HumanitySources, circles_matches, ssv_verified_matches
 from ics_assessment.runtime_inputs import HumanityRuntimeInputs
 
 
@@ -41,6 +41,15 @@ class HumanityEvaluator:
             return CheckOutcome(score=HUMANITY_SCORES["circles-verified"], detail=truncate(matches))
         return CheckOutcome(score=0)
 
+    def ssv_verified_score(self, addresses: set[str]) -> CheckOutcome:
+        """
+        Returns the Proof-of-Humanity score for SSV Verified Operators.
+        """
+        matches = ssv_verified_matches(addresses, self.sources)
+        if matches:
+            return CheckOutcome(score=HUMANITY_SCORES["ssv-verified"], detail=truncate(matches))
+        return CheckOutcome(score=0)
+
     def discord_account_score(self, provided: bool) -> int:
         """
         Return Discord score from a resolved boolean.
@@ -56,11 +65,13 @@ class HumanityEvaluator:
     def evaluate(self, addresses: set[str]) -> CategoryResult:
         hp = self.human_passport_score()
         circles = self.circles_verified_score(addresses)
+        ssv_verified = self.ssv_verified_score(addresses)
         discord_score = self.discord_account_score(bool(self.runtime_inputs.discord))
         x_score = self.x_account_score(bool(self.runtime_inputs.x))
         checks = [
             hp.to_result("human-passport"),
             circles.to_result("circles-verified"),
+            ssv_verified.to_result("ssv-verified"),
             CheckOutcome(score=discord_score, detail="provided" if discord_score else None).to_result("discord-account"),
             CheckOutcome(score=x_score, detail="provided" if x_score else None).to_result("x-account"),
         ]

--- a/ics_assessment/humanity/sources.py
+++ b/ics_assessment/humanity/sources.py
@@ -12,11 +12,20 @@ from ics_assessment.data_utils import read_csv_rows
 @dataclass(frozen=True)
 class HumanitySources:
     circle_group_members_path: Path
+    ssv_verified_operators_path: Path
 
 
 def circles_matches(addresses: set[str], sources: HumanitySources) -> list[str]:
     matches: list[str] = []
     for row in read_csv_rows(sources.circle_group_members_path):
+        if row and row[0].strip().lower() in addresses:
+            matches.append(row[0].strip().lower())
+    return matches
+
+
+def ssv_verified_matches(addresses: set[str], sources: HumanitySources) -> list[str]:
+    matches: list[str] = []
+    for row in read_csv_rows(sources.ssv_verified_operators_path):
         if row and row[0].strip().lower() in addresses:
             matches.append(row[0].strip().lower())
     return matches

--- a/ics_assessment/main.py
+++ b/ics_assessment/main.py
@@ -134,7 +134,8 @@ def resolve_runtime_inputs(
     discord: bool | None = None,
     x: bool | None = None,
     human_passport_score_override: float | None = None,
-    high_signal_score: float | None = None,
+    lido_high_signal_score: float | None = None,
+    ssv_high_signal_score: float | None = None,
     allow_prompt: bool = True,
 ) -> AssessmentRuntimeInputs:
     humanity = HumanityRuntimeInputs(
@@ -143,7 +144,20 @@ def resolve_runtime_inputs(
         human_passport_score=human_passport_score_override,
     )
     engagement = EngagementRuntimeInputs(
-        high_signal_score=high_signal_score,
+        high_signal_score=max(
+            score
+            for score in (lido_high_signal_score or 0.0, ssv_high_signal_score or 0.0)
+        )
+        if lido_high_signal_score is not None or ssv_high_signal_score is not None
+        else None,
+        high_signal_project=(
+            "ssv"
+            if ssv_high_signal_score is not None
+            and (lido_high_signal_score is None or ssv_high_signal_score > lido_high_signal_score)
+            else "lido"
+            if lido_high_signal_score is not None
+            else None
+        ),
     )
 
     if humanity.human_passport_score is None:
@@ -186,18 +200,27 @@ def resolve_runtime_inputs(
     if engagement.high_signal_score is None:
         high_signal_api_key = os.getenv("HIGH_SIGNAL_API_KEY")
         if high_signal_api_key:
-            score, address = fetch_high_signal_max(addresses, high_signal_api_key)
+            score, address, username, project = fetch_high_signal_max(addresses, high_signal_api_key)
             engagement = EngagementRuntimeInputs(
                 high_signal_score=score,
                 high_signal_address=address,
+                high_signal_username=username,
+                high_signal_project=project,
             )
         elif allow_prompt:
+            lido_score = _prompt_float(
+                "Lido High-signal score (0-100)",
+                "--lido-high-signal-score",
+                env_var="HIGH_SIGNAL_API_KEY",
+            )
+            ssv_score = _prompt_float(
+                "SSV High-signal score (0-100)",
+                "--ssv-high-signal-score",
+                env_var="HIGH_SIGNAL_API_KEY",
+            )
             engagement = EngagementRuntimeInputs(
-                high_signal_score=_prompt_float(
-                    "High-signal score (0-100)",
-                    "--high-signal-score",
-                    env_var="HIGH_SIGNAL_API_KEY",
-                ),
+                high_signal_score=max(lido_score, ssv_score),
+                high_signal_project="ssv" if ssv_score > lido_score else "lido",
             )
 
     return AssessmentRuntimeInputs(humanity=humanity, engagement=engagement)
@@ -209,7 +232,8 @@ def _run_assess(
     discord: bool | None = None,
     x: bool | None = None,
     human_passport_score_override: float | None = None,
-    high_signal_score: float | None = None,
+    lido_high_signal_score: float | None = None,
+    ssv_high_signal_score: float | None = None,
 ) -> int:
     normalized_addresses = {address.strip().lower() for address in addresses}
     runtime_inputs = resolve_runtime_inputs(
@@ -217,7 +241,8 @@ def _run_assess(
         discord=discord,
         x=x,
         human_passport_score_override=human_passport_score_override,
-        high_signal_score=high_signal_score,
+        lido_high_signal_score=lido_high_signal_score,
+        ssv_high_signal_score=ssv_high_signal_score,
         allow_prompt=True,
     )
     result = evaluate_assessment(
@@ -233,7 +258,8 @@ def _add_runtime_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--discord", choices=["yes", "no"])
     parser.add_argument("--x", choices=["yes", "no"])
     parser.add_argument("--human-passport-score", type=float)
-    parser.add_argument("--high-signal-score", type=float)
+    parser.add_argument("--lido-high-signal-score", type=float)
+    parser.add_argument("--ssv-high-signal-score", type=float)
 
 
 def main(argv: list[str] | None = None):
@@ -263,7 +289,8 @@ def main(argv: list[str] | None = None):
             discord=_parse_optional_bool(parsed.discord),
             x=_parse_optional_bool(parsed.x),
             human_passport_score_override=parsed.human_passport_score,
-            high_signal_score=parsed.high_signal_score,
+            lido_high_signal_score=parsed.lido_high_signal_score,
+            ssv_high_signal_score=parsed.ssv_high_signal_score,
         )
     if parsed.command == "sync":
         return sync_main(parsed.targets, chunk_size=parsed.chunk_size)

--- a/ics_assessment/main.py
+++ b/ics_assessment/main.py
@@ -20,6 +20,7 @@ from ics_assessment.config import (
     NODE_OPERATOR_OWNERS_MAINNET_PATH,
     PROTOCOL_GUILD_PATH,
     SNAPSHOT_VOTERS_PATH,
+    SSV_VERIFIED_OPERATORS_PATH,
 )
 from ics_assessment.engagement.assess import EngagementEvaluator
 from ics_assessment.engagement.sources import EngagementSources, fetch_high_signal_max
@@ -58,6 +59,7 @@ DEFAULT_EXPERIENCE_SOURCES = ExperienceSources(
 
 DEFAULT_HUMANITY_SOURCES = HumanitySources(
     circle_group_members_path=CIRCLE_GROUP_MEMBERS_PATH,
+    ssv_verified_operators_path=SSV_VERIFIED_OPERATORS_PATH,
 )
 
 

--- a/ics_assessment/runtime_inputs.py
+++ b/ics_assessment/runtime_inputs.py
@@ -13,6 +13,8 @@ class HumanityRuntimeInputs:
 class EngagementRuntimeInputs:
     high_signal_score: float | None = None
     high_signal_address: str | None = None
+    high_signal_username: str | None = None
+    high_signal_project: str | None = None
 
 
 @dataclass(frozen=True)

--- a/ics_assessment/tests/test_assessment_flow.py
+++ b/ics_assessment/tests/test_assessment_flow.py
@@ -69,6 +69,11 @@ def test_batch_assess_addresses_writes_report(monkeypatch, tmp_path):
         "evaluate_assessment",
         lambda addresses, runtime_inputs=None: result,
     )
+    monkeypatch.setattr(
+        mod,
+        "resolve_runtime_inputs",
+        lambda addresses, discord=None, x=None, allow_prompt=False: None,
+    )
     monkeypatch.setattr(mod, "render_assessment_result", lambda r: "report body")
 
     exp, hum, eng, total, eligible = mod.assess_addresses(
@@ -87,14 +92,20 @@ def test_resolve_runtime_inputs_prefers_env_fetch(monkeypatch):
     monkeypatch.setenv("HUMAN_PASSPORT_API_KEY", "hp")
     monkeypatch.setenv("HIGH_SIGNAL_API_KEY", "hs")
     monkeypatch.setattr(mod, "fetch_human_passport_max", lambda addresses, api_key: (7.2, "0xhp"))
-    monkeypatch.setattr(mod, "fetch_high_signal_max", lambda addresses, api_key: (85.0, "0xhs"))
+    monkeypatch.setattr(
+        mod,
+        "fetch_high_signal_max",
+        lambda addresses, api_key: (85.0, "0xlido", "alice", "lido"),
+    )
 
     resolved = mod.resolve_runtime_inputs({"0xabc"}, allow_prompt=False)
 
     assert resolved.humanity.human_passport_score == 7.2
     assert resolved.humanity.human_passport_address == "0xhp"
     assert resolved.engagement.high_signal_score == 85.0
-    assert resolved.engagement.high_signal_address == "0xhs"
+    assert resolved.engagement.high_signal_address == "0xlido"
+    assert resolved.engagement.high_signal_username == "alice"
+    assert resolved.engagement.high_signal_project == "lido"
     assert resolved.humanity.discord is None
     assert resolved.humanity.x is None
 
@@ -104,7 +115,7 @@ def test_resolve_runtime_inputs_prompts_when_env_missing(monkeypatch):
     monkeypatch.delenv("HUMAN_PASSPORT_API_KEY", raising=False)
     monkeypatch.delenv("HIGH_SIGNAL_API_KEY", raising=False)
     monkeypatch.setattr(mod.sys.stdin, "isatty", lambda: True)
-    answers = iter(["5", "yes", "no", "80"])
+    answers = iter(["5", "yes", "no", "80", "45"])
     monkeypatch.setattr("builtins.input", lambda _: next(answers))
 
     resolved = mod.resolve_runtime_inputs({"0xabc"}, allow_prompt=True)
@@ -113,3 +124,4 @@ def test_resolve_runtime_inputs_prompts_when_env_missing(monkeypatch):
     assert resolved.humanity.discord is True
     assert resolved.humanity.x is False
     assert resolved.engagement.high_signal_score == 80.0
+    assert resolved.engagement.high_signal_project == "lido"

--- a/ics_assessment/tests/test_engagement_main.py
+++ b/ics_assessment/tests/test_engagement_main.py
@@ -7,6 +7,7 @@ from pathlib import Path
 HERE = Path(__file__).resolve()
 ENGAGEMENT_DIR = HERE.parent.parent / "engagement"
 MODULE_PATH = ENGAGEMENT_DIR / "assess.py"
+SOURCES_MODULE_PATH = ENGAGEMENT_DIR / "sources.py"
 
 
 def _write(path: Path, content: str) -> None:
@@ -33,6 +34,19 @@ def _load_module(tmp_path: Path):
         protocol_guild_path=tmp_path / "protocol_guild.csv",
     )
     mod.evaluator = mod.EngagementEvaluator(mod.sources)
+    return mod
+
+
+def _load_sources_module(monkeypatch):
+    web3_stub = types.SimpleNamespace(
+        Web3=types.SimpleNamespace(to_checksum_address=lambda x: x.upper())
+    )
+    monkeypatch.setitem(sys.modules, "web3", web3_stub)
+
+    spec = util.spec_from_file_location("engagement_sources", str(SOURCES_MODULE_PATH))
+    mod = util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(mod)
     return mod
 
 
@@ -110,17 +124,89 @@ def test_gitpoap_no_matches_zero(tmp_path):
     assert mod.evaluator.gitpoap({"0xabc"}) == mod.CheckOutcome(score=0)
 
 
-def test_high_signal_api_buckets_and_max(monkeypatch, tmp_path):
+def test_high_signal_api_buckets_and_detail(monkeypatch, tmp_path):
     mod = _load_module(tmp_path)
     outcome = mod.EngagementEvaluator(
         mod.sources,
         mod.EngagementRuntimeInputs(
             high_signal_score=85,
             high_signal_address="0x1231231231231231231312312312312311231232",
+            high_signal_username="alice",
+            high_signal_project="ssv",
         ),
     ).high_signal()
     assert outcome.score == mod.ENGAGEMENT_SCORES["high-signal-80"]
     assert "address=0x1231231231231231231312312312312311231232" in outcome.detail
+    assert "username=alice" in outcome.detail
+    assert "project=ssv" in outcome.detail
+
+
+def test_fetch_high_signal_max_uses_ssv_when_higher(monkeypatch):
+    mod = _load_sources_module(monkeypatch)
+
+    def fake_get(url, params=None, timeout=None):
+        if params["project"] == "lido":
+            assert params["apiKey"] == "secret"
+            assert params["searchType"] == "ethereumAddress"
+            assert params["searchValue"] == "0XABC"
+            return types.SimpleNamespace(
+                status_code=200,
+                raise_for_status=lambda: None,
+                json=lambda: {
+                    "username": "alice",
+                    "totalScores": [{"totalScore": 35}, {"totalScore": 90}],
+                },
+            )
+        assert params["project"] == "ssv"
+        assert "apiKey" not in params
+        assert params["searchType"] == "highSignalUsername"
+        assert params["searchValue"] == "alice"
+        return types.SimpleNamespace(
+            status_code=200,
+            raise_for_status=lambda: None,
+            json=lambda: {
+                "username": "alice",
+                "totalScores": [{"totalScore": 75}, {"totalScore": 95}],
+            },
+        )
+
+    monkeypatch.setattr(mod.requests, "get", fake_get)
+
+    assert mod.fetch_high_signal_max({"0xabc"}, "secret") == (
+        75.0,
+        "0xabc",
+        "alice",
+        "ssv",
+    )
+
+
+def test_fetch_high_signal_max_keeps_lido_when_ssv_missing(monkeypatch):
+    mod = _load_sources_module(monkeypatch)
+
+    def fake_get(url, params=None, timeout=None):
+        if params["project"] == "lido":
+            return types.SimpleNamespace(
+                status_code=200,
+                raise_for_status=lambda: None,
+                json=lambda: {
+                    "username": "alice",
+                    "totalScores": [{"totalScore": 42}, {"totalScore": 90}],
+                },
+            )
+        return types.SimpleNamespace(
+            status_code=404,
+            raise_for_status=lambda: None,
+            json=lambda: {},
+        )
+
+    monkeypatch.setattr(mod.requests, "get", fake_get)
+
+    assert mod.fetch_high_signal_max({"0xabc"}, "secret") == (
+        42.0,
+        "0xabc",
+        "alice",
+        "lido",
+    )
 
 
 def test_high_signal_valid_boundaries(tmp_path):
@@ -138,6 +224,26 @@ def test_high_signal_invalid_and_out_of_range(tmp_path):
     assert mod.evaluator.high_signal() == mod.CheckOutcome(score=0)
     assert mod.EngagementEvaluator(mod.sources, mod.EngagementRuntimeInputs(high_signal_score=150)).high_signal() == mod.CheckOutcome(score=0)
     assert mod.EngagementEvaluator(mod.sources, mod.EngagementRuntimeInputs(high_signal_score=25)).high_signal() == mod.CheckOutcome(score=0)
+
+
+def test_high_signal_uses_one_chosen_score(tmp_path):
+    mod = _load_module(tmp_path)
+    _write(mod.sources.snapshot_voters_path, "Address,VoteCount\n")
+    _write(mod.sources.aragon_voters_path, "Address,VoteCount\n")
+    _write(mod.sources.galxe_loyalty_points_path, "Address,Points\n")
+    _write(mod.sources.gitpoap_holders_path, "Address,EventID,EventName\n")
+    _write(mod.sources.protocol_guild_path, "")
+
+    result = mod.EngagementEvaluator(
+        mod.sources,
+        mod.EngagementRuntimeInputs(
+            high_signal_score=75,
+            high_signal_project="ssv",
+        ),
+    ).evaluate({"0xabc"})
+
+    assert result.raw_score == mod.ENGAGEMENT_SCORES["high-signal-60"]
+    assert result.final_score == result.raw_score
 
 
 def test_main_aggregator_threshold_and_capping(monkeypatch, tmp_path):

--- a/ics_assessment/tests/test_humanity_main.py
+++ b/ics_assessment/tests/test_humanity_main.py
@@ -16,7 +16,10 @@ def mod(tmp_path):
     assert spec and spec.loader
     spec.loader.exec_module(mod)
     mod.current_dir = Path(tmp_path)
-    mod.sources = mod.HumanitySources(circle_group_members_path=tmp_path / "circle_group_members.csv")
+    mod.sources = mod.HumanitySources(
+        circle_group_members_path=tmp_path / "circle_group_members.csv",
+        ssv_verified_operators_path=tmp_path / "ssv-verified-operators.csv",
+    )
     mod.evaluator = mod.HumanityEvaluator(mod.sources)
     return mod
 
@@ -54,6 +57,15 @@ def test_circles_verified_score(mod):
     assert mod.evaluator.circles_verified_score({"0xdef"}) == mod.CheckOutcome(score=0)
 
 
+def test_ssv_verified_score(mod):
+    mod.sources.ssv_verified_operators_path.write_text("0xabc\n")
+    assert mod.evaluator.ssv_verified_score({"0xabc"}) == mod.CheckOutcome(
+        score=mod.HUMANITY_SCORES["ssv-verified"],
+        detail="0xabc",
+    )
+    assert mod.evaluator.ssv_verified_score({"0xdef"}) == mod.CheckOutcome(score=0)
+
+
 def test_discord_and_x_account_scores(mod):
     assert mod.evaluator.discord_account_score(True) == mod.HUMANITY_SCORES["discord-account"]
     assert mod.evaluator.discord_account_score(False) == 0
@@ -64,18 +76,21 @@ def test_discord_and_x_account_scores(mod):
 def test_main_aggregator_threshold_and_capping(monkeypatch, mod):
     monkeypatch.setattr(mod.HumanityEvaluator, "human_passport_score", lambda self: mod.CheckOutcome(score=0))
     monkeypatch.setattr(mod.HumanityEvaluator, "circles_verified_score", lambda self, a: mod.CheckOutcome(score=0))
+    monkeypatch.setattr(mod.HumanityEvaluator, "ssv_verified_score", lambda self, a: mod.CheckOutcome(score=0))
     monkeypatch.setattr(mod.HumanityEvaluator, "discord_account_score", lambda self, discord: 2)
     monkeypatch.setattr(mod.HumanityEvaluator, "x_account_score", lambda self, x: 1)
     assert mod.evaluator.evaluate({"0xabc"}).final_score == 0
 
     monkeypatch.setattr(mod.HumanityEvaluator, "human_passport_score", lambda self: mod.CheckOutcome(score=8))
     monkeypatch.setattr(mod.HumanityEvaluator, "circles_verified_score", lambda self, a: mod.CheckOutcome(score=4))
+    monkeypatch.setattr(mod.HumanityEvaluator, "ssv_verified_score", lambda self, a: mod.CheckOutcome(score=3))
     monkeypatch.setattr(mod.HumanityEvaluator, "discord_account_score", lambda self, discord: 2)
     monkeypatch.setattr(mod.HumanityEvaluator, "x_account_score", lambda self, x: 1)
     assert mod.evaluator.evaluate({"0xabc"}).final_score == mod.HUMANITY_MAX_SCORE
 
     monkeypatch.setattr(mod.HumanityEvaluator, "human_passport_score", lambda self: mod.CheckOutcome(score=4))
     monkeypatch.setattr(mod.HumanityEvaluator, "circles_verified_score", lambda self, a: mod.CheckOutcome(score=0))
+    monkeypatch.setattr(mod.HumanityEvaluator, "ssv_verified_score", lambda self, a: mod.CheckOutcome(score=0))
     monkeypatch.setattr(mod.HumanityEvaluator, "discord_account_score", lambda self, discord: 0)
     monkeypatch.setattr(mod.HumanityEvaluator, "x_account_score", lambda self, x: 0)
     assert mod.evaluator.evaluate({"0xabc"}).final_score == 4

--- a/ics_assessment/tests/test_static_prepared_data.py
+++ b/ics_assessment/tests/test_static_prepared_data.py
@@ -47,7 +47,10 @@ EXPERIENCE_SOURCES = ExperienceSources(
     node_operator_owners_mainnet_path=NODE_OPERATOR_OWNERS_MAINNET_PATH,
 )
 EXPERIENCE_EVALUATOR = ExperienceEvaluator(EXPERIENCE_SOURCES)
-HUMANITY_SOURCES = HumanitySources(circle_group_members_path=CIRCLE_GROUP_MEMBERS_PATH)
+HUMANITY_SOURCES = HumanitySources(
+    circle_group_members_path=CIRCLE_GROUP_MEMBERS_PATH,
+    ssv_verified_operators_path=SSV_VERIFIED_OPERATORS_PATH,
+)
 HUMANITY_EVALUATOR = HumanityEvaluator(HUMANITY_SOURCES)
 
 
@@ -128,6 +131,15 @@ def test_static_ssv_verified_uses_prepared_data():
     outcome = EXPERIENCE_EVALUATOR.ssv_verified_score({address})
 
     assert outcome.score == EXPERIENCE_SCORES["ssv-verified"]
+    assert address in (outcome.detail or "")
+
+
+def test_static_ssv_verified_humanity_uses_prepared_data():
+    address = _first_csv_row(SSV_VERIFIED_OPERATORS_PATH)[0].strip().lower()
+
+    outcome = HUMANITY_EVALUATOR.ssv_verified_score({address})
+
+    assert outcome.score == HUMANITY_SCORES["ssv-verified"]
     assert address in (outcome.detail or "")
 
 


### PR DESCRIPTION
## Summary

- Add SSV Verified Operator as a Proof of Humanity check using the existing SSV verified operators artifact.
- Resolve Lido High Signal by address with the Lido API key, then use the resolved High Signal username to query public SSV High Signal without the key.
- Score Engagement from the higher High Signal score across Lido and SSV, using the existing High Signal buckets.
- Update CLI overrides, README notes, and assessment tests for the max-score model.

## Validation

- `venv/bin/python -m pytest ics_assessment/tests`