### PR TITLE
feat: extend staking modules regression action

### DIFF
--- a/.github/actions/regression-tests/action.yml
+++ b/.github/actions/regression-tests/action.yml
@@ -1,5 +1,5 @@
 name: "Regression tests"
-description: "Checkout and run regression tests for community-staking-module"
+description: "Checkout and run staking modules fork regression suites"
 
 inputs:
   rpc_url:
@@ -12,17 +12,29 @@ inputs:
   ref:
     description: "Git ref of the repository to test."
     required: false
-    default: "main"
+    default: "develop"
   path:
     description: "Path to checkout the repository."
     required: false
     default: "community-staking-module"
+  csm_deploy_config:
+    description: "CSM deployment config used by fork tests."
+    required: false
+    default: "./artifacts/mainnet/csm/upgrade-v3-mainnet.json"
+  curated_deploy_config:
+    description: "Curated module deployment config used by fork tests."
+    required: false
+    default: "./artifacts/mainnet/curated/deploy-mainnet.json"
+  vote_prev_block:
+    description: "Block number before the vote execution; enables temporary post-vote upgrade tests."
+    required: false
+    default: ""
 
 runs:
   using: "composite"
   steps:
-    - name: Checkout community-staking-module
-      uses: actions/checkout@v4
+    - name: Checkout staking modules repository
+      uses: actions/checkout@v7
       with:
         repository: ${{ inputs.repository }}
         ref: ${{ inputs.ref }}
@@ -32,7 +44,7 @@ runs:
       shell: bash
       working-directory: ${{ inputs.path }}
       run: |
-        echo "FOUNDRY_VERSION=$(head .foundryref)" >> "$GITHUB_ENV"
+        echo "FOUNDRY_VERSION=$(head -n 1 .foundryref)" >> "$GITHUB_ENV"
         echo "JUST_TAG=1.24.0" >> "$GITHUB_ENV"
 
     - name: Cache just
@@ -71,12 +83,54 @@ runs:
       working-directory: ${{ inputs.path }}
       run: just build
 
-    - name: Run regression tests
+    - name: Run CSM deployment regression
+      shell: bash
+      working-directory: ${{ inputs.path }}
+      run: just test-deployment-full-afterVote
+      env:
+        RPC_URL: ${{ inputs.rpc_url }}
+        CHAIN: mainnet
+        DEPLOY_CONFIG: ${{ inputs.csm_deploy_config }}
+        FOUNDRY_PROFILE: ci_quick
+
+    - name: Run CSM integration regression
       shell: bash
       working-directory: ${{ inputs.path }}
       run: just test-integration
       env:
         RPC_URL: ${{ inputs.rpc_url }}
         CHAIN: mainnet
-        DEPLOY_CONFIG: ./artifacts/mainnet/upgrade-v2-mainnet.json
+        DEPLOY_CONFIG: ${{ inputs.csm_deploy_config }}
+        FOUNDRY_PROFILE: ci_quick
+
+    - name: Run Curated deployment regression
+      shell: bash
+      working-directory: ${{ inputs.path }}
+      run: just test-deployment-full-afterVote
+      env:
+        RPC_URL: ${{ inputs.rpc_url }}
+        CHAIN: mainnet
+        DEPLOY_CONFIG: ${{ inputs.curated_deploy_config }}
+        FOUNDRY_PROFILE: ci_quick
+
+    - name: Run Curated integration regression
+      shell: bash
+      working-directory: ${{ inputs.path }}
+      run: just test-integration
+      env:
+        RPC_URL: ${{ inputs.rpc_url }}
+        CHAIN: mainnet
+        DEPLOY_CONFIG: ${{ inputs.curated_deploy_config }}
+        FOUNDRY_PROFILE: ci_quick
+
+    - name: Run CSM post-vote regression
+      if: ${{ inputs.vote_prev_block != '' }}
+      shell: bash
+      working-directory: ${{ inputs.path }}
+      run: just test-post-upgrade
+      env:
+        RPC_URL: ${{ inputs.rpc_url }}
+        CHAIN: mainnet
+        DEPLOY_CONFIG: ${{ inputs.csm_deploy_config }}
+        VOTE_PREV_BLOCK: ${{ inputs.vote_prev_block }}
         FOUNDRY_PROFILE: ci_quick

--- a/.github/workflows/test-full.yml
+++ b/.github/workflows/test-full.yml
@@ -48,7 +48,7 @@ jobs:
     if: ${{ github.head_ref == 'develop' }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,7 +58,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: bootstrap
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
 
@@ -94,7 +94,7 @@ jobs:
     needs: bootstrap
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
 


### PR DESCRIPTION
## What changed

Updates the reusable `.github/actions/regression-tests` action so the scripts repository can call it directly for the SRv3/CMv2/CSMv3 fork regression flow.

- defaults the checked-out modules repository ref to `develop`
- adds explicit CSM and Curated deploy config inputs
- runs CSM and Curated `just test-deployment-full-afterVote` suites before integration
- runs CSM and Curated `just test-integration` suites explicitly
- adds optional CSM post-vote regression when `vote_prev_block` is provided

## Why

The scripts workflow should not carry a local copy of the regression action. Keeping this command surface in `staking-modules` lets scripts pass only RPC/config inputs while the modules repo owns the exact test commands, including post-deployment/state checks.

## Validation

- `git diff --check`
- Action YAML was formatted by the repo pre-commit hook.
- Cross-checked the commands and default deploy config paths against the local `community-staking-module` checkout.