### PR TITLE
[codex] Require clean workspace for live deploys

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -29,12 +29,28 @@ anvil_rpc_url := "http://" + anvil_host + ":" + anvil_port
 disable_code_size_limit := if env("DISABLE_CODE_SIZE_LIMIT", "") != "" { "--disable-code-size-limit" } else { "" }
 
 # Shared deployment helpers
+_assert-clean-workspace:
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    if [ "${ALLOW_DIRTY_LIVE_DEPLOY:-}" = "1" ]; then
+        echo "Skipping clean workspace check because ALLOW_DIRTY_LIVE_DEPLOY=1." >&2
+        exit 0
+    fi
+
+    if [ -n "$(git status --porcelain=v1 --untracked-files=all)" ]; then
+        echo "Live deployment requires a clean git workspace." >&2
+        git status --short >&2
+        exit 1
+    fi
+
 _deploy-generic deploy_script_path rpc_url *args:
     FOUNDRY_PROFILE=deploy \
         forge script {{deploy_script_path}} --sig="run(string)" --rpc-url {{rpc_url}} --broadcast --slow {{args}} -- `git rev-parse HEAD`
 
 [confirm("You are about to broadcast deployment transactions to the network. Are you sure?")]
 _deploy-live-generic deploy_script_path *args:
+    just _assert-clean-workspace
     just _deploy-live-generic-no-confirm {{deploy_script_path}} --broadcast --verify {{args}}
 
 _deploy-live-generic-no-confirm deploy_script_path *args:
@@ -347,6 +363,7 @@ deploy-utils-live module_name contract_name *args:
 
 [confirm("You are about to broadcast utility contract deployment transactions to the network. Are you sure?")]
 _deploy-utils-live-confirmed module_name contract_name *args:
+    just _assert-clean-workspace
     just _deploy-utils {{module_name}} {{contract_name}} $RPC_URL ./artifacts/latest/{{module_name}}/utils/{{contract_name}}/ "" --broadcast --verify {{args}}
 
 _deploy-utils module_name contract_name rpc_url artifacts_dir dry-prefix *args:

--- a/csm.just
+++ b/csm.just
@@ -50,6 +50,7 @@ deploy-csm-impl *args:
 [confirm("You are about to broadcast deployment transactions to the network. Are you sure?")]
 deploy-csm-impl-live *args:
     just _warn "The current `tput bold`chain={{chain}}`tput sgr0` with the following rpc url: $RPC_URL"
+    just _assert-clean-workspace
     ARTIFACTS_DIR={{csm_artifacts_latest_dir}} \
         just _deploy-csm-impl --broadcast --verify {{args}}
     just _finalize-broadcast-artifacts {{deploy_csm_implementations_script_name}} $RPC_URL "" "deploy-latest.json" {{csm_latest_upgrade_config_path}}


### PR DESCRIPTION
## Summary
- Add a clean git workspace guard for interactive live deployment recipes.
- Allow explicit bypass with `ALLOW_DIRTY_LIVE_DEPLOY=1`.
- Keep no-confirm and dry-run paths unchanged for automation.