### PR TITLE
test: avoid refreshing circuit breaker pausers

### DIFF
--- a/test/fork/integration/csm/CircuitBreaker.t.sol
+++ b/test/fork/integration/csm/CircuitBreaker.t.sol
@@ -11,13 +11,8 @@ contract CircuitBreakerTest is CSMIntegrationBase {
         vm.skip(!_isCircuitBreakerDeployed(address(circuitBreaker)), "CircuitBreaker is not deployed");
     }
 
-    function _ensureLiveAndPause(address pausable) internal {
-        address pauser = circuitBreaker.getPauser(pausable);
-        if (!circuitBreaker.isPauserLive(pauser)) {
-            vm.prank(pauser);
-            circuitBreaker.heartbeat();
-        }
-        vm.prank(pauser);
+    function _pause(address pausable) internal {
+        vm.prank(circuitBreaker.getPauser(pausable));
         circuitBreaker.pause(pausable);
     }
 
@@ -31,7 +26,7 @@ contract CircuitBreakerTest is CSMIntegrationBase {
         pausables[5] = address(vettedGate);
 
         for (uint256 i = 0; i < pausables.length; i++) {
-            _ensureLiveAndPause(pausables[i]);
+            _pause(pausables[i]);
         }
 
         assertTrue(module.isPaused());
@@ -43,7 +38,7 @@ contract CircuitBreakerTest is CSMIntegrationBase {
     }
 
     function test_pauseCSM() public {
-        _ensureLiveAndPause(address(module));
+        _pause(address(module));
 
         assertTrue(module.isPaused());
         assertFalse(accounting.isPaused());
@@ -54,7 +49,7 @@ contract CircuitBreakerTest is CSMIntegrationBase {
     }
 
     function test_pauseAccounting() public {
-        _ensureLiveAndPause(address(accounting));
+        _pause(address(accounting));
 
         assertFalse(module.isPaused());
         assertTrue(accounting.isPaused());
@@ -65,7 +60,7 @@ contract CircuitBreakerTest is CSMIntegrationBase {
     }
 
     function test_pauseOracle() public {
-        _ensureLiveAndPause(address(oracle));
+        _pause(address(oracle));
 
         assertFalse(module.isPaused());
         assertFalse(accounting.isPaused());
@@ -76,7 +71,7 @@ contract CircuitBreakerTest is CSMIntegrationBase {
     }
 
     function test_pauseVerifier() public {
-        _ensureLiveAndPause(address(verifier));
+        _pause(address(verifier));
 
         assertFalse(module.isPaused());
         assertFalse(accounting.isPaused());
@@ -87,7 +82,7 @@ contract CircuitBreakerTest is CSMIntegrationBase {
     }
 
     function test_pauseEjector() public {
-        _ensureLiveAndPause(address(ejector));
+        _pause(address(ejector));
 
         assertFalse(module.isPaused());
         assertFalse(accounting.isPaused());
@@ -98,7 +93,7 @@ contract CircuitBreakerTest is CSMIntegrationBase {
     }
 
     function test_pauseVettedGate() public {
-        _ensureLiveAndPause(address(vettedGate));
+        _pause(address(vettedGate));
 
         assertFalse(module.isPaused());
         assertFalse(accounting.isPaused());

--- a/test/fork/integration/csm0x02/CircuitBreaker.t.sol
+++ b/test/fork/integration/csm0x02/CircuitBreaker.t.sol
@@ -11,13 +11,8 @@ contract CircuitBreakerTest is CSM0x02IntegrationBase {
         vm.skip(!_isCircuitBreakerDeployed(address(circuitBreaker)), "CircuitBreaker is not deployed");
     }
 
-    function _ensureLiveAndPause(address pausable) internal {
-        address pauser = circuitBreaker.getPauser(pausable);
-        if (!circuitBreaker.isPauserLive(pauser)) {
-            vm.prank(pauser);
-            circuitBreaker.heartbeat();
-        }
-        vm.prank(pauser);
+    function _pause(address pausable) internal {
+        vm.prank(circuitBreaker.getPauser(pausable));
         circuitBreaker.pause(pausable);
     }
 
@@ -30,7 +25,7 @@ contract CircuitBreakerTest is CSM0x02IntegrationBase {
         pausables[4] = address(ejector);
 
         for (uint256 i = 0; i < pausables.length; i++) {
-            _ensureLiveAndPause(pausables[i]);
+            _pause(pausables[i]);
         }
 
         assertTrue(module.isPaused());
@@ -41,7 +36,7 @@ contract CircuitBreakerTest is CSM0x02IntegrationBase {
     }
 
     function test_pauseCSM() public {
-        _ensureLiveAndPause(address(module));
+        _pause(address(module));
 
         assertTrue(module.isPaused());
         assertFalse(accounting.isPaused());
@@ -51,7 +46,7 @@ contract CircuitBreakerTest is CSM0x02IntegrationBase {
     }
 
     function test_pauseAccounting() public {
-        _ensureLiveAndPause(address(accounting));
+        _pause(address(accounting));
 
         assertFalse(module.isPaused());
         assertTrue(accounting.isPaused());
@@ -61,7 +56,7 @@ contract CircuitBreakerTest is CSM0x02IntegrationBase {
     }
 
     function test_pauseOracle() public {
-        _ensureLiveAndPause(address(oracle));
+        _pause(address(oracle));
 
         assertFalse(module.isPaused());
         assertFalse(accounting.isPaused());
@@ -71,7 +66,7 @@ contract CircuitBreakerTest is CSM0x02IntegrationBase {
     }
 
     function test_pauseVerifier() public {
-        _ensureLiveAndPause(address(verifier));
+        _pause(address(verifier));
 
         assertFalse(module.isPaused());
         assertFalse(accounting.isPaused());
@@ -81,7 +76,7 @@ contract CircuitBreakerTest is CSM0x02IntegrationBase {
     }
 
     function test_pauseEjector() public {
-        _ensureLiveAndPause(address(ejector));
+        _pause(address(ejector));
 
         assertFalse(module.isPaused());
         assertFalse(accounting.isPaused());

--- a/test/fork/integration/curated/CircuitBreaker.t.sol
+++ b/test/fork/integration/curated/CircuitBreaker.t.sol
@@ -11,13 +11,8 @@ contract CircuitBreakerTest is CuratedIntegrationBase {
         vm.skip(!_isCircuitBreakerDeployed(address(circuitBreaker)), "CircuitBreaker is not deployed");
     }
 
-    function _ensureLiveAndPause(address pausable) internal {
-        address pauser = circuitBreaker.getPauser(pausable);
-        if (!circuitBreaker.isPauserLive(pauser)) {
-            vm.prank(pauser);
-            circuitBreaker.heartbeat();
-        }
-        vm.prank(pauser);
+    function _pause(address pausable) internal {
+        vm.prank(circuitBreaker.getPauser(pausable));
         circuitBreaker.pause(pausable);
     }
 
@@ -30,7 +25,7 @@ contract CircuitBreakerTest is CuratedIntegrationBase {
         pausables[4] = address(ejector);
 
         for (uint256 i = 0; i < pausables.length; i++) {
-            _ensureLiveAndPause(pausables[i]);
+            _pause(pausables[i]);
         }
 
         assertTrue(curatedModule.isPaused());
@@ -41,7 +36,7 @@ contract CircuitBreakerTest is CuratedIntegrationBase {
     }
 
     function test_pauseCuratedModule() public {
-        _ensureLiveAndPause(address(curatedModule));
+        _pause(address(curatedModule));
 
         assertTrue(curatedModule.isPaused());
         assertFalse(accounting.isPaused());
@@ -51,7 +46,7 @@ contract CircuitBreakerTest is CuratedIntegrationBase {
     }
 
     function test_pauseAccounting() public {
-        _ensureLiveAndPause(address(accounting));
+        _pause(address(accounting));
 
         assertFalse(curatedModule.isPaused());
         assertTrue(accounting.isPaused());
@@ -61,7 +56,7 @@ contract CircuitBreakerTest is CuratedIntegrationBase {
     }
 
     function test_pauseOracle() public {
-        _ensureLiveAndPause(address(oracle));
+        _pause(address(oracle));
 
         assertFalse(curatedModule.isPaused());
         assertFalse(accounting.isPaused());
@@ -71,7 +66,7 @@ contract CircuitBreakerTest is CuratedIntegrationBase {
     }
 
     function test_pauseVerifier() public {
-        _ensureLiveAndPause(address(verifier));
+        _pause(address(verifier));
 
         assertFalse(curatedModule.isPaused());
         assertFalse(accounting.isPaused());
@@ -81,7 +76,7 @@ contract CircuitBreakerTest is CuratedIntegrationBase {
     }
 
     function test_pauseEjector() public {
-        _ensureLiveAndPause(address(ejector));
+        _pause(address(ejector));
 
         assertFalse(curatedModule.isPaused());
         assertFalse(accounting.isPaused());


### PR DESCRIPTION
## What Changed

- Removed the test-side `heartbeat()` refresh from CircuitBreaker integration pause tests.
- Pauses now run directly as the currently registered pauser, so tests fail if the real pauser is not live.
- Applied the change to CSM, CSM 0x02, and Curated integration suites.

## Validation

- `forge fmt --check` on the touched CircuitBreaker integration tests.
- Compile-only `forge test --match-path 'test/fork/integration/*/CircuitBreaker.t.sol' --no-match-test '.*'`.
