### PR TITLE
chore: Use separate keysLimit to match snapshot params

### DIFF
--- a/script/curated/DeployLocalDevNet.s.sol
+++ b/script/curated/DeployLocalDevNet.s.sol
@@ -51,7 +51,7 @@ contract DeployLocalDevNet is DeployBase {
         // ParametersRegistry
         config.defaultKeyRemovalCharge = 0;
         config.defaultGeneralDelayedPenaltyAdditionalFine = 0.1 ether;
-        config.defaultKeysLimit = 80;
+        config.defaultKeysLimit = 100;
         config.defaultAvgPerfLeewayBP = 10000;
         config.defaultRewardShareBP = 6250; // 62.5% of 4% = 2.5% of the total
         config.defaultStrikesLifetimeFrames = 6;
@@ -75,7 +75,8 @@ contract DeployLocalDevNet is DeployBase {
             gate.name = "Professional Operator Gate";
             gate.treeRoot = bytes32(uint256(0xaaaabbbb)); // TODO: derive from final tree
             gate.treeCid = "TODO: ipfs-cid-cohort-a";
-            gate.params.metaRegistryBondCurveWeight = _m(70000);
+            gate.params.metaRegistryBondCurveWeight = _m(50000);
+            gate.params.keysLimit = _m(80);
         }
 
         // Professional Trusted Operator Gate

--- a/script/curated/DeployMainnet.s.sol
+++ b/script/curated/DeployMainnet.s.sol
@@ -59,7 +59,7 @@ contract DeployMainnet is DeployBase {
         // ParametersRegistry
         config.defaultKeyRemovalCharge = 0;
         config.defaultGeneralDelayedPenaltyAdditionalFine = 0.1 ether;
-        config.defaultKeysLimit = 80;
+        config.defaultKeysLimit = 100;
         config.defaultAvgPerfLeewayBP = 10000;
         config.defaultRewardShareBP = 6250; // 62.5% of 4% = 2.5% of the total
         config.defaultStrikesLifetimeFrames = 6;
@@ -84,6 +84,7 @@ contract DeployMainnet is DeployBase {
             gate.treeRoot = bytes32(uint256(0xaaaabbbb)); // TODO: derive from final tree
             gate.treeCid = "TODO: ipfs-cid-cohort-a";
             gate.params.metaRegistryBondCurveWeight = _m(50000);
+            gate.params.keysLimit = _m(80);
         }
 
         // Professional Trusted Operator Gate


### PR DESCRIPTION
## Description

For some reason, DaoOps decided to have a separate keysLimit for PO type - http://ipfs.io/ipfs/bafybeibhlw3e6zy6xkbdmusky5i5v5rwcpxnjqws23jpmszzkp5xwzzppe (https://snapshot.org/#/s:lido-snapshot.eth/proposal/0x7b07bc31f0b38b69a117473031bc126becc70b9fa37246b53d9fe5a841c814f5)

## Checklist

- [x] Appropriate PR labels applied
- [x] Test coverage maintained (`just coverage`)
  - [x] No need to add/update tests
- [x] Documentation maintained
  - [x] No need to update
