### PR TITLE
fix: wrong CB mainnet address

### DIFF
--- a/script/csm/DeployMainnet.s.sol
+++ b/script/csm/DeployMainnet.s.sol
@@ -128,7 +128,7 @@ contract DeployMainnet is DeployBase {
         config.identifiedDVTClusterExitDelayFee = 0.05 ether;
 
         // CircuitBreaker
-        config.circuitBreaker = address(0x63697263756974627265616b6572); // TODO: Set real CircuitBreaker address
+        config.circuitBreaker = 0x6019CB557978296BA3C08a7B73225C0975DFB2F7; // Proposed by LIP-34
         config.circuitBreakerPauser = 0xC52fC3081123073078698F1EAc2f1Dc7Bd71880f; // CSM Committee MS
 
         // DG

--- a/script/curated/DeployMainnet.s.sol
+++ b/script/curated/DeployMainnet.s.sol
@@ -189,7 +189,7 @@ contract DeployMainnet is DeployBase {
         config.setOperatorInfoManager = 0x2570e0b22AD904501dfB0d49575991ACB801dD91; // CMC https://docs.lido.fi/multisigs/committees#220-curated-module-committee-cmc
 
         // CircuitBreaker
-        config.circuitBreaker = address(0x63697263756974627265616b6572); // TODO: Set real CircuitBreaker address
+        config.circuitBreaker = 0x6019CB557978296BA3C08a7B73225C0975DFB2F7; // Proposed by LIP-34
         config.circuitBreakerPauser = 0x2570e0b22AD904501dfB0d49575991ACB801dD91; // CMC https://docs.lido.fi/multisigs/committees#220-curated-module-committee-cmc
 
         // DG


### PR DESCRIPTION
## Description

The fake CircuitBreaker address has been replaced with a real, deployed one (as suggested in LIP-34).