### PR TITLE
feat: add weight boost providers

### DIFF
--- a/script/curated/DeployBase.s.sol
+++ b/script/curated/DeployBase.s.sol
@@ -27,6 +27,8 @@ import { BaseOracle } from "../../src/lib/base-oracle/BaseOracle.sol";
 import { IVerifier } from "../../src/interfaces/IVerifier.sol";
 import { IParametersRegistry } from "../../src/interfaces/IParametersRegistry.sol";
 import { IBondCurve } from "../../src/interfaces/IBondCurve.sol";
+import { IMetaRegistry } from "../../src/interfaces/IMetaRegistry.sol";
+import { IWeightBoostProvider } from "../../src/interfaces/IWeightBoostProvider.sol";
 
 import { JsonObj, Json } from "../utils/Json.sol";
 import { Dummy } from "../utils/Dummy.sol";
@@ -348,6 +350,10 @@ abstract contract DeployBase is Script {
 
             accounting.grantRole(accounting.MANAGE_BOND_CURVES_ROLE(), address(deployer));
             accounting.grantRole(accounting.SET_BOND_CURVE_MULTIPLIER_ROLE(), address(additionalBondRegistry));
+            metaRegistry.addWeightBoostProvider(
+                IWeightBoostProvider(address(additionalBondRegistry)),
+                IMetaRegistry.WeightBoostProviderMode.NodeOperator
+            );
             metaRegistry.grantRole(metaRegistry.SET_BOND_CURVE_WEIGHT_ROLE(), deployer);
 
             for (uint256 i = 0; i < gatesCount; i++) {

--- a/src/Accounting.sol
+++ b/src/Accounting.sol
@@ -15,7 +15,6 @@ import { PausableWithRoles } from "./abstract/PausableWithRoles.sol";
 
 import { AssetRecovererLib } from "./lib/AssetRecovererLib.sol";
 
-import { IStakingModule } from "./interfaces/IStakingModule.sol";
 import { IBaseModule, NodeOperatorManagementProperties } from "./interfaces/IBaseModule.sol";
 import { IAccounting } from "./interfaces/IAccounting.sol";
 import { IFeeDistributor } from "./interfaces/IFeeDistributor.sol";
@@ -614,7 +613,7 @@ contract Accounting is
     }
 
     function _onlyExistingNodeOperator(uint256 nodeOperatorId) internal view {
-        if (nodeOperatorId < IStakingModule(address(MODULE)).getNodeOperatorsCount()) return;
+        if (nodeOperatorId < MODULE.getNodeOperatorsCount()) return;
 
         revert NodeOperatorDoesNotExist();
     }

--- a/src/AdditionalBondRegistry.sol
+++ b/src/AdditionalBondRegistry.sol
@@ -10,6 +10,7 @@ import { IAccounting } from "./interfaces/IAccounting.sol";
 import { ICuratedModule } from "./interfaces/ICuratedModule.sol";
 import { IMetaRegistry } from "./interfaces/IMetaRegistry.sol";
 import { IAdditionalBondRegistry, TierInfo, OperatorTierState } from "./interfaces/IAdditionalBondRegistry.sol";
+import { IWeightBoostProvider } from "./interfaces/IWeightBoostProvider.sol";
 import { MAX_BP } from "./lib/Constants.sol";
 
 /// @notice Manages operator tiers.
@@ -96,7 +97,7 @@ contract AdditionalBondRegistry is IAdditionalBondRegistry, Initializable, Acces
         $.operatorTier[nodeOperatorId] = tierId;
         emit TierSelected(nodeOperatorId, tierId);
 
-        META_REGISTRY.refreshOperatorWeight(nodeOperatorId);
+        META_REGISTRY.notifyWeightBoostChanged(nodeOperatorId);
     }
 
     /// @inheritdoc IAdditionalBondRegistry
@@ -125,6 +126,12 @@ contract AdditionalBondRegistry is IAdditionalBondRegistry, Initializable, Acces
         state.curveMultiplierCooldownUntil = $.curveMultiplierCooldownUntil[nodeOperatorId];
         state.weightMultiplier = MAX_BP + $.tiers[state.tierId].weightMultiplier;
         state.curveMultiplier = ACCOUNTING.getBondCurveMultiplier(nodeOperatorId);
+    }
+
+    /// @inheritdoc IWeightBoostProvider
+    function getWeightBoostMultiplierBP(uint256 nodeOperatorId) external view returns (uint256 multiplierBP) {
+        AdditionalBondRegistryStorage storage $ = _storage();
+        multiplierBP = MAX_BP + $.tiers[$.operatorTier[nodeOperatorId]].weightMultiplier;
     }
 
     /// @inheritdoc IAdditionalBondRegistry

--- a/src/MetaRegistry.sol
+++ b/src/MetaRegistry.sol
@@ -12,6 +12,7 @@ import { IBondCurve } from "./interfaces/IBondCurve.sol";
 import { INodeOperatorsRegistry } from "./interfaces/INodeOperatorsRegistry.sol";
 import { ICuratedModule } from "./interfaces/ICuratedModule.sol";
 import { IBaseModule } from "./interfaces/IBaseModule.sol";
+import { IWeightBoostProvider } from "./interfaces/IWeightBoostProvider.sol";
 import { IStakingModule } from "./interfaces/IStakingModule.sol";
 import { IStakingRouter } from "./interfaces/IStakingRouter.sol";
 import { IMetaRegistry, OperatorMetadata } from "./interfaces/IMetaRegistry.sol";
@@ -50,6 +51,9 @@ contract MetaRegistry is IMetaRegistry, Initializable, AccessControlEnumerableUp
         mapping(uint256 nodeOperatorId => OperatorMetadata) operatorMetadata;
         mapping(uint256 moduleId => address moduleAddress) moduleAddressCache;
         uint256 groupsCount;
+        mapping(uint256 providerId => WeightBoostProviderEntry entry) weightBoostProviders;
+        mapping(address provider => uint256 providerId) weightBoostProviderIdByAddress;
+        uint256 weightBoostProvidersCount;
     }
 
     bytes32 public constant MANAGE_OPERATOR_GROUPS_ROLE = keccak256("MANAGE_OPERATOR_GROUPS_ROLE");
@@ -148,7 +152,44 @@ contract MetaRegistry is IMetaRegistry, Initializable, AccessControlEnumerableUp
 
         $.bondCurveWeight[curveId] = weight;
         emit BondCurveWeightSet(curveId, weight);
-        MODULE.requestFullDepositInfoUpdate();
+        _requestFullDepositInfoUpdate();
+    }
+
+    /// @inheritdoc IMetaRegistry
+    function addWeightBoostProvider(
+        IWeightBoostProvider provider,
+        WeightBoostProviderMode mode
+    ) external onlyRole(DEFAULT_ADMIN_ROLE) {
+        address providerAddr = address(provider);
+        if (providerAddr == address(0)) revert InvalidWeightBoostProvider();
+
+        MetaRegistryStorage storage $ = _storage();
+        if ($.weightBoostProviderIdByAddress[providerAddr] != 0) {
+            revert WeightBoostProviderAlreadyAdded();
+        }
+
+        uint256 providerId = ++$.weightBoostProvidersCount;
+        $.weightBoostProviders[providerId] = WeightBoostProviderEntry({
+            provider: provider,
+            mode: mode,
+            enabled: true
+        });
+        $.weightBoostProviderIdByAddress[providerAddr] = providerId;
+        emit WeightBoostProviderAdded(providerAddr, mode);
+        _requestFullDepositInfoUpdate();
+    }
+
+    /// @inheritdoc IMetaRegistry
+    function setWeightBoostProviderEnabled(uint256 providerId, bool enabled) external onlyRole(DEFAULT_ADMIN_ROLE) {
+        MetaRegistryStorage storage $ = _storage();
+        WeightBoostProviderEntry storage entry = $.weightBoostProviders[providerId];
+        address providerAddr = address(entry.provider);
+        if (providerAddr == address(0)) revert WeightBoostProviderNotFound();
+        if (entry.enabled == enabled) revert SameWeightBoostProviderEnabled();
+
+        entry.enabled = enabled;
+        emit WeightBoostProviderEnabledSet(providerAddr, enabled);
+        _requestFullDepositInfoUpdate();
     }
 
     /// @inheritdoc IMetaRegistry
@@ -157,6 +198,82 @@ contract MetaRegistry is IMetaRegistry, Initializable, AccessControlEnumerableUp
         if (groupId == NO_GROUP_ID) return;
 
         _refreshOperatorWeight(groupId, nodeOperatorId);
+    }
+
+    /// @inheritdoc IMetaRegistry
+    function refreshGroupWeights(uint256 groupId) external {
+        if (groupId == NO_GROUP_ID) revert InvalidOperatorGroupId();
+        if (groupId > _storage().groupsCount) revert InvalidOperatorGroupId();
+
+        _refreshGroupWeights(groupId);
+    }
+
+    /// @inheritdoc IMetaRegistry
+    function notifyWeightBoostProviderConfigChanged() external {
+        MetaRegistryStorage storage $ = _storage();
+        uint256 providerId = $.weightBoostProviderIdByAddress[msg.sender];
+        if (providerId == 0) revert WeightBoostProviderNotFound();
+
+        if (!$.weightBoostProviders[providerId].enabled) return;
+
+        emit WeightBoostProviderConfigChanged(msg.sender);
+        _requestFullDepositInfoUpdate();
+    }
+
+    /// @inheritdoc IMetaRegistry
+    function notifyWeightBoostChanged(uint256 nodeOperatorId) external {
+        MetaRegistryStorage storage $ = _storage();
+        uint256 providerId = $.weightBoostProviderIdByAddress[msg.sender];
+        if (providerId == 0) revert WeightBoostProviderNotFound();
+
+        uint256 groupId = $.groupIndex.groupIdByOperatorId[nodeOperatorId];
+        // Provider notifications are node-operator scoped; operators outside groups have no group cache to refresh.
+        if (groupId == NO_GROUP_ID) return;
+
+        WeightBoostProviderEntry storage entry = $.weightBoostProviders[providerId];
+        if (!entry.enabled) return;
+
+        if (entry.mode == WeightBoostProviderMode.NodeOperator) {
+            _refreshOperatorWeight(groupId, nodeOperatorId);
+            return;
+        }
+
+        if (entry.mode == WeightBoostProviderMode.GroupMax) {
+            _refreshGroupWeights(groupId);
+            return;
+        }
+
+        revert InvalidWeightBoostProviderMode();
+    }
+
+    /// @inheritdoc IMetaRegistry
+    function getWeightBoostProviders() external view returns (IWeightBoostProvider[] memory providers) {
+        MetaRegistryStorage storage $ = _storage();
+        uint256 providersCount = $.weightBoostProvidersCount;
+        providers = new IWeightBoostProvider[](providersCount);
+        for (uint256 i; i < providersCount; ++i) {
+            providers[i] = $.weightBoostProviders[i + 1].provider;
+        }
+    }
+
+    /// @inheritdoc IMetaRegistry
+    function getWeightBoostProvidersCount() external view returns (uint256 count) {
+        count = _storage().weightBoostProvidersCount;
+    }
+
+    /// @inheritdoc IMetaRegistry
+    function getWeightBoostProvider(uint256 providerId) external view returns (WeightBoostProviderEntry memory entry) {
+        entry = _storage().weightBoostProviders[providerId];
+    }
+
+    /// @inheritdoc IMetaRegistry
+    function getWeightBoostProviderMode(uint256 providerId) external view returns (WeightBoostProviderMode mode) {
+        mode = _storage().weightBoostProviders[providerId].mode;
+    }
+
+    /// @inheritdoc IMetaRegistry
+    function getWeightBoostProviderId(address provider) external view returns (uint256 providerId) {
+        providerId = _storage().weightBoostProviderIdByAddress[provider];
     }
 
     /// @inheritdoc IMetaRegistry
@@ -249,6 +366,7 @@ contract MetaRegistry is IMetaRegistry, Initializable, AccessControlEnumerableUp
 
         uint256 groupId = ++_storage().groupsCount;
         _storeGroupData(groupId, groupInfo);
+        _refreshGroupWeights(groupId);
         emit OperatorGroupCreated(groupId, groupInfo);
     }
 
@@ -263,6 +381,7 @@ contract MetaRegistry is IMetaRegistry, Initializable, AccessControlEnumerableUp
             emit OperatorGroupCleared(groupId);
         } else {
             _storeGroupData(groupId, groupInfo);
+            _refreshGroupWeights(groupId);
             emit OperatorGroupUpdated(groupId, groupInfo);
         }
     }
@@ -310,7 +429,6 @@ contract MetaRegistry is IMetaRegistry, Initializable, AccessControlEnumerableUp
         CachedOperatorGroup storage group = $.groups[groupId];
 
         uint256 shareSum;
-        uint256 effectiveWeightSum;
         for (uint256 i; i < subNodeOperators.length; ++i) {
             uint64 noId = subNodeOperators[i].nodeOperatorId;
             uint16 share = subNodeOperators[i].share;
@@ -322,15 +440,10 @@ contract MetaRegistry is IMetaRegistry, Initializable, AccessControlEnumerableUp
             $.groupIndex.shareByOperatorId[noId] = share;
             group.subNodeOperatorIds.push(noId);
 
-            uint256 effectiveWeight = _getLatestEffectiveWeight(noId, share);
-            _setEffectiveWeight(noId, effectiveWeight);
-            effectiveWeightSum += effectiveWeight;
             shareSum += share;
         }
 
         if (shareSum != MAX_BP) revert InvalidSubNodeOperatorShares();
-
-        $.effectiveWeightCache.groupEffectiveWeightSum[groupId] = effectiveWeightSum;
     }
 
     function _storeExternalOperators(uint256 groupId, ExternalOperator[] calldata externalOperators) internal {
@@ -356,7 +469,8 @@ contract MetaRegistry is IMetaRegistry, Initializable, AccessControlEnumerableUp
         MetaRegistryStorage storage $ = _storage();
         uint256 share = $.groupIndex.shareByOperatorId[noId];
 
-        uint256 newWeight = _getLatestEffectiveWeight(noId, share);
+        uint256 multiplierBP = _getWeightBoostMultiplierBP($.groups[groupId], noId);
+        uint256 newWeight = _getLatestEffectiveWeight(noId, share, multiplierBP);
         uint256 oldWeight = _setEffectiveWeight(noId, newWeight);
 
         if (oldWeight != newWeight) {
@@ -371,6 +485,35 @@ contract MetaRegistry is IMetaRegistry, Initializable, AccessControlEnumerableUp
         }
     }
 
+    function _refreshGroupWeights(uint256 groupId) internal {
+        MetaRegistryStorage storage $ = _storage();
+        CachedOperatorGroup storage group = $.groups[groupId];
+        uint256 providersCount = $.weightBoostProvidersCount;
+        uint256[] memory groupMaxMultipliersBP = new uint256[](providersCount);
+        bool[] memory groupMaxMultiplierCached = new bool[](providersCount);
+
+        uint256 effectiveWeightSum;
+        uint256 subOperatorsCount = group.subNodeOperatorIds.length;
+        for (uint256 i; i < subOperatorsCount; ++i) {
+            uint256 noId = group.subNodeOperatorIds[i];
+            uint256 share = $.groupIndex.shareByOperatorId[noId];
+            // Keep full-group and single-operator refreshes on the same ordered multiplier path.
+            // Each Math.mulDiv floors, so pre-aggregating providers by mode can produce different weights.
+            uint256 multiplierBP = _getWeightBoostMultiplierBP(
+                group,
+                noId,
+                groupMaxMultipliersBP,
+                groupMaxMultiplierCached
+            );
+            uint256 effectiveWeight = _getLatestEffectiveWeight(noId, share, multiplierBP);
+            _setEffectiveWeight(noId, effectiveWeight);
+            effectiveWeightSum += effectiveWeight;
+        }
+
+        $.effectiveWeightCache.groupEffectiveWeightSum[groupId] = effectiveWeightSum;
+        emit GroupWeightsRefreshed(groupId);
+    }
+
     function _setEffectiveWeight(uint256 nodeOperatorId, uint256 newWeight) internal returns (uint256 oldWeight) {
         MetaRegistryStorage storage $ = _storage();
         oldWeight = $.effectiveWeightCache.operatorEffectiveWeight[nodeOperatorId];
@@ -381,6 +524,10 @@ contract MetaRegistry is IMetaRegistry, Initializable, AccessControlEnumerableUp
         emit NodeOperatorEffectiveWeightChanged(nodeOperatorId, oldWeight, newWeight);
 
         MODULE.notifyNodeOperatorWeightChange(nodeOperatorId, oldWeight, newWeight);
+    }
+
+    function _requestFullDepositInfoUpdate() internal {
+        MODULE.requestFullDepositInfoUpdate();
     }
 
     function _storeOperatorMetadata(uint256 nodeOperatorId, OperatorMetadata memory metadata) internal {
@@ -406,13 +553,90 @@ contract MetaRegistry is IMetaRegistry, Initializable, AccessControlEnumerableUp
         }
     }
 
-    function _getLatestEffectiveWeight(uint256 nodeOperatorId, uint256 share) internal view returns (uint256) {
-        uint256 baseWeight = _storage().bondCurveWeight[ACCOUNTING.getBondCurveId(nodeOperatorId)];
+    function _getLatestEffectiveWeight(
+        uint256 nodeOperatorId,
+        uint256 share,
+        uint256 multiplierBP
+    ) internal view returns (uint256) {
+        uint256 baseWeight = _getOperatorBaseWeight(nodeOperatorId);
         if (baseWeight == 0 || share == 0) return 0;
-        uint256 weighted = Math.mulDiv(baseWeight, share, MAX_BP);
-        uint256 weightMul = ADDITIONAL_BOND_REGISTRY.getOperatorTierState(nodeOperatorId).weightMultiplier;
-        if (weightMul == MAX_BP) return weighted;
-        return Math.mulDiv(weighted, weightMul, MAX_BP);
+
+        uint256 sharedBaseWeight = Math.mulDiv(baseWeight, share, MAX_BP);
+        return Math.mulDiv(sharedBaseWeight, multiplierBP, MAX_BP);
+    }
+
+    function _getOperatorBaseWeight(uint256 nodeOperatorId) internal view returns (uint256) {
+        return _storage().bondCurveWeight[ACCOUNTING.getBondCurveId(nodeOperatorId)];
+    }
+
+    function _getWeightBoostMultiplierBP(
+        CachedOperatorGroup storage group,
+        uint256 nodeOperatorId
+    ) internal view returns (uint256 multiplierBP) {
+        MetaRegistryStorage storage $ = _storage();
+        multiplierBP = MAX_BP;
+        uint256 providersCount = $.weightBoostProvidersCount;
+        for (uint256 i; i < providersCount; ++i) {
+            WeightBoostProviderEntry storage entry = $.weightBoostProviders[i + 1];
+            if (!entry.enabled) continue;
+
+            IWeightBoostProvider provider = entry.provider;
+            if (entry.mode == WeightBoostProviderMode.NodeOperator) {
+                multiplierBP = Math.mulDiv(multiplierBP, provider.getWeightBoostMultiplierBP(nodeOperatorId), MAX_BP);
+            } else if (entry.mode == WeightBoostProviderMode.GroupMax) {
+                multiplierBP = Math.mulDiv(
+                    multiplierBP,
+                    _getProviderGroupMaxWeightBoostMultiplierBP(provider, group),
+                    MAX_BP
+                );
+            } else {
+                revert InvalidWeightBoostProviderMode();
+            }
+        }
+    }
+
+    function _getWeightBoostMultiplierBP(
+        CachedOperatorGroup storage group,
+        uint256 nodeOperatorId,
+        uint256[] memory groupMaxMultipliersBP,
+        bool[] memory groupMaxMultiplierCached
+    ) internal view returns (uint256 multiplierBP) {
+        MetaRegistryStorage storage $ = _storage();
+        multiplierBP = MAX_BP;
+        uint256 providersCount = groupMaxMultipliersBP.length;
+        for (uint256 i; i < providersCount; ++i) {
+            WeightBoostProviderEntry storage entry = $.weightBoostProviders[i + 1];
+            if (!entry.enabled) continue;
+
+            IWeightBoostProvider provider = entry.provider;
+            if (entry.mode == WeightBoostProviderMode.NodeOperator) {
+                multiplierBP = Math.mulDiv(multiplierBP, provider.getWeightBoostMultiplierBP(nodeOperatorId), MAX_BP);
+            } else if (entry.mode == WeightBoostProviderMode.GroupMax) {
+                if (!groupMaxMultiplierCached[i]) {
+                    groupMaxMultipliersBP[i] = _getProviderGroupMaxWeightBoostMultiplierBP(provider, group);
+                    groupMaxMultiplierCached[i] = true;
+                }
+                multiplierBP = Math.mulDiv(multiplierBP, groupMaxMultipliersBP[i], MAX_BP);
+            } else {
+                revert InvalidWeightBoostProviderMode();
+            }
+        }
+    }
+
+    function _getProviderGroupMaxWeightBoostMultiplierBP(
+        IWeightBoostProvider provider,
+        CachedOperatorGroup storage group
+    ) internal view returns (uint256 maxMultiplierBP) {
+        uint256 subOperatorsCount = group.subNodeOperatorIds.length;
+        if (subOperatorsCount == 0) return MAX_BP;
+
+        maxMultiplierBP = provider.getWeightBoostMultiplierBP(group.subNodeOperatorIds[0]);
+        for (uint256 i = 1; i < subOperatorsCount; ++i) {
+            uint256 candidateMultiplierBP = provider.getWeightBoostMultiplierBP(group.subNodeOperatorIds[i]);
+            if (candidateMultiplierBP > maxMultiplierBP) {
+                maxMultiplierBP = candidateMultiplierBP;
+            }
+        }
     }
 
     /// @dev Returns the cached module address. Reverts if the address was

--- a/src/abstract/BondCurve.sol
+++ b/src/abstract/BondCurve.sol
@@ -73,7 +73,7 @@ abstract contract BondCurve is IBondCurve, Initializable {
 
     /// @inheritdoc IBondCurve
     function getBondAmountByKeysCount(uint256 keys, uint256 curveId) public view returns (uint256) {
-        return BondCurvesLib.getBondAmountByKeysCount(_getBondCurveStorage(), keys, curveId, MAX_BP);
+        return getBondAmountByKeysCount(keys, curveId, MAX_BP);
     }
 
     /// @inheritdoc IBondCurve
@@ -83,7 +83,7 @@ abstract contract BondCurve is IBondCurve, Initializable {
 
     /// @inheritdoc IBondCurve
     function getKeysCountByBondAmount(uint256 amount, uint256 curveId) public view returns (uint256) {
-        return BondCurvesLib.getKeysCountByBondAmount(_getBondCurveStorage(), amount, curveId, MAX_BP);
+        return getKeysCountByBondAmount(amount, curveId, MAX_BP);
     }
 
     /// @inheritdoc IBondCurve

--- a/src/interfaces/IAdditionalBondRegistry.sol
+++ b/src/interfaces/IAdditionalBondRegistry.sol
@@ -6,6 +6,7 @@ pragma solidity 0.8.33;
 import { IAccounting } from "./IAccounting.sol";
 import { ICuratedModule } from "./ICuratedModule.sol";
 import { IMetaRegistry } from "./IMetaRegistry.sol";
+import { IWeightBoostProvider } from "./IWeightBoostProvider.sol";
 
 /// @dev Bond tier. Fields hold increments above MAX_BP in storage; `getTierInfo` returns them as full
 ///      effective multipliers (MAX_BP + stored increment).
@@ -14,7 +15,7 @@ struct TierInfo {
     uint128 weightMultiplier;
 }
 
-/// @dev Operator's effective tier state, with multipliers as full basis-point values (not `TierInfo` increments).
+/// @dev Operator's effective tier state, with multipliers as full basis-point values.
 ///      During a downgrade cooldown `curveMultiplier` keeps the pre-downgrade value until `applyCurveMultiplier`,
 ///      so it may exceed the current tier's value (and stay above MAX_BP while `tierId == 0`).
 struct OperatorTierState {
@@ -25,7 +26,7 @@ struct OperatorTierState {
 }
 
 /// @notice Manages operator bond tiers and associated tier downgrade cooldown state.
-interface IAdditionalBondRegistry {
+interface IAdditionalBondRegistry is IWeightBoostProvider {
     event TierAdded(uint256 indexed tierId, uint256 curveMultiplier, uint256 weightMultiplier);
     event TierSelected(uint256 indexed nodeOperatorId, uint256 tierId);
     event CurveMultiplierCooldownSet(uint256 indexed nodeOperatorId, uint256 cooldownUntil);
@@ -48,7 +49,7 @@ interface IAdditionalBondRegistry {
     /// @notice Accounting contract holding bond curves and the operator curve multiplier.
     function ACCOUNTING() external view returns (IAccounting);
 
-    /// @notice MetaRegistry called back via `refreshOperatorWeight` on tier changes.
+    /// @notice MetaRegistry called back via `notifyWeightBoostChanged` on tier changes.
     function META_REGISTRY() external view returns (IMetaRegistry);
 
     /// @notice Upper bound for `curveMultiplier`.

--- a/src/interfaces/IMetaRegistry.sol
+++ b/src/interfaces/IMetaRegistry.sol
@@ -6,6 +6,7 @@ pragma solidity 0.8.33;
 import { IAccounting } from "./IAccounting.sol";
 import { ICuratedModule } from "./ICuratedModule.sol";
 import { IAdditionalBondRegistry } from "./IAdditionalBondRegistry.sol";
+import { IWeightBoostProvider } from "./IWeightBoostProvider.sol";
 
 /// @notice Stored operator metadata.
 struct OperatorMetadata {
@@ -31,10 +32,25 @@ interface IMetaRegistry {
         ExternalOperator[] externalOperators;
     }
 
+    enum WeightBoostProviderMode {
+        NodeOperator,
+        GroupMax
+    }
+
+    struct WeightBoostProviderEntry {
+        IWeightBoostProvider provider;
+        WeightBoostProviderMode mode;
+        bool enabled;
+    }
+
     event OperatorGroupCreated(uint256 indexed groupId, OperatorGroup groupInfo);
     event OperatorGroupUpdated(uint256 indexed groupId, OperatorGroup groupInfo);
     event OperatorGroupCleared(uint256 indexed groupId);
     event BondCurveWeightSet(uint256 indexed curveId, uint256 weight);
+    event WeightBoostProviderAdded(address indexed provider, WeightBoostProviderMode mode);
+    event WeightBoostProviderEnabledSet(address indexed provider, bool enabled);
+    event WeightBoostProviderConfigChanged(address indexed provider);
+    event GroupWeightsRefreshed(uint256 indexed groupId);
     event OperatorMetadataSet(uint256 indexed nodeOperatorId, OperatorMetadata metadata);
     event NodeOperatorEffectiveWeightChanged(uint256 indexed nodeOperatorId, uint256 oldWeight, uint256 newWeight);
 
@@ -51,6 +67,11 @@ interface IMetaRegistry {
     error OwnerEditsRestricted();
     error SameBondCurveWeight();
     error InvalidBondCurveWeight();
+    error InvalidWeightBoostProvider();
+    error InvalidWeightBoostProviderMode();
+    error WeightBoostProviderAlreadyAdded();
+    error WeightBoostProviderNotFound();
+    error SameWeightBoostProviderEnabled();
     error ModuleAddressNotCached();
     error OperatorNameTooLong();
     error OperatorDescriptionTooLong();
@@ -75,6 +96,27 @@ interface IMetaRegistry {
 
     /// @notice Tier provider that manages operator bond tiers.
     function ADDITIONAL_BOND_REGISTRY() external view returns (IAdditionalBondRegistry);
+
+    /// @notice Returns configured weight boost providers.
+    function getWeightBoostProviders() external view returns (IWeightBoostProvider[] memory providers);
+
+    /// @notice Returns configured weight boost providers count.
+    function getWeightBoostProvidersCount() external view returns (uint256 count);
+
+    /// @notice Returns configured weight boost provider entry by ID.
+    /// @param providerId Provider ID.
+    /// @return entry Configured boost provider entry.
+    function getWeightBoostProvider(uint256 providerId) external view returns (WeightBoostProviderEntry memory entry);
+
+    /// @notice Returns configured weight boost provider mode by ID.
+    /// @param providerId Provider ID.
+    /// @return mode Provider aggregation mode.
+    function getWeightBoostProviderMode(uint256 providerId) external view returns (WeightBoostProviderMode mode);
+
+    /// @notice Returns configured weight boost provider ID by address.
+    /// @param provider Address to check.
+    /// @return providerId Provider ID, or zero if the address is not a configured provider.
+    function getWeightBoostProviderId(address provider) external view returns (uint256 providerId);
 
     /// @notice Initialize the registry.
     /// @param admin Address to receive DEFAULT_ADMIN_ROLE.
@@ -141,6 +183,21 @@ interface IMetaRegistry {
     /// @param weight Base allocation weight.
     function setBondCurveWeight(uint256 curveId, uint256 weight) external;
 
+    /// @notice Add a weight boost provider.
+    /// @dev Adding a provider is expected to be a rare operation and does not refresh cached weights automatically.
+    ///      A full deposit info update is requested and affected groups must be refreshed asynchronously.
+    ///      Added providers are enabled by default. Providers are append-only and can only be disabled.
+    /// @param provider Boost provider consumed during weight calculation.
+    /// @param mode Provider aggregation mode.
+    function addWeightBoostProvider(IWeightBoostProvider provider, WeightBoostProviderMode mode) external;
+
+    /// @notice Enable or disable a weight boost provider.
+    /// @dev Enabling or disabling a provider does not refresh cached weights automatically.
+    ///      A full deposit info update is requested and affected groups must be refreshed asynchronously.
+    /// @param providerId Boost provider ID to update.
+    /// @param enabled Whether the provider should participate in weight calculations.
+    function setWeightBoostProviderEnabled(uint256 providerId, bool enabled) external;
+
     /// @notice Returns effective weight for the node operator.
     /// @param nodeOperatorId Node operator ID to query.
     /// @return weight Effective allocation weight.
@@ -170,4 +227,19 @@ interface IMetaRegistry {
     /// @notice Trigger the operator weight update routine in the registry.
     /// @param nodeOperatorId Node operator ID to trigger the update for.
     function refreshOperatorWeight(uint256 nodeOperatorId) external;
+
+    /// @notice Trigger the group weight update routine in the registry.
+    /// @param groupId Operator group ID to trigger the update for.
+    /// @dev Use this after asynchronous provider configuration changes such as addWeightBoostProvider(),
+    ///      notifyWeightBoostProviderConfigChanged(), and setWeightBoostProviderEnabled().
+    function refreshGroupWeights(uint256 groupId) external;
+
+    /// @notice Notify the registry that a configured provider changed a node operator boost.
+    /// @param nodeOperatorId Node operator ID whose provider boost changed.
+    function notifyWeightBoostChanged(uint256 nodeOperatorId) external;
+
+    /// @notice Notify the registry that a configured provider changed global boost parameters.
+    /// @dev Requests a full deposit info update when the sender is an enabled provider.
+    ///      Unregistered or disabled providers are ignored since cached weights do not depend on them.
+    function notifyWeightBoostProviderConfigChanged() external;
 }

--- a/src/interfaces/IWeightBoostProvider.sol
+++ b/src/interfaces/IWeightBoostProvider.sol
@@ -1,0 +1,12 @@
+// SPDX-FileCopyrightText: 2026 Lido <info@lido.fi>
+// SPDX-License-Identifier: GPL-3.0
+
+pragma solidity 0.8.33;
+
+/// @notice Weight multiplier provider consumed by MetaRegistry.
+interface IWeightBoostProvider {
+    /// @notice Return weight multiplier in basis points for a node operator.
+    /// @param nodeOperatorId Node Operator ID.
+    /// @return multiplierBP Full multiplier in basis points. 10_000 means no scaling.
+    function getWeightBoostMultiplierBP(uint256 nodeOperatorId) external view returns (uint256 multiplierBP);
+}

--- a/test/fork/deployment/PostDeploymentCommon.t.sol
+++ b/test/fork/deployment/PostDeploymentCommon.t.sol
@@ -24,6 +24,8 @@ contract DeploymentBaseTest is Test, Utilities, DeploymentFixtures {
     CommonDeployParams internal deployParams;
     uint256 adminsCount;
     uint256 expectedModuleScratchNonce;
+    uint256 expectedModuleScratchNonceFromGates;
+    uint256 expectedModuleScratchNonceFromWeightBoostProviders;
 
     function setUp() public {
         Env memory env = envVars();
@@ -36,7 +38,14 @@ contract DeploymentBaseTest is Test, Utilities, DeploymentFixtures {
         if (moduleType == ModuleType.Curated) {
             // Curated deployment sets bond-curve weights once per gate. Each set triggers
             // requestFullDepositInfoUpdate(), which increments module nonce.
-            expectedModuleScratchNonce = vm.parseJsonAddressArray(config, ".CuratedGates").length;
+            expectedModuleScratchNonceFromGates = vm.parseJsonAddressArray(config, ".CuratedGates").length;
+
+            // Each registered weight boost provider also requests full update and contributes one nonce.
+            expectedModuleScratchNonceFromWeightBoostProviders = metaRegistry.getWeightBoostProvidersCount();
+
+            expectedModuleScratchNonce =
+                expectedModuleScratchNonceFromGates +
+                expectedModuleScratchNonceFromWeightBoostProviders;
         }
     }
 }

--- a/test/helpers/mocks/AdditionalBondRegistryMock.sol
+++ b/test/helpers/mocks/AdditionalBondRegistryMock.sol
@@ -3,17 +3,16 @@
 
 pragma solidity 0.8.33;
 
+import { IWeightBoostProvider } from "src/interfaces/IWeightBoostProvider.sol";
 import { MAX_BP } from "src/lib/Constants.sol";
-import { OperatorTierState } from "src/interfaces/IAdditionalBondRegistry.sol";
 
 /// @dev Minimal AdditionalBondRegistry mock for MetaRegistry tests.
-///      Stores the weight multiplier increment above MAX_BP, mirroring AdditionalBondRegistry storage;
-///      getOperatorTierState returns the effective value MAX_BP + increment (0 = identity = MAX_BP).
-contract AdditionalBondRegistryMock {
+///      Stores the weight multiplier increment above MAX_BP, mirroring AdditionalBondRegistry storage.
+contract AdditionalBondRegistryMock is IWeightBoostProvider {
     mapping(uint256 => uint256) private _weightMultiplier;
 
-    function getOperatorTierState(uint256 nodeOperatorId) external view returns (OperatorTierState memory state) {
-        state.weightMultiplier = MAX_BP + _weightMultiplier[nodeOperatorId];
+    function getWeightBoostMultiplierBP(uint256 nodeOperatorId) external view returns (uint256 multiplierBP) {
+        multiplierBP = MAX_BP + _weightMultiplier[nodeOperatorId];
     }
 
     function mock_setWeightMultiplier(uint256 nodeOperatorId, uint256 weightMultiplier) external {

--- a/test/helpers/mocks/MetaRegistryMock.sol
+++ b/test/helpers/mocks/MetaRegistryMock.sol
@@ -6,15 +6,15 @@ pragma solidity 0.8.33;
 import { IMetaRegistry, OperatorMetadata } from "src/interfaces/IMetaRegistry.sol";
 
 contract MetaRegistryMock {
-    uint256 public refreshOperatorWeightCallCount;
-    uint256 public lastRefreshedOperatorId;
+    uint256 public notifyWeightBoostChangedCallCount;
+    uint256 public lastChangedBoostOperatorId;
 
     function setOperatorMetadataAsAdmin(uint256 nodeOperatorId, OperatorMetadata calldata metadata) external {
         emit IMetaRegistry.OperatorMetadataSet({ nodeOperatorId: nodeOperatorId, metadata: metadata });
     }
 
-    function refreshOperatorWeight(uint256 nodeOperatorId) external {
-        refreshOperatorWeightCallCount++;
-        lastRefreshedOperatorId = nodeOperatorId;
+    function notifyWeightBoostChanged(uint256 nodeOperatorId) external {
+        notifyWeightBoostChangedCallCount++;
+        lastChangedBoostOperatorId = nodeOperatorId;
     }
 }

--- a/test/unit/AdditionalBondRegistry.t.sol
+++ b/test/unit/AdditionalBondRegistry.t.sol
@@ -185,11 +185,13 @@ contract AdditionalBondRegistrySelectTierTest is AdditionalBondRegistrySelectTie
         vm.prank(nodeOperatorOwner);
         additionalBondRegistry.selectTier(0, 1);
 
-        assertEq(additionalBondRegistry.getOperatorTierState(0).tierId, 1);
-        assertEq(additionalBondRegistry.getOperatorTierState(0).weightMultiplier, MAX_BP + T1_WEIGHT);
+        OperatorTierState memory s = additionalBondRegistry.getOperatorTierState(0);
+        assertEq(s.tierId, 1);
+        assertEq(s.weightMultiplier, MAX_BP + T1_WEIGHT);
+        assertEq(additionalBondRegistry.getWeightBoostMultiplierBP(0), MAX_BP + T1_WEIGHT);
         assertEq(acct.getBondCurveMultiplier(0), MAX_BP + T1_BOND);
-        assertEq(metaRegistryMock.refreshOperatorWeightCallCount(), 1);
-        assertEq(metaRegistryMock.lastRefreshedOperatorId(), 0);
+        assertEq(metaRegistryMock.notifyWeightBoostChangedCallCount(), 1);
+        assertEq(metaRegistryMock.lastChangedBoostOperatorId(), 0);
     }
 
     function test_selectTier_Upgrade_Tier1ToTier2() public {
@@ -204,6 +206,7 @@ contract AdditionalBondRegistrySelectTierTest is AdditionalBondRegistrySelectTie
         OperatorTierState memory s = additionalBondRegistry.getOperatorTierState(0);
         assertEq(s.tierId, 2);
         assertEq(s.weightMultiplier, MAX_BP + T2_WEIGHT);
+        assertEq(additionalBondRegistry.getWeightBoostMultiplierBP(0), MAX_BP + T2_WEIGHT);
         assertEq(s.curveMultiplier, MAX_BP + T2_BOND);
         assertEq(s.curveMultiplierCooldownUntil, 0);
         assertEq(acct.getBondCurveMultiplier(0), MAX_BP + T2_BOND);
@@ -226,7 +229,8 @@ contract AdditionalBondRegistrySelectTierTest is AdditionalBondRegistrySelectTie
         // Tier 0 keeps the pre-downgrade multiplier until release, so it stays above MAX_BP.
         assertEq(s.curveMultiplier, MAX_BP + T1_BOND);
         assertEq(acct.getBondCurveMultiplier(0), MAX_BP + T1_BOND);
-        assertEq(metaRegistryMock.refreshOperatorWeightCallCount(), 2);
+        assertEq(additionalBondRegistry.getWeightBoostMultiplierBP(0), MAX_BP);
+        assertEq(metaRegistryMock.notifyWeightBoostChangedCallCount(), 2);
     }
 
     function test_selectTier_Upgrade_ClearsCooldownIfActive() public {
@@ -415,6 +419,7 @@ contract AdditionalBondRegistryViewsTest is AdditionalBondRegistrySelectTierBase
         assertEq(s.weightMultiplier, MAX_BP);
         assertEq(s.curveMultiplier, MAX_BP);
         assertEq(s.curveMultiplierCooldownUntil, 0);
+        assertEq(additionalBondRegistry.getWeightBoostMultiplierBP(0), MAX_BP);
     }
 
     function test_getOperatorTierState_AfterUpgrade() public {
@@ -423,6 +428,7 @@ contract AdditionalBondRegistryViewsTest is AdditionalBondRegistrySelectTierBase
         OperatorTierState memory s = additionalBondRegistry.getOperatorTierState(0);
         assertEq(s.tierId, 1);
         assertEq(s.weightMultiplier, MAX_BP + T1_WEIGHT);
+        assertEq(additionalBondRegistry.getWeightBoostMultiplierBP(0), MAX_BP + T1_WEIGHT);
         assertEq(s.curveMultiplier, MAX_BP + T1_BOND);
         assertEq(s.curveMultiplierCooldownUntil, 0);
     }
@@ -436,6 +442,7 @@ contract AdditionalBondRegistryViewsTest is AdditionalBondRegistrySelectTierBase
         OperatorTierState memory s = additionalBondRegistry.getOperatorTierState(0);
         assertEq(s.tierId, 1);
         assertEq(s.weightMultiplier, MAX_BP + T1_WEIGHT);
+        assertEq(additionalBondRegistry.getWeightBoostMultiplierBP(0), MAX_BP + T1_WEIGHT);
         assertEq(s.curveMultiplier, MAX_BP + T2_BOND);
         assertEq(s.curveMultiplierCooldownUntil, block.timestamp + CURVE_MULTIPLIER_COOLDOWN);
     }

--- a/test/unit/MetaRegistry.t.sol
+++ b/test/unit/MetaRegistry.t.sol
@@ -14,6 +14,7 @@ import { NodeOperatorManagementProperties } from "src/interfaces/IBaseModule.sol
 import { ICuratedModule } from "src/interfaces/ICuratedModule.sol";
 import { IBaseModule } from "src/interfaces/IBaseModule.sol";
 import { IStakingRouter } from "src/interfaces/IStakingRouter.sol";
+import { IWeightBoostProvider } from "src/interfaces/IWeightBoostProvider.sol";
 import { ExternalOperatorLib } from "src/lib/ExternalOperatorLib.sol";
 
 import { CuratedMock } from "../helpers/mocks/CuratedMock.sol";
@@ -33,6 +34,21 @@ contract MetaRegistryForTest is MetaRegistry {
 
     function mock_getModuleAddressInCache(uint256 moduleId) external view returns (address moduleAddress) {
         moduleAddress = _storage().moduleAddressCache[moduleId];
+    }
+}
+
+contract WeightBoostProviderMock is IWeightBoostProvider {
+    uint256 internal constant DEFAULT_MULTIPLIER_BP = 10_000;
+
+    mapping(uint256 nodeOperatorId => uint256 multiplierBP) public multiplierBP;
+
+    function mock_setMultiplierBP(uint256 nodeOperatorId, uint256 value) external {
+        multiplierBP[nodeOperatorId] = value;
+    }
+
+    function getWeightBoostMultiplierBP(uint256 nodeOperatorId) external view returns (uint256) {
+        uint256 value = multiplierBP[nodeOperatorId];
+        return value == 0 ? DEFAULT_MULTIPLIER_BP : value;
     }
 }
 
@@ -1074,6 +1090,544 @@ contract MetaRegistryWeightsTest is MetaRegistryGroupsBaseTest {
     }
 }
 
+contract MetaRegistryWeightBoostProviderTest is MetaRegistryGroupsBaseTest {
+    WeightBoostProviderMock public provider;
+    WeightBoostProviderMock public secondProvider;
+
+    IMetaRegistry.WeightBoostProviderMode internal constant NODE_OPERATOR_MODE =
+        IMetaRegistry.WeightBoostProviderMode.NodeOperator;
+    IMetaRegistry.WeightBoostProviderMode internal constant GROUP_MAX_MODE =
+        IMetaRegistry.WeightBoostProviderMode.GroupMax;
+
+    function setUp() public override {
+        super.setUp();
+
+        provider = new WeightBoostProviderMock();
+        secondProvider = new WeightBoostProviderMock();
+    }
+
+    function _assertWeightBoostProvider(
+        uint256 providerId,
+        IWeightBoostProvider expectedProvider,
+        IMetaRegistry.WeightBoostProviderMode expectedMode,
+        bool expectedEnabled
+    ) internal view {
+        IMetaRegistry.WeightBoostProviderEntry memory entry = registry.getWeightBoostProvider(providerId);
+        assertEq(address(entry.provider), address(expectedProvider));
+        assertEq(uint256(entry.mode), uint256(expectedMode));
+        assertEq(entry.enabled, expectedEnabled);
+    }
+
+    function test_addWeightBoostProvider_StoresNodeOperatorProviderAndLeavesExistingGroupsStale() public {
+        _setBondCurveWeight(0, CURVE_WEIGHT);
+        uint256 groupId = _nextGroupId();
+        vm.prank(groupManager);
+        _createGroup(_subOperatorsArr1(0, MAX_BP), _extOperatorsArr0());
+
+        provider.mock_setMultiplierBP(0, 11000);
+
+        vm.expectCall(address(module), abi.encodeWithSelector(IBaseModule.requestFullDepositInfoUpdate.selector));
+        vm.expectEmit(address(registry));
+        emit IMetaRegistry.WeightBoostProviderAdded(address(provider), NODE_OPERATOR_MODE);
+        vm.prank(admin);
+        registry.addWeightBoostProvider(provider, NODE_OPERATOR_MODE);
+
+        IWeightBoostProvider[] memory providers = registry.getWeightBoostProviders();
+        assertEq(providers.length, 1);
+        assertEq(address(providers[0]), address(provider));
+        _assertWeightBoostProvider(1, provider, NODE_OPERATOR_MODE, true);
+        assertEq(uint256(registry.getWeightBoostProviderMode(1)), uint256(NODE_OPERATOR_MODE));
+        assertEq(registry.getWeightBoostProviderId(address(provider)), 1);
+        assertEq(registry.getWeightBoostProvidersCount(), 1);
+        assertEq(registry.getNodeOperatorWeight(0), CURVE_WEIGHT);
+
+        registry.refreshGroupWeights(groupId);
+        assertEq(registry.getNodeOperatorWeight(0), 11000);
+    }
+
+    function test_addWeightBoostProvider_StoresGroupMaxProviderAndLeavesExistingGroupsStale() public {
+        _setBondCurveWeight(0, CURVE_WEIGHT);
+        uint256 groupId = _nextGroupId();
+        vm.prank(groupManager);
+        _createGroup(
+            _subOperatorsArr2(
+                IMetaRegistry.SubNodeOperator({ nodeOperatorId: 0, share: MAX_BP / 2 }),
+                IMetaRegistry.SubNodeOperator({ nodeOperatorId: 1, share: MAX_BP / 2 })
+            ),
+            _extOperatorsArr0()
+        );
+
+        secondProvider.mock_setMultiplierBP(0, 11000);
+        secondProvider.mock_setMultiplierBP(1, 12000);
+
+        vm.expectCall(address(module), abi.encodeWithSelector(IBaseModule.requestFullDepositInfoUpdate.selector));
+        vm.expectEmit(address(registry));
+        emit IMetaRegistry.WeightBoostProviderAdded(address(secondProvider), GROUP_MAX_MODE);
+        vm.prank(admin);
+        registry.addWeightBoostProvider(secondProvider, GROUP_MAX_MODE);
+
+        assertEq(registry.getWeightBoostProvidersCount(), 1);
+        _assertWeightBoostProvider(1, secondProvider, GROUP_MAX_MODE, true);
+        assertEq(registry.getNodeOperatorWeight(0), 5000);
+        assertEq(registry.getNodeOperatorWeight(1), 5000);
+
+        registry.refreshGroupWeights(groupId);
+        assertEq(registry.getNodeOperatorWeight(0), 6000);
+        assertEq(registry.getNodeOperatorWeight(1), 6000);
+    }
+
+    function test_addWeightBoostProvider_RevertWhen_InvalidOrDuplicate() public {
+        vm.startPrank(admin);
+
+        vm.expectRevert(IMetaRegistry.InvalidWeightBoostProvider.selector);
+        registry.addWeightBoostProvider(IWeightBoostProvider(address(0)), NODE_OPERATOR_MODE);
+
+        registry.addWeightBoostProvider(provider, GROUP_MAX_MODE);
+
+        vm.expectRevert(IMetaRegistry.WeightBoostProviderAlreadyAdded.selector);
+        registry.addWeightBoostProvider(provider, NODE_OPERATOR_MODE);
+
+        vm.stopPrank();
+    }
+
+    function test_addWeightBoostProvider_RevertWhen_NoRole() public {
+        expectRoleRevert(stranger, registry.DEFAULT_ADMIN_ROLE());
+        vm.prank(stranger);
+        registry.addWeightBoostProvider(provider, GROUP_MAX_MODE);
+    }
+
+    function test_setWeightBoostProviderEnabled_DisablesProviderAndLeavesExistingGroupsStale() public {
+        _setBondCurveWeight(0, CURVE_WEIGHT);
+        uint256 groupId = _nextGroupId();
+        vm.prank(groupManager);
+        _createGroup(_subOperatorsArr1(0, MAX_BP), _extOperatorsArr0());
+
+        provider.mock_setMultiplierBP(0, 11000);
+        vm.prank(admin);
+        registry.addWeightBoostProvider(provider, NODE_OPERATOR_MODE);
+
+        registry.refreshGroupWeights(groupId);
+        assertEq(registry.getNodeOperatorWeight(0), 11000);
+
+        vm.expectCall(address(module), abi.encodeWithSelector(IBaseModule.requestFullDepositInfoUpdate.selector));
+        vm.expectEmit(address(registry));
+        emit IMetaRegistry.WeightBoostProviderEnabledSet(address(provider), false);
+        vm.prank(admin);
+        registry.setWeightBoostProviderEnabled(1, false);
+
+        _assertWeightBoostProvider(1, provider, NODE_OPERATOR_MODE, false);
+        assertEq(registry.getNodeOperatorWeight(0), 11000);
+
+        registry.refreshGroupWeights(groupId);
+        assertEq(registry.getNodeOperatorWeight(0), CURVE_WEIGHT);
+    }
+
+    function test_refreshGroupWeights_SkipsDisabledProviderInMultiplierLoop() public {
+        _setBondCurveWeight(0, CURVE_WEIGHT);
+        provider.mock_setMultiplierBP(0, 12000);
+        secondProvider.mock_setMultiplierBP(0, 11000);
+
+        vm.startPrank(admin);
+        registry.addWeightBoostProvider(provider, NODE_OPERATOR_MODE);
+        registry.addWeightBoostProvider(secondProvider, NODE_OPERATOR_MODE);
+        registry.setWeightBoostProviderEnabled(1, false);
+        vm.stopPrank();
+
+        vm.prank(groupManager);
+        _createGroup(_subOperatorsArr1(0, MAX_BP), _extOperatorsArr0());
+
+        assertEq(registry.getNodeOperatorWeight(0), 11000);
+
+        registry.refreshOperatorWeight(0);
+        assertEq(registry.getNodeOperatorWeight(0), 11000);
+    }
+
+    function test_setWeightBoostProviderEnabled_EnablesProviderAndLeavesExistingGroupsStale() public {
+        provider.mock_setMultiplierBP(0, 11000);
+        vm.startPrank(admin);
+        registry.addWeightBoostProvider(provider, NODE_OPERATOR_MODE);
+        registry.setWeightBoostProviderEnabled(1, false);
+        vm.stopPrank();
+
+        _setBondCurveWeight(0, CURVE_WEIGHT);
+        uint256 groupId = _nextGroupId();
+        vm.prank(groupManager);
+        _createGroup(_subOperatorsArr1(0, MAX_BP), _extOperatorsArr0());
+        assertEq(registry.getNodeOperatorWeight(0), CURVE_WEIGHT);
+
+        vm.expectCall(address(module), abi.encodeWithSelector(IBaseModule.requestFullDepositInfoUpdate.selector));
+        vm.expectEmit(address(registry));
+        emit IMetaRegistry.WeightBoostProviderEnabledSet(address(provider), true);
+        vm.prank(admin);
+        registry.setWeightBoostProviderEnabled(1, true);
+
+        _assertWeightBoostProvider(1, provider, NODE_OPERATOR_MODE, true);
+        assertEq(registry.getNodeOperatorWeight(0), CURVE_WEIGHT);
+
+        registry.refreshGroupWeights(groupId);
+        assertEq(registry.getNodeOperatorWeight(0), 11000);
+    }
+
+    function test_refreshGroupWeights_UsesDefaultGroupMaxMultiplierForEmptyGroup() public {
+        vm.prank(admin);
+        registry.addWeightBoostProvider(provider, GROUP_MAX_MODE);
+
+        uint256 groupId = _nextGroupId();
+        vm.startPrank(groupManager);
+        _createGroup(_subOperatorsArr1(0, MAX_BP), _extOperatorsArr0());
+        _clearGroup(groupId);
+        vm.stopPrank();
+
+        registry.refreshGroupWeights(groupId);
+
+        assertEq(registry.getNodeOperatorWeight(0), 0);
+    }
+
+    function test_setWeightBoostProviderEnabled_SkipsDisabledGroupMaxProvider() public {
+        _setBondCurveWeight(0, CURVE_WEIGHT);
+        provider.mock_setMultiplierBP(0, 11000);
+        provider.mock_setMultiplierBP(1, 12000);
+
+        vm.startPrank(admin);
+        registry.addWeightBoostProvider(provider, GROUP_MAX_MODE);
+        registry.setWeightBoostProviderEnabled(1, false);
+        vm.stopPrank();
+
+        uint256 groupId = _nextGroupId();
+        vm.prank(groupManager);
+        _createGroup(
+            _subOperatorsArr2(
+                IMetaRegistry.SubNodeOperator({ nodeOperatorId: 0, share: MAX_BP / 2 }),
+                IMetaRegistry.SubNodeOperator({ nodeOperatorId: 1, share: MAX_BP / 2 })
+            ),
+            _extOperatorsArr0()
+        );
+
+        assertEq(registry.getNodeOperatorWeight(0), 5000);
+        assertEq(registry.getNodeOperatorWeight(1), 5000);
+
+        vm.prank(admin);
+        registry.setWeightBoostProviderEnabled(1, true);
+
+        registry.refreshGroupWeights(groupId);
+        assertEq(registry.getNodeOperatorWeight(0), 6000);
+        assertEq(registry.getNodeOperatorWeight(1), 6000);
+    }
+
+    function test_setWeightBoostProviderEnabled_RevertWhen_NotFoundSameOrNoRole() public {
+        vm.prank(admin);
+        vm.expectRevert(IMetaRegistry.WeightBoostProviderNotFound.selector);
+        registry.setWeightBoostProviderEnabled(1, false);
+
+        vm.prank(admin);
+        registry.addWeightBoostProvider(provider, NODE_OPERATOR_MODE);
+
+        vm.prank(admin);
+        vm.expectRevert(IMetaRegistry.SameWeightBoostProviderEnabled.selector);
+        registry.setWeightBoostProviderEnabled(1, true);
+
+        expectRoleRevert(stranger, registry.DEFAULT_ADMIN_ROLE());
+        vm.prank(stranger);
+        registry.setWeightBoostProviderEnabled(1, false);
+
+        vm.prank(admin);
+        registry.setWeightBoostProviderEnabled(1, false);
+
+        vm.prank(admin);
+        vm.expectRevert(IMetaRegistry.SameWeightBoostProviderEnabled.selector);
+        registry.setWeightBoostProviderEnabled(1, false);
+    }
+
+    function test_notifyWeightBoostChanged_FromDisabledProviderDoesNotRefresh() public {
+        _setBondCurveWeight(0, CURVE_WEIGHT);
+        vm.prank(groupManager);
+        _createGroup(_subOperatorsArr1(0, MAX_BP), _extOperatorsArr0());
+
+        vm.startPrank(admin);
+        registry.addWeightBoostProvider(provider, NODE_OPERATOR_MODE);
+        registry.setWeightBoostProviderEnabled(1, false);
+        vm.stopPrank();
+
+        provider.mock_setMultiplierBP(0, 11000);
+        vm.prank(address(provider));
+        registry.notifyWeightBoostChanged(0);
+
+        assertEq(registry.getNodeOperatorWeight(0), CURVE_WEIGHT);
+    }
+
+    function test_notifyWeightBoostChanged_NoOpWhenOperatorHasNoGroup() public {
+        vm.prank(admin);
+        registry.addWeightBoostProvider(provider, NODE_OPERATOR_MODE);
+
+        provider.mock_setMultiplierBP(0, 11000);
+        vm.prank(address(provider));
+        registry.notifyWeightBoostChanged(0);
+
+        assertEq(registry.getNodeOperatorWeight(0), 0);
+    }
+
+    function test_notifyWeightBoostProviderConfigChanged_RequestsFullDepositInfoUpdate() public {
+        vm.prank(admin);
+        registry.addWeightBoostProvider(provider, NODE_OPERATOR_MODE);
+
+        vm.expectCall(address(module), abi.encodeWithSelector(IBaseModule.requestFullDepositInfoUpdate.selector));
+        vm.expectEmit(address(registry));
+        emit IMetaRegistry.WeightBoostProviderConfigChanged(address(provider));
+        vm.prank(address(provider));
+        registry.notifyWeightBoostProviderConfigChanged();
+    }
+
+    function test_notifyWeightBoostProviderConfigChanged_RevertWhen_ProviderNotFound() public {
+        vm.prank(address(provider));
+        vm.expectRevert(IMetaRegistry.WeightBoostProviderNotFound.selector);
+        registry.notifyWeightBoostProviderConfigChanged();
+    }
+
+    function test_notifyWeightBoostProviderConfigChanged_NoOpWhenProviderDisabled() public {
+        vm.startPrank(admin);
+        registry.addWeightBoostProvider(provider, NODE_OPERATOR_MODE);
+        registry.setWeightBoostProviderEnabled(1, false);
+        vm.stopPrank();
+
+        vm.mockCallRevert(
+            address(module),
+            abi.encodeWithSelector(IBaseModule.requestFullDepositInfoUpdate.selector),
+            abi.encode("UNEXPECTED_REQUEST_FULL_DEPOSIT_INFO_UPDATE")
+        );
+
+        vm.prank(address(provider));
+        registry.notifyWeightBoostProviderConfigChanged();
+    }
+
+    function test_createAndUpdateGroup_RecalculatesGroupMaxFromComposition() public {
+        _setBondCurveWeight(0, CURVE_WEIGHT);
+        provider.mock_setMultiplierBP(0, 11000);
+        provider.mock_setMultiplierBP(1, 12000);
+
+        vm.prank(admin);
+        registry.addWeightBoostProvider(provider, GROUP_MAX_MODE);
+
+        uint256 groupId = _nextGroupId();
+        vm.prank(groupManager);
+        _createGroup(
+            _subOperatorsArr2(
+                IMetaRegistry.SubNodeOperator({ nodeOperatorId: 0, share: MAX_BP / 2 }),
+                IMetaRegistry.SubNodeOperator({ nodeOperatorId: 1, share: MAX_BP / 2 })
+            ),
+            _extOperatorsArr0()
+        );
+        assertEq(registry.getNodeOperatorWeight(0), 6000);
+        assertEq(registry.getNodeOperatorWeight(1), 6000);
+
+        vm.prank(groupManager);
+        _updateGroup(groupId, _subOperatorsArr1(0, MAX_BP), _extOperatorsArr0());
+        assertEq(registry.getNodeOperatorWeight(0), 11000);
+        assertEq(registry.getNodeOperatorWeight(1), 0);
+
+        vm.prank(groupManager);
+        _clearGroup(groupId);
+        assertEq(registry.getNodeOperatorWeight(0), 0);
+    }
+
+    function test_notifyWeightBoostChanged_FromGroupMaxProviderRefreshesWholeGroupWhenMaxChanges() public {
+        _setBondCurveWeight(0, CURVE_WEIGHT);
+        vm.prank(groupManager);
+        _createGroup(
+            _subOperatorsArr2(
+                IMetaRegistry.SubNodeOperator({ nodeOperatorId: 0, share: MAX_BP / 2 }),
+                IMetaRegistry.SubNodeOperator({ nodeOperatorId: 1, share: MAX_BP / 2 })
+            ),
+            _extOperatorsArr0()
+        );
+
+        vm.prank(admin);
+        registry.addWeightBoostProvider(provider, GROUP_MAX_MODE);
+        provider.mock_setMultiplierBP(0, 12000);
+
+        vm.prank(address(provider));
+        registry.notifyWeightBoostChanged(0);
+
+        assertEq(registry.getNodeOperatorWeight(0), 6000);
+        assertEq(registry.getNodeOperatorWeight(1), 6000);
+    }
+
+    function test_notifyWeightBoostChanged_FromGroupMaxProviderRefreshesWholeGroupWhenMaxUnchanged() public {
+        _setBondCurveWeight(0, CURVE_WEIGHT);
+        provider.mock_setMultiplierBP(0, 11000);
+        provider.mock_setMultiplierBP(1, 12000);
+
+        vm.prank(admin);
+        registry.addWeightBoostProvider(provider, GROUP_MAX_MODE);
+        uint256 groupId = _nextGroupId();
+        vm.prank(groupManager);
+        _createGroup(
+            _subOperatorsArr2(
+                IMetaRegistry.SubNodeOperator({ nodeOperatorId: 0, share: MAX_BP / 2 }),
+                IMetaRegistry.SubNodeOperator({ nodeOperatorId: 1, share: MAX_BP / 2 })
+            ),
+            _extOperatorsArr0()
+        );
+
+        provider.mock_setMultiplierBP(0, 11500);
+
+        vm.expectEmit(address(registry));
+        emit IMetaRegistry.GroupWeightsRefreshed(groupId);
+        vm.prank(address(provider));
+        registry.notifyWeightBoostChanged(0);
+
+        assertEq(registry.getNodeOperatorWeight(0), 6000);
+        assertEq(registry.getNodeOperatorWeight(1), 6000);
+    }
+
+    function test_notifyWeightBoostChanged_FromNodeOperatorProviderRefreshesOnlyOperator() public {
+        _setBondCurveWeight(0, CURVE_WEIGHT);
+        vm.prank(groupManager);
+        _createGroup(
+            _subOperatorsArr2(
+                IMetaRegistry.SubNodeOperator({ nodeOperatorId: 0, share: MAX_BP / 2 }),
+                IMetaRegistry.SubNodeOperator({ nodeOperatorId: 1, share: MAX_BP / 2 })
+            ),
+            _extOperatorsArr0()
+        );
+
+        vm.prank(admin);
+        registry.addWeightBoostProvider(provider, NODE_OPERATOR_MODE);
+        provider.mock_setMultiplierBP(0, 11000);
+
+        vm.prank(address(provider));
+        registry.notifyWeightBoostChanged(0);
+
+        assertEq(registry.getNodeOperatorWeight(0), 5500);
+        assertEq(registry.getNodeOperatorWeight(1), 5000);
+    }
+
+    function test_refreshGroupWeights_MultipliesProviderMultipliers() public {
+        _setBondCurveWeight(0, CURVE_WEIGHT);
+        provider.mock_setMultiplierBP(0, 12000);
+        secondProvider.mock_setMultiplierBP(0, 11000);
+
+        vm.startPrank(admin);
+        registry.addWeightBoostProvider(provider, GROUP_MAX_MODE);
+        registry.addWeightBoostProvider(secondProvider, NODE_OPERATOR_MODE);
+        vm.stopPrank();
+
+        vm.prank(groupManager);
+        _createGroup(_subOperatorsArr1(0, MAX_BP), _extOperatorsArr0());
+
+        assertEq(registry.getNodeOperatorWeight(0), 13200);
+    }
+
+    function test_refreshGroupWeights_CachesGroupMaxProviderMultiplierPerRefresh() public {
+        _setBondCurveWeight(0, CURVE_WEIGHT);
+        provider.mock_setMultiplierBP(0, 11000);
+        provider.mock_setMultiplierBP(1, 12000);
+        provider.mock_setMultiplierBP(2, 13000);
+
+        IMetaRegistry.SubNodeOperator[] memory subOperators = new IMetaRegistry.SubNodeOperator[](3);
+        subOperators[0] = IMetaRegistry.SubNodeOperator({ nodeOperatorId: 0, share: 3000 });
+        subOperators[1] = IMetaRegistry.SubNodeOperator({ nodeOperatorId: 1, share: 3000 });
+        subOperators[2] = IMetaRegistry.SubNodeOperator({ nodeOperatorId: 2, share: 4000 });
+
+        uint256 groupId = _nextGroupId();
+        vm.prank(groupManager);
+        _createGroup(subOperators, _extOperatorsArr0());
+
+        vm.prank(admin);
+        registry.addWeightBoostProvider(provider, GROUP_MAX_MODE);
+
+        vm.expectCall(
+            address(provider),
+            abi.encodeCall(IWeightBoostProvider.getWeightBoostMultiplierBP, (uint256(0))),
+            1
+        );
+        vm.expectCall(
+            address(provider),
+            abi.encodeCall(IWeightBoostProvider.getWeightBoostMultiplierBP, (uint256(1))),
+            1
+        );
+        vm.expectCall(
+            address(provider),
+            abi.encodeCall(IWeightBoostProvider.getWeightBoostMultiplierBP, (uint256(2))),
+            1
+        );
+
+        registry.refreshGroupWeights(groupId);
+
+        assertEq(registry.getNodeOperatorWeight(0), 3900);
+        assertEq(registry.getNodeOperatorWeight(1), 3900);
+        assertEq(registry.getNodeOperatorWeight(2), 5200);
+    }
+
+    function test_refreshGroupWeights_UsesSameOrderedMultiplierAsOperatorRefresh() public {
+        _setBondCurveWeight(0, CURVE_WEIGHT);
+        WeightBoostProviderMock thirdProvider = new WeightBoostProviderMock();
+
+        provider.mock_setMultiplierBP(0, 16293);
+        secondProvider.mock_setMultiplierBP(0, 14016);
+        thirdProvider.mock_setMultiplierBP(0, 13527);
+
+        vm.startPrank(admin);
+        registry.addWeightBoostProvider(provider, NODE_OPERATOR_MODE);
+        registry.addWeightBoostProvider(secondProvider, GROUP_MAX_MODE);
+        registry.addWeightBoostProvider(thirdProvider, NODE_OPERATOR_MODE);
+        vm.stopPrank();
+
+        uint256 groupId = _nextGroupId();
+        vm.prank(groupManager);
+        _createGroup(_subOperatorsArr1(0, MAX_BP), _extOperatorsArr0());
+
+        assertEq(registry.getNodeOperatorWeight(0), 30890);
+
+        registry.refreshOperatorWeight(0);
+
+        assertEq(registry.getNodeOperatorWeight(0), 30890);
+        registry.refreshGroupWeights(groupId);
+        assertEq(registry.getNodeOperatorWeight(0), 30890);
+    }
+
+    function test_refreshOperatorWeight_AllowsProviderMultiplierBelowBaseline() public {
+        _setBondCurveWeight(0, CURVE_WEIGHT);
+        vm.prank(groupManager);
+        _createGroup(_subOperatorsArr1(0, MAX_BP), _extOperatorsArr0());
+
+        vm.prank(admin);
+        registry.addWeightBoostProvider(provider, NODE_OPERATOR_MODE);
+        provider.mock_setMultiplierBP(0, 9000);
+
+        registry.refreshOperatorWeight(0);
+
+        assertEq(registry.getNodeOperatorWeight(0), 9000);
+    }
+
+    function test_notifyWeightBoostChanged_RevertWhen_ProviderNotFound() public {
+        vm.expectRevert(IMetaRegistry.WeightBoostProviderNotFound.selector);
+        registry.notifyWeightBoostChanged(0);
+    }
+
+    function test_refreshGroupWeights_RevertWhen_InvalidGroupId() public {
+        vm.expectRevert(IMetaRegistry.InvalidOperatorGroupId.selector);
+        registry.refreshGroupWeights(NO_GROUP_ID);
+
+        uint256 nonExistingGroupId = _nextGroupId();
+        vm.expectRevert(IMetaRegistry.InvalidOperatorGroupId.selector);
+        registry.refreshGroupWeights(nonExistingGroupId);
+    }
+
+    function test_refreshOperatorWeight_RecalculatesCurrentProviderValues() public {
+        _setBondCurveWeight(0, CURVE_WEIGHT);
+        vm.prank(groupManager);
+        _createGroup(_subOperatorsArr1(0, MAX_BP), _extOperatorsArr0());
+
+        vm.prank(admin);
+        registry.addWeightBoostProvider(provider, NODE_OPERATOR_MODE);
+        provider.mock_setMultiplierBP(0, 11000);
+
+        registry.refreshOperatorWeight(0);
+
+        assertEq(registry.getNodeOperatorWeight(0), 11000);
+    }
+}
+
 contract MetaRegistryBondCurveTest is MetaRegistryGroupsBaseTest {
     uint256 internal constant VALID_BOND_CURVE_WEIGHT = CURVE_WEIGHT + 123;
 
@@ -1209,6 +1763,9 @@ contract MetaRegistryBondCurveTest is MetaRegistryGroupsBaseTest {
     function test_refreshOperatorWeight_AppliesTierWeightMultiplier() public {
         uint64 noId = 0;
 
+        vm.prank(admin);
+        registry.addWeightBoostProvider(additionalBondRegistry, IMetaRegistry.WeightBoostProviderMode.NodeOperator);
+
         vm.prank(groupManager);
         _createGroup(_subOperatorsArr1(noId, MAX_BP), _extOperatorsArr0());
 
@@ -1221,18 +1778,24 @@ contract MetaRegistryBondCurveTest is MetaRegistryGroupsBaseTest {
     }
 
     function test_refreshOperatorWeight_TierWeightMultiplierScalesAfterShare() public {
-        IMetaRegistry.SubNodeOperator memory op0 = IMetaRegistry.SubNodeOperator({ nodeOperatorId: 0, share: 6000 });
-        IMetaRegistry.SubNodeOperator memory op1 = IMetaRegistry.SubNodeOperator({ nodeOperatorId: 1, share: 4000 });
+        IMetaRegistry.SubNodeOperator memory op0 = IMetaRegistry.SubNodeOperator({ nodeOperatorId: 0, share: 1 });
+        IMetaRegistry.SubNodeOperator memory op1 = IMetaRegistry.SubNodeOperator({
+            nodeOperatorId: 1,
+            share: MAX_BP - 1
+        });
+
+        vm.prank(admin);
+        registry.addWeightBoostProvider(additionalBondRegistry, IMetaRegistry.WeightBoostProviderMode.NodeOperator);
 
         vm.prank(groupManager);
         _createGroup(_subOperatorsArr2(op0, op1), _extOperatorsArr0());
 
-        _setBondCurveWeight(0, CURVE_WEIGHT);
-        additionalBondRegistry.mock_setWeightMultiplier(0, 5_000);
+        _setBondCurveWeight(0, CURVE_WEIGHT + 1);
+        additionalBondRegistry.mock_setWeightMultiplier(0, 9_999);
         registry.refreshOperatorWeight(0);
 
         (uint256 weight, ) = registry.getNodeOperatorWeightAndExternalStake(0);
-        assertEq(weight, 9000); // weighted=6000 (share), 6000 * 15000 / 10000 = 9000
+        assertEq(weight, 1); // shared=1, 1 * 19999 / 10000 = 1
     }
 }
 


### PR DESCRIPTION
## Summary

- add generic `IWeightBoostProvider` support in `MetaRegistry`
- add node-operator and group-max provider modes with async explicit refresh
- route `AdditionalBondRegistry` through the weight boost provider interface
- include the requested merge commit from `origin/develop`

## Checks

- `forge test --offline --match-path test/unit/MetaRegistry.t.sol`
- `forge test --offline --match-path test/unit/AdditionalBondRegistry.t.sol`
